### PR TITLE
added verification on PRefine on debug mode

### DIFF
--- a/Mesh/pzintel.cpp
+++ b/Mesh/pzintel.cpp
@@ -1588,6 +1588,18 @@ void TPZInterpolatedElement::Print(std::ostream &out) const {
 }
 
 void TPZInterpolatedElement::PRefine(int order) {
+#ifdef PZDEBUG
+    auto elementGMesh = this->fMesh->Reference();
+    auto referenceGMesh = this->Reference()->Mesh();
+    if(elementGMesh != referenceGMesh){
+        PZError<<__PRETTY_FUNCTION__;
+        PZError<<"Computational mesh of this element seems not to be associated\n";
+        PZError<<"with the same mesh as the one this element's reference belongs to.\n";
+        PZError<<"You may want to call TPZGeoMesh::ResetReference()\n";
+        PZError<<" and TPZCompMesh::LoadReferences() before PRefine\n";
+    }
+
+#endif
     SetPreferredOrder(order);
 
 #ifdef LOG4CXX


### PR DESCRIPTION
Although is not strictly necessary for the `TPZGeoMesh` to be associated with the `TPZCompMesh` that is going under a process of p-refinement, the algorithm may perform differently if that is the case. This verification, performed only if NeoPZ is compiled in Debug mode, aims to warn the user if the references are not properly loaded.