### PR TITLE
DebugStop() now shows where it was invoked

### DIFF
--- a/Common/pzerror.cpp
+++ b/Common/pzerror.cpp
@@ -1,0 +1,12 @@
+#include "pzerror.h"
+
+void DebugStopImpl(const char *fileName, const std::size_t lineN)
+{
+#ifdef WIN32
+	//ShowMessage("Erro encontrado! Entre em contato com o suporte do programa!");
+#endif
+	std::cout << "Your chance to put a breakpoint at " << fileName<< ":"<< lineN <<  "\n";
+	std::bad_exception myex;
+	throw myex;
+	
+}

--- a/Common/pzerror.h
+++ b/Common/pzerror.h
@@ -8,16 +8,17 @@
 #include <iostream>
 #include <stdlib.h>
 
-/** 
- * @ingroup common
- * @brief Defines the output device to error messages.
- */
-#define PZError std::cout
-
 /**
  * @ingroup common
- * @brief Returns a message to user put a breakpoint in 
+ * @brief Defines the output device to error messages and the DebugStop() function.
  */
-void DebugStop();
+#define PZError std::cout
+/**
+ * @ingroup common
+ * @brief Returns a message to user put a breakpoint in
+ */
+#define DebugStop() DebugStopImpl(__FILE__, __LINE__)
+
+void DebugStopImpl(const char *fileName, const std::size_t lineN);
 
 #endif

--- a/Common/pzreal.cpp
+++ b/Common/pzreal.cpp
@@ -1,7 +1,7 @@
 
 /**
  * @file
- * @brief Contains the TPZCounter methods and the DebugStop() function.
+ * @brief Contains the TPZCounter methods.
  */
 
 #include "pzreal.h"
@@ -54,17 +54,6 @@ std::ostream &operator<<(std::ostream &out,const TPZCounter &count)
 #ifdef WIN32
 //#include <Dialogs.hpp>
 #endif
-
-void DebugStop()
-{
-#ifdef WIN32
-	//ShowMessage("Erro encontrado! Entre em contato com o suporte do programa!");
-#endif
-	std::cout << "Your chance to put a breakpoint at " << __FILE__ <<  "\n";
-	std::bad_exception myex;
-	throw myex;
-	
-}
 
 //#if !defined(__cplusplus) || __cplusplus < 201103L // If we aren't using C++11.
 #if (!defined(__cplusplus) || __cplusplus < 201103L) && (!defined(_MSC_VER) || _MSC_VER < 1900)// If we aren't using C++11.

--- a/Common/pzreal.h
+++ b/Common/pzreal.h
@@ -23,8 +23,6 @@
 #include <config.h>
 #include "fpo_exceptions.h"
 
-void DebugStop();
-
 
 /** @brief Gets maxime value between a and b */
 #ifndef MAX


### PR DESCRIPTION
- The declaration of _DebugStop()_ was moved from _pzreal.h_ to _pzerror.h_
- 
The macro:
`#define DebugStop() DebugStopImpl(__FILE__, __LINE__)`,
 combined with the definition of 
`DebugStopImpl(const char *fileName, const std::size_t lineN)`,
 allows the user to know where DebugStop() was called.