### PR TITLE
Added move ctor and std::vec ctor for TPZVec

### DIFF
--- a/UnitTest_PZ/CMakeLists.txt
+++ b/UnitTest_PZ/CMakeLists.txt
@@ -14,6 +14,7 @@ if(BUILD_UNITTESTING)
 		add_subdirectory(TestMaterial)
 		add_subdirectory(TestIntegNum)
 		add_subdirectory(TestGeometry)
+		add_subdirectory(TestVectorAttributions)
 
 		source_group(UnitTestFad FILES ${pztestfad})
 		source_group(UnitTestTopology FILES ${pztesttopology})
@@ -21,10 +22,11 @@ if(BUILD_UNITTESTING)
 		source_group(UnitTestMesh FILES ${pztestmesh})
 		source_group(UnitTestIntegNum FILES ${pztestintegnum})
 		source_group(UnitTestGeometry FILES ${pztestgeometry})
+		source_group(UnitTestVectorAttributions FILES ${pztestvectorattributions})
 
 	else()
 
-		set(pztest ${pztest} ${pztestfad} ${pztesttopology} ${pztestmatrix} ${pztestmesh} ${pztestintegnum})
+		set(pztest ${pztest} ${pztestfad} ${pztesttopology} ${pztestmatrix} ${pztestmesh} ${pztestintegnum} ${pztestvectorattributions})
 
 	endif()
 endif()

--- a/UnitTest_PZ/TestVectorAttributions/CMakeLists.txt
+++ b/UnitTest_PZ/TestVectorAttributions/CMakeLists.txt
@@ -1,0 +1,26 @@
+# @file neopz/UnitTest_PZ/TestVectorAttributions/CMakeLists.txt  -- CMake file for unit test of the topology module
+
+file(GLOB headers *.h)
+file(GLOB sources *.cpp)
+
+
+if(BUILD_UNITTESTING)
+
+	include (CTestTestFile.cmake)
+
+	set(pztestvectorattributions ${headers} ${sources} PARENT_SCOPE )
+
+	add_executable(TestVectorAttributions ${headers} ${sources})
+
+if(USING_BOOST)
+	IF (WIN32)
+		target_link_libraries(TestVectorAttributions pz ${Boost_LIBRARIES})
+	ELSE()
+		target_link_libraries(TestVectorAttributions pz)
+	ENDIF()
+else()
+	target_link_libraries(TestVectorAttributions pz)
+endif()
+
+endif()
+

--- a/UnitTest_PZ/TestVectorAttributions/CTestTestFile.cmake
+++ b/UnitTest_PZ/TestVectorAttributions/CTestTestFile.cmake
@@ -1,0 +1,3 @@
+ENABLE_TESTING()
+
+ADD_TEST(TestVectorAttributions TestVectorAttributions)

--- a/UnitTest_PZ/TestVectorAttributions/TestVectorAttributions.cpp
+++ b/UnitTest_PZ/TestVectorAttributions/TestVectorAttributions.cpp
@@ -1,0 +1,143 @@
+//
+//  TestVectorAttributions.cpp
+//  PZ
+//
+//  Created by Thiago Quinelato on 1/dec/17.
+//
+
+#include "pzvec.h"
+#include "pzmanvector.h"
+
+#ifdef USING_BOOST
+
+#ifndef WIN32
+#define BOOST_TEST_DYN_LINK
+#endif
+#define BOOST_TEST_MAIN pz vector tests
+
+#include "boost/test/output_test_stream.hpp"
+#include "boost/test/unit_test.hpp"
+
+TPZVec<int> BuildTPZVec(){
+    TPZVec<int> vec(10);
+    for (unsigned int i = 0; i < 10; ++i) {
+        vec[i] = i;
+    }
+    return vec;
+}
+
+TPZManVector<int, 10> BuildTPZManVector(){
+    TPZManVector<int, 10> vec(10);
+    for (unsigned int i = 0; i < 10; ++i) {
+        vec[i] = i;
+    }
+    return vec;
+}
+
+std::vector<int> BuildStdVector(){
+    std::vector<int> vec(10);
+    for (unsigned int i = 0; i < 10; ++i) {
+        vec[i] = i;
+    }
+    return vec;
+}
+
+void TestingCopyTPZVecToTPZVec() {
+    TPZVec<int> initialVec = BuildTPZVec();
+    TPZVec<int> finalVec(initialVec);
+    BOOST_ASSERT(finalVec.size() == 10);
+    for (unsigned int i = 0; i < 10; ++i) {
+        BOOST_ASSERT(finalVec[i] == i);
+    }
+}
+
+void TestingMoveTPZVecToTPZVec() {
+    TPZVec<int> finalVec(std::move(BuildTPZVec()));
+    BOOST_ASSERT(finalVec.size() == 10);
+    for (unsigned int i = 0; i < 10; ++i) {
+        BOOST_ASSERT(finalVec[i] == i);
+    }
+}
+
+void TestingCopyTPZManVectorToTPZManVector() {
+    TPZManVector<int, 10> initialVec = BuildTPZManVector();
+    TPZManVector<int, 10> finalVec(initialVec);
+    BOOST_ASSERT(finalVec.size() == 10);
+    for (unsigned int i = 0; i < 10; ++i) {
+        BOOST_ASSERT(finalVec[i] == i);
+    }
+}
+
+void TestingMoveTPZManVectorToTPZManVector() {
+    TPZManVector<int, 10> finalVec(std::move(BuildTPZManVector()));
+    BOOST_ASSERT(finalVec.size() == 10);
+    for (unsigned int i = 0; i < 10; ++i) {
+        BOOST_ASSERT(finalVec[i] == i);
+    }
+}
+
+void TestingCopyTPZManVectorToTPZVec() {
+    TPZManVector<int,10> initialVec = BuildTPZManVector();
+    TPZVec<int> finalVec(initialVec);
+    BOOST_ASSERT(finalVec.size() == 10);
+    for (unsigned int i = 0; i < 10; ++i) {
+        BOOST_ASSERT(finalVec[i] == i);
+    }
+}
+
+void TestingMoveTPZManVectorToTPZVec() {
+    TPZVec<int> finalVec(std::move(BuildTPZManVector()));
+    BOOST_ASSERT(finalVec.size() == 10);
+    for (unsigned int i = 0; i < 10; ++i) {
+        BOOST_ASSERT(finalVec[i] == i);
+    }
+}
+void TestingCopyStdVectorToTPZVec() {
+    std::vector<int> initialVec = BuildStdVector();
+    TPZVec<int> finalVec(initialVec);
+    BOOST_ASSERT(finalVec.size() == 10);
+    for (unsigned int i = 0; i < 10; ++i) {
+        BOOST_ASSERT(finalVec[i] == i);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE(tpzvec_tests)
+
+BOOST_AUTO_TEST_CASE(tpzvec_to_tpzvec_copy)
+{
+    TestingCopyTPZVecToTPZVec();
+}
+
+BOOST_AUTO_TEST_CASE(tpzvec_to_tpzvec_move)
+{
+    TestingMoveTPZVecToTPZVec();
+}
+
+BOOST_AUTO_TEST_CASE(tpzmanvector_to_tpzmanvector_copy)
+{
+    TestingCopyTPZManVectorToTPZManVector();
+}
+
+BOOST_AUTO_TEST_CASE(tpzmanvector_to_tpzmanvector_move)
+{
+    TestingMoveTPZManVectorToTPZManVector();
+}
+
+BOOST_AUTO_TEST_CASE(tpzmanvector_to_tpzvec_copy)
+{
+    TestingCopyTPZManVectorToTPZVec();
+}
+
+BOOST_AUTO_TEST_CASE(tpzmanvector_to_tpzvec_move)
+{
+    TestingMoveTPZManVectorToTPZVec();
+}
+
+BOOST_AUTO_TEST_CASE(stdvector_to_tpzvec_move)
+{
+    TestingCopyStdVectorToTPZVec();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+#endif

--- a/Util/pzvec.h
+++ b/Util/pzvec.h
@@ -15,6 +15,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <vector>
 
 /// Overloading the operator <<
 inline std::ostream &operator<<(std::ostream &out, const std::pair<int,int> &element)
@@ -61,6 +62,19 @@ public:
 	 * @param copy : original vector
 	 */
 	TPZVec(const TPZVec<T> &copy);
+
+	/**
+	 * @brief Creates a vector from a std::vec. \n
+	 * will call the empty constructor on all objects of type T created
+	 * @param copy : original vector
+	 */
+	TPZVec(const std::vector<T> &copy);
+
+	/**
+	 * @brief Creates a vector with from a temporary TPZVec.
+	 * @param copy : original vector
+	 */
+	TPZVec(TPZVec<T> &&temp);
 	
 	/** @brief destructor, will delete the storage allocated */
 	virtual ~TPZVec();
@@ -291,6 +305,28 @@ TPZVec<T>::TPZVec(const TPZVec<T> &copy){
 	fNElements = copy.fNElements;
 }
 
+template< class T >
+TPZVec<T>::TPZVec(const std::vector<T> &copy) {
+	fStore = 0;
+
+	if( copy.size() > 0 )
+		fStore = new T[copy.size()];
+	else
+		fStore = 0;
+
+	for(long i=0; i<copy.size(); i++)
+		fStore[i]=copy[i];
+
+	fNElements = copy.size();
+}
+
+template< class T>
+TPZVec<T>::TPZVec(TPZVec<T> &&temp) {
+	fNElements = temp.fNElements;
+	fStore = temp.fStore;
+	temp.fStore = nullptr;
+	temp.fNElements = 0;
+}
 
 template<class T>
 inline TPZVec<T>::~TPZVec() {
@@ -461,18 +497,18 @@ template <class T>
 std::ostream& operator<<( std::ostream& Out, const TPZVec< T >& v )
 {
 	std::streamsize width = Out.width();
-	
+
 	const char* sep = ( width == 0 ? ", " : "" );
-	
+
 	long size = v.NElements();
-	
+
 	if(size) Out << std::setw(width) << v.fStore[0];
-	
+
 	for( long ii = 1; ii < size; ii++ )
 	{
 	    Out << std::setw( width ) << sep << v.fStore[ ii ];
 	}
-	
+
 	return Out;
 }
 


### PR DESCRIPTION
This pull request aims to add two constructors for the ```TPZVec<T>``` class.
The first one is the move constructor, which has the following signature:

    TPZVec(TPZVec<T> &&temp);

It will be called on temporary objects of the type ```TPZVec<T>```(*e.g.*, a ```TPZVec<T>``` that results from an add operation).

The second one is the constructor from a ```std::vector```.

    TPZVec(std::vector<T> &copy);

It allows creating ```TPZVec<T>``` objects in an easier fashion, like:

    TPZVec<REAL> vec({1,2,3,4})

A move constructor with a ```std::vector``` *rvalue reference* would be interesting, but I couldn't think of an implementation that would work regardless of the template parameter of ```TPZVec```, since most NeoPZ classes are yet to have a move constructor implemented(this implementation would allow the use of ```std::move``` directly).