### PR TITLE
Topology minor refactor

### DIFF
--- a/Common/pzreal.h
+++ b/Common/pzreal.h
@@ -227,6 +227,10 @@ atan(int __x)
 }
 #endif //VC
 
+namespace pztopology{
+    const REAL gTolerance = 1.E-12;
+}
+
 // fabs function adapted to complex numbers.
 inline float
 fabs(std::complex <float> __x)

--- a/Common/pzreal.h
+++ b/Common/pzreal.h
@@ -227,8 +227,33 @@ atan(int __x)
 }
 #endif //VC
 
+#include <limits>
 namespace pztopology{
-    const REAL gTolerance = 1.E-12;
+//    class Settings{
+//    private:
+//        Settings() = default;
+//        REAL gTolerance;
+//    public:
+//        static Settings &GetSettings(){static Settings fOnlyInstance;return fOnlyInstance;}
+//        Settings(Settings const&)   = delete;
+//        void operator=(Settings const&) = delete;
+//    };// if, in the future, there are more topology settings to be adjusted, this model of singleton can be used.
+
+    typedef std::numeric_limits< REAL > dbl;
+    static REAL gTolerance = pow(10,(-1 * (dbl::max_digits10- 5)));
+
+    static REAL GetTolerance(){return gTolerance;}
+
+    static void SetTolerance(const REAL &tol){
+        if(tol > 0) gTolerance = tol;
+        else {
+            typedef std::numeric_limits< REAL > dbl;
+
+            std::cout.precision(dbl::max_digits10);
+            std::cout<<"Invalid tolerance parameter for topologies. Trying to set: "<<tol<<std::endl;
+            std::cout<<"This value will be ignored. Tolerance is set at: "<<gTolerance<<std::endl;
+        }
+    }
 }
 
 // fabs function adapted to complex numbers.

--- a/Geom/TPZGeoCube.cpp
+++ b/Geom/TPZGeoCube.cpp
@@ -20,121 +20,76 @@ using namespace std;
 
 namespace pzgeom {
     const double tol = pzgeom_TPZNodeRep_tol;
-    template<class T>
-    void TPZGeoCube::CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
-                                       TPZVec<T> &corrFactorDxi){
-        std::ostringstream sout;
-        if(side < NNodes || side >= NSides){
-            sout<<"The side\t"<<side<<"is invalid. Aborting..."<<std::endl;
 
-            PZError<<std::endl<<sout.str()<<std::endl;
-            DebugStop();
-        }
-        #ifdef PZDEBUG
 
-        if(!IsInParametricDomain(xi,tol)){
-            sout<<"The method CalcSideInfluence expects the point xi to correspond to coordinates of a point";
-            sout<<" inside the parametric domain. Aborting...";
-            PZError<<std::endl<<sout.str()<<std::endl;
-            #ifdef LOG4CXX
-            LOGPZ_FATAL(logger,sout.str().c_str());
-            #endif
-            DebugStop();
+    TPZGeoEl *TPZGeoCube::CreateBCGeoEl(TPZGeoEl *orig, int side, int bc) {
+
+        if (side < 0 || side > 26) {
+            cout << "TPZGeoCube::CreateBCGeoEl unexpected side = " << side << endl;
+            return 0;
         }
-        #endif
-        corrFactorDxi.Resize(TPZGeoCube::Dimension,(T)0);
-        if(side < NSides - 1){
-            TPZFNMatrix<4,T> phi(NNodes,1);
-            TPZFNMatrix<8,T> dphi(Dimension,NNodes);
-            TPZGeoCube::TShape(xi,phi,dphi);
-            correctionFactor = 0;
-            for(int i = 0; i < TPZGeoCube::NSideNodes(side);i++){
-                const int currentNode = TPZGeoCube::SideNodeLocId(side, i);
-                correctionFactor += phi(currentNode,0);
-                corrFactorDxi[0] +=  dphi(0,currentNode);
-                corrFactorDxi[1] +=  dphi(1,currentNode);
-                corrFactorDxi[2] +=  dphi(2,currentNode);
+        if (side == 26) {
+            cout << "TPZGeoCube::CreateBCGeoEl with side = 26 not implemented\n";
+            return 0;
+        }
+
+        if (side < 8) {
+            TPZManVector<int64_t> nodeindexes(1);
+            //    TPZGeoElPoint *gel;
+            nodeindexes[0] = orig->NodeIndex(side);
+            int64_t index;
+            TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EPoint, nodeindexes, bc, index);
+            //    gel = new TPZGeoElPoint(nodeindexes,bc,*orig->Mesh());
+            TPZGeoElSide(gel, 0).SetConnectivity(TPZGeoElSide(orig, side));
+            return gel;
+        } else if (side > 7 && side < 20) {//side = 8 a 19 : arestas
+            TPZManVector<int64_t> nodes(2);
+            nodes[0] = orig->SideNodeIndex(side, 0);
+            nodes[1] = orig->SideNodeIndex(side, 1);
+            //      TPZGeoEl1d *gel = new TPZGeoEl1d(nodes,bc,*orig->Mesh());
+            int64_t index;
+            TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EOned, nodes, bc, index);
+            TPZGeoElSide(gel, 0).SetConnectivity(TPZGeoElSide(orig, TPZShapeCube::ContainedSideLocId(side, 0)));
+            TPZGeoElSide(gel, 1).SetConnectivity(TPZGeoElSide(orig, TPZShapeCube::ContainedSideLocId(side, 1)));
+            TPZGeoElSide(gel, 2).SetConnectivity(TPZGeoElSide(orig, side));
+            return gel;
+        } else if (side > 19 && side < 26) {//side = 20 a 25 : faces
+            TPZManVector<int64_t> nodes(4);
+            int in;
+            for (in = 0; in < 4; in++) {
+                nodes[in] = orig->SideNodeIndex(side, in);
             }
-
-        }else{
-            correctionFactor = 1;
-        }
+            int64_t index;
+            TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EQuadrilateral, nodes, bc, index);
+            //		TPZGeoElQ2d *gel = new TPZGeoElQ2d(nodes,bc,*orig->Mesh());
+            for (in = 0; in < 8; in++) {
+                TPZGeoElSide(gel, in).SetConnectivity(TPZGeoElSide(orig, TPZShapeCube::ContainedSideLocId(side, in)));
+            }
+            TPZGeoElSide(gel, 8).SetConnectivity(TPZGeoElSide(orig, side));
+            return gel;
+        } else
+            PZError << "TPZGeoCube::CreateBCGeoEl. Side = " << side << endl;
+        return 0;
     }
-    
-	TPZGeoEl *TPZGeoCube::CreateBCGeoEl(TPZGeoEl *orig, int side,int bc) {
-		
-		if(side<0 || side>26) {
-			cout <<  "TPZGeoCube::CreateBCGeoEl unexpected side = " << side << endl;
-			return 0;
-		}
-		if(side==26) {
-			cout << "TPZGeoCube::CreateBCGeoEl with side = 26 not implemented\n";
-			return 0;
-		}
-		
-		if(side<8) {
-			TPZManVector<int64_t> nodeindexes(1);
-			//    TPZGeoElPoint *gel;
-			nodeindexes[0] = orig->NodeIndex(side);
-			int64_t index;
-			TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EPoint,nodeindexes,bc,index);
-			//    gel = new TPZGeoElPoint(nodeindexes,bc,*orig->Mesh());
-			TPZGeoElSide(gel,0).SetConnectivity(TPZGeoElSide(orig,side));
-			return gel;
-		} 
-		else 
-			if(side > 7 && side < 20) {//side = 8 a 19 : arestas
-				TPZManVector<int64_t> nodes(2);
-				nodes[0] = orig->SideNodeIndex(side,0);
-				nodes[1] = orig->SideNodeIndex(side,1);
-				//      TPZGeoEl1d *gel = new TPZGeoEl1d(nodes,bc,*orig->Mesh());
-				int64_t index;
-				TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EOned,nodes,bc,index);
-				TPZGeoElSide(gel,0).SetConnectivity(TPZGeoElSide(orig,TPZShapeCube::ContainedSideLocId(side,0)));
-				TPZGeoElSide(gel,1).SetConnectivity(TPZGeoElSide(orig,TPZShapeCube::ContainedSideLocId(side,1)));
-				TPZGeoElSide(gel,2).SetConnectivity(TPZGeoElSide(orig,side));
-				return gel;
-			} 
-			else 
-				if(side > 19 && side < 26) {//side = 20 a 25 : faces
-					TPZManVector<int64_t> nodes(4);
-					int in;
-					for (in=0;in<4;in++){
-						nodes[in] = orig->SideNodeIndex(side,in);
-					}
-					int64_t index;
-					TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EQuadrilateral,nodes,bc,index);
-					//		TPZGeoElQ2d *gel = new TPZGeoElQ2d(nodes,bc,*orig->Mesh());
-					for (in=0;in<8;in++){
-						TPZGeoElSide(gel,in).SetConnectivity(TPZGeoElSide(orig,TPZShapeCube::ContainedSideLocId(side,in)));
-					}
-					TPZGeoElSide(gel,8).SetConnectivity(TPZGeoElSide(orig,side));
-					return gel;
-				} 
-				else 
-					PZError << "TPZGeoCube::CreateBCGeoEl. Side = " << side << endl;
-		return 0;
-	}
-    
+
     /// create an example element based on the topology
     /* @param gmesh mesh in which the element should be inserted
      @param matid material id of the element
      @param lowercorner (in/out) on input lower corner o the cube where the element should be created, on exit position of the next cube
      @param size (in) size of space where the element should be created
      */
-    void TPZGeoCube::InsertExampleElement(TPZGeoMesh &gmesh, int matid, TPZVec<REAL> &lowercorner, TPZVec<REAL> &size)
-    {
-        TPZManVector<REAL,3> co(3),shift(3),scale(3);
-        TPZManVector<int64_t,3> nodeindexes(8);
-        for (int i=0; i<3; i++) {
-            scale[i] = size[i]/3.;
-            shift[i] = 1./2.+lowercorner[i];
+    void TPZGeoCube::InsertExampleElement(TPZGeoMesh &gmesh, int matid, TPZVec<REAL> &lowercorner, TPZVec<REAL> &size) {
+        TPZManVector<REAL, 3> co(3), shift(3), scale(3);
+        TPZManVector<int64_t, 3> nodeindexes(8);
+        for (int i = 0; i < 3; i++) {
+            scale[i] = size[i] / 3.;
+            shift[i] = 1. / 2. + lowercorner[i];
         }
-        
-        for (int i=0; i<NCornerNodes; i++) {
+
+        for (int i = 0; i < NCornerNodes; i++) {
             ParametricDomainNodeCoord(i, co);
-            for (int j=0; j<3; j++) {
-                co[j] = shift[j]+scale[j]*co[j]+(rand()*0.2/RAND_MAX)-0.1;
+            for (int j = 0; j < 3; j++) {
+                co[j] = shift[j] + scale[j] * co[j] + (rand() * 0.2 / RAND_MAX) - 0.1;
             }
             nodeindexes[i] = gmesh.NodeVec().AllocateNewElement();
             gmesh.NodeVec()[nodeindexes[i]].Initialize(co, gmesh);
@@ -142,41 +97,29 @@ namespace pzgeom {
         int64_t index;
         CreateGeoElement(gmesh, ECube, nodeindexes, matid, index);
     }
-    
-
-	
-	/**
-	 * Creates a geometric element according to the type of the father element
-	 */
-	TPZGeoEl *TPZGeoCube::CreateGeoElement(TPZGeoMesh &mesh, MElementType type,
-										   TPZVec<int64_t>& nodeindexes,
-										   int matid,
-										   int64_t& index)
-	{
-		return CreateGeoElementPattern(mesh,type,nodeindexes,matid,index);
-	}
-        
-        int TPZGeoCube::ClassId() const{
-            return Hash("TPZGeoCube") ^ TPZNodeRep<8, pztopology::TPZCube>::ClassId() << 1;
-        }
-        
-        void TPZGeoCube::Read(TPZStream& buf, void* context) {
-            TPZNodeRep<8, pztopology::TPZCube>::Read(buf,context);
-        }
-
-        void TPZGeoCube::Write(TPZStream& buf, int withclassid) const {
-            TPZNodeRep<8, pztopology::TPZCube>::Write(buf,withclassid);
-        }
 
 
-    template void TPZGeoCube::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
+    /**
+     * Creates a geometric element according to the type of the father element
+     */
+    TPZGeoEl *TPZGeoCube::CreateGeoElement(TPZGeoMesh &mesh, MElementType type,
+                                           TPZVec<int64_t> &nodeindexes,
+                                           int matid,
+                                           int64_t &index) {
+        return CreateGeoElementPattern(mesh, type, nodeindexes, matid, index);
+    }
+
+    int TPZGeoCube::ClassId() const {
+        return Hash("TPZGeoCube") ^ TPZNodeRep<8, pztopology::TPZCube>::ClassId() << 1;
+    }
+
+    void TPZGeoCube::Read(TPZStream &buf, void *context) {
+        TPZNodeRep<8, pztopology::TPZCube>::Read(buf, context);
+    }
+
+    void TPZGeoCube::Write(TPZStream &buf, int withclassid) const {
+        TPZNodeRep<8, pztopology::TPZCube>::Write(buf, withclassid);
+    }
+
 
 };
-
-#ifdef _AUTODIFF
-template<class T=REAL>
-class Fad;
-
-template void pzgeom::TPZGeoCube::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
-        TPZVec<Fad<REAL>> &);
-#endif

--- a/Geom/TPZGeoCube.h
+++ b/Geom/TPZGeoCube.h
@@ -68,11 +68,6 @@ namespace pzgeom {
         /** @brief Returns the type name of the element */
         static std::string TypeName() { return "Hexahedron";}
         
-        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
-        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
-            TShape(loc, phi, dphi);
-        }
-        
         /* @brief Compute x mapping from local parametric coordinates */
         template<class T>
         void X(const TPZGeoEl &gel,TPZVec<T> &loc,TPZVec<T> &x) const
@@ -101,18 +96,6 @@ namespace pzgeom {
             
             GradX(coord,loc,gradx);
         }
-        
-         /**
-         * This method calculates the influence (a.k.a. the blend function) of the side side regarding an
-         * interior point qsi. It is used by the TPZGeoBlend class.
-         * @param side the index of the side
-         * @param xi coordinates of the interior point
-         * @param correctionFactor influence (0 <= correctionFactor <= 1)
-         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
-         */
-        template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
-                                      TPZVec<T> &corrFactorDxi);
         /** @brief Compute x mapping from element nodes and local parametric coordinates */
         template<class T>
         static void X(const TPZFMatrix<REAL> &nodecoordinates,TPZVec<T> &loc,TPZVec<T> &x);
@@ -120,10 +103,6 @@ namespace pzgeom {
         /** @brief Compute gradient of x mapping from element nodes and local parametric coordinates */
         template<class T>
         static void GradX(const TPZFMatrix<REAL> &nodecoordinates,TPZVec<T> &loc, TPZFMatrix<T> &gradx);
-        
-        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
-        template<class T>
-        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
         
         static TPZGeoEl *CreateBCGeoEl(TPZGeoEl *gel, int side,int bc);
         
@@ -149,59 +128,7 @@ int ClassId() const override;
                                           int64_t& index);
         
     };
-    
-    template<class T>
-    inline void TPZGeoCube::TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi) {
-        T qsi = loc[0], eta = loc[1] , zeta  = loc[2];
-        
-        T x[2],dx[2],y[2],dy[2],z[2],dz[2];
-        x[0]    = (1.-qsi)/2.;
-        x[1]    = (1.+qsi)/2.;
-        dx[0]   = -0.5;
-        dx[1]   = +0.5;
-        y[0]    = (1.-eta)/2.;
-        y[1]    = (1.+eta)/2.;
-        dy[0]   = -0.5;
-        dy[1]   = +0.5;
-        z[0]    = (1.-zeta)/2.;
-        z[1]    = (1.+zeta)/2.;
-        dz[0]   = -0.5;
-        dz[1]   = +0.5;
-        
-        phi(0,0) = x[0]*y[0]*z[0];
-        phi(1,0) = x[1]*y[0]*z[0];
-        phi(2,0) = x[1]*y[1]*z[0];
-        phi(3,0) = x[0]*y[1]*z[0];
-        phi(4,0) = x[0]*y[0]*z[1];
-        phi(5,0) = x[1]*y[0]*z[1];
-        phi(6,0) = x[1]*y[1]*z[1];
-        phi(7,0) = x[0]*y[1]*z[1];
-        dphi(0,0) = dx[0]*y[0]*z[0];
-        dphi(1,0) = x[0]*dy[0]*z[0];
-        dphi(2,0) = x[0]*y[0]*dz[0];
-        dphi(0,1) = dx[1]*y[0]*z[0];
-        dphi(1,1) = x[1]*dy[0]*z[0];
-        dphi(2,1) = x[1]*y[0]*dz[0];
-        dphi(0,2) = dx[1]*y[1]*z[0];
-        dphi(1,2) = x[1]*dy[1]*z[0];
-        dphi(2,2) = x[1]*y[1]*dz[0];
-        dphi(0,3) = dx[0]*y[1]*z[0];
-        dphi(1,3) = x[0]*dy[1]*z[0];
-        dphi(2,3) = x[0]*y[1]*dz[0];
-        dphi(0,4) = dx[0]*y[0]*z[1];
-        dphi(1,4) = x[0]*dy[0]*z[1];
-        dphi(2,4) = x[0]*y[0]*dz[1];
-        dphi(0,5) = dx[1]*y[0]*z[1];
-        dphi(1,5) = x[1]*dy[0]*z[1];
-        dphi(2,5) = x[1]*y[0]*dz[1];
-        dphi(0,6) = dx[1]*y[1]*z[1];
-        dphi(1,6) = x[1]*dy[1]*z[1];
-        dphi(2,6) = x[1]*y[1]*dz[1];
-        dphi(0,7) = dx[0]*y[1]*z[1];
-        dphi(1,7) = x[0]*dy[1]*z[1];
-        dphi(2,7) = x[0]*y[1]*dz[1];
-        
-    }
+
     
     template<class T>
     inline void TPZGeoCube::X(const TPZFMatrix<REAL> &nodes,TPZVec<T> &loc,TPZVec<T> &x){

--- a/Geom/TPZGeoLinear.h
+++ b/Geom/TPZGeoLinear.h
@@ -71,11 +71,6 @@ namespace pzgeom
         /** @brief Returns the type name of the element */
         static std::string TypeName() { return "Linear";}
         
-        /** @brief Compute the shape being used to construct the X mapping from local parametric coordinates  */
-        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
-            TShape(loc, phi, dphi);
-        }
-        
         /* @brief Compute X mapping from local parametric coordinates */
         template<class T>
         void X(const TPZGeoEl &gel,TPZVec<T> &loc,TPZVec<T> &x) const
@@ -112,10 +107,7 @@ namespace pzgeom
         /** @brief Compute gradient of X mapping from element nodes and local parametric coordinates */
         template<class T>
         static void GradX(const TPZFMatrix<REAL> &nodes,TPZVec<T> &loc, TPZFMatrix<T> &gradx);
-        
-        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
-        template<class T>
-        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
+
         
         /** @brief Compute the jacoabina associated to the x mapping from local parametric coordinates  */
         static void Jacobian(const TPZFMatrix<REAL> &nodes,TPZVec<REAL> &param,TPZFMatrix<REAL> &jacobian,
@@ -150,15 +142,7 @@ namespace pzgeom
                                           int64_t& index);
         
     };
-    
-    template<class T>
-    inline void TPZGeoLinear::TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi) {
-        T x = loc[0];
-        phi(0,0) = (1.0-x)/2.;
-        phi(1,0) = (1.0+x)/2.;
-        dphi(0,0) = -0.5;
-        dphi(0,1) = 0.5;
-    }
+
     
     template<class T>
     inline void TPZGeoLinear::X(const TPZFMatrix<REAL> &nodes,TPZVec<T> &loc,TPZVec<T> &x){

--- a/Geom/pzgeopoint.h
+++ b/Geom/pzgeopoint.h
@@ -109,17 +109,6 @@ namespace pzgeom {
         
         template<class T>
         static void GradX(const TPZFMatrix<REAL> &nodes,TPZVec<T> &loc, TPZFMatrix<T> &gradx);
-		
-		static void Shape(TPZVec<REAL> &pt,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi)
-        {
-            phi(0,0) = 1.;
-        }
-		
-        template<class T>
-        static void TShape(const TPZVec<T> &pt,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi)
-        {
-            phi(0,0) = (T)1.;
-        }
         
 		static TPZGeoEl *CreateBCGeoEl(TPZGeoEl *gel, int side,int bc);
 		

--- a/Geom/pzgeoprism.cpp
+++ b/Geom/pzgeoprism.cpp
@@ -19,334 +19,194 @@ using namespace pzshape;
 using namespace std;
 
 namespace pzgeom {
-	
-	static const double tol = pzgeom_TPZNodeRep_tol;
-    template<class T>
-    void TPZGeoPrism::CalcSideInfluence(const int &side, const TPZVec<T> &xiVec, T &correctionFactor,
-                                        TPZVec<T> &corrFactorDxi){
-        #ifdef PZDEBUG
-        std::ostringstream sout;
-        if(side < NNodes || side >= NSides){
-            sout<<"The side\t"<<side<<"is invalid. Aborting..."<<std::endl;
 
-            PZError<<std::endl<<sout.str()<<std::endl;
-            DebugStop();
+    static const double tol = pzgeom_TPZNodeRep_tol;
+
+
+    TPZGeoEl *TPZGeoPrism::CreateBCGeoEl(TPZGeoEl *orig, int side, int bc) {
+        TPZGeoEl *result = 0;
+        if (side < 0 || side > 20) {
+            cout << "TPZGeoPrism::CreateBCCompEl bad side = " << side << " not implemented\n";
+            return result;
         }
 
-        if(!IsInParametricDomain(xiVec,tol)){
-            sout<<"The method CalcSideInfluence expects the point qsi to correspond to coordinates of a point";
-            sout<<" inside the parametric domain. Aborting...";
-            PZError<<std::endl<<sout.str()<<std::endl;
-            #ifdef LOG4CXX
-            LOGPZ_FATAL(logger,sout.str().c_str());
-            #endif
-            DebugStop();
+        if (side == 20) {
+            cout << "TPZGeoPrism::CreateBCCompEl with side = 20 not implemented\n";
+            return result;
         }
-        #endif
-        corrFactorDxi.Resize(TPZGeoPrism::Dimension, (T) 0);
-        const T &xi = xiVec[0];
-        const T &eta = xiVec[1];
-        const T &zeta = xiVec[2];
-        switch(side){
-            case  0:
-            case  1:
-            case  2:
-            case  3:
-            case  4:
-            case  5:
-                correctionFactor = 0;
-                return;
-            case  6:
-                correctionFactor = 0.5*(1.-zeta)*(1.-eta)*(1.-eta);
-                corrFactorDxi[0] = 0;
-                corrFactorDxi[1] = -1.*(1 - eta)*(1 - zeta);
-                corrFactorDxi[2] = -0.5*((1 - eta)*(1 - eta));
-                return;
-            case  7:
-                correctionFactor = 0.5*(1.-zeta)*(xi+eta)*(xi+eta);
-                corrFactorDxi[0] =1.*(eta + xi)*(1 - zeta);
-                corrFactorDxi[1] =1.*(eta + xi)*(1 - zeta);
-                corrFactorDxi[2] =-0.5*((eta + xi)*(eta + xi));
-                return;
-            case  8:
-                correctionFactor = 0.5*(1.-zeta)*(1.-xi)*(1.-xi);
-                corrFactorDxi[0] =-1.*(1 - xi)*(1 - zeta);
-                corrFactorDxi[1] =0;
-                corrFactorDxi[2] =-0.5*((1 - xi)*(1 - xi));
-                return;
-            case  9:
-                correctionFactor = 1. - xi - eta;
-                corrFactorDxi[0] = -1;
-                corrFactorDxi[1] = -1;
-                corrFactorDxi[2] = 0;
-                return;
-            case 10:
-                correctionFactor = xi;
-                corrFactorDxi[0] = 1;
-                corrFactorDxi[1] = 0;
-                corrFactorDxi[2] = 0;
-                return;
-            case 11:
-                correctionFactor = eta;
-                corrFactorDxi[0] = 0;
-                corrFactorDxi[1] = 1;
-                corrFactorDxi[2] = 0;
-                return;
-            case 12:
-                correctionFactor = 0.5*(1.+zeta)*(1.-eta)*(1.-eta);
-                corrFactorDxi[0] = 0;
-                corrFactorDxi[1] = -1.*(1 - eta)*(1 + zeta);
-                corrFactorDxi[2] = 0.5*((1 - eta)*(1 - eta));
-                return;
-            case 13:
-                correctionFactor = 0.5*(1.+zeta)*(xi+eta)*(xi+eta);
-                corrFactorDxi[0] = 1.*(eta + xi)*(1 + zeta);
-                corrFactorDxi[1] = 1.*(eta + xi)*(1 + zeta);
-                corrFactorDxi[2] = 0.5*((eta + xi)*(eta + xi));
-                return;
-            case 14:
-                correctionFactor = 0.5*(1.+zeta)*(1.-xi)*(1.-xi);
-                corrFactorDxi[0] = -1.*(1 - xi)*(1 + zeta);
-                corrFactorDxi[1] = 0;
-                corrFactorDxi[2] = 0.5*((1 - xi)*(1 - xi));
-                return;
-            case 15:
-                correctionFactor = 0.5*(1.-zeta);
-                corrFactorDxi[0] = 0;
-                corrFactorDxi[1] = 0;
-                corrFactorDxi[2] = -0.5;
-                return;
-            case 16:
-                correctionFactor = 1.-eta;
-                corrFactorDxi[0] = 0;
-                corrFactorDxi[1] = -1;
-                corrFactorDxi[2] = 0;
-                return;
-            case 17:
-                correctionFactor = xi+eta;
-                corrFactorDxi[0] = 1;
-                corrFactorDxi[1] = 1;
-                corrFactorDxi[2] = 0;
-                return;
-            case 18:
-                correctionFactor = 1.-xi;
-                corrFactorDxi[0] = -1;
-                corrFactorDxi[1] = 0;
-                corrFactorDxi[2] = 0;
-                return;
-            case 19:
-                correctionFactor = 0.5*(1.+zeta);
-                corrFactorDxi[0] = 0;
-                corrFactorDxi[1] = 0;
-                corrFactorDxi[2] = 0.5;
-                return;
+
+        int64_t index;
+        if (side < 6) {
+            TPZManVector<int64_t> nodeindexes(1);
+            TPZGeoEl *gel;
+            //		int nodestore [4];
+            nodeindexes[0] = orig->NodeIndex(side);
+            gel = orig->Mesh()->CreateGeoElement(EPoint, nodeindexes, bc, index);
+            //gel = new TPZGeoElPoint(nodeindexes,bc,*orig->Mesh());
+            TPZGeoElSide(gel, 0).SetConnectivity(TPZGeoElSide(orig, side));
+            result = gel;
+        } else if (side > 5 && side < 15) {//side = 6 a 14 : arestas
+            TPZManVector<int64_t> nodes(2);
+            nodes[0] = orig->SideNodeIndex(side, 0);//(TPZCompElPr3d::SideNodes[s][0]);
+            nodes[1] = orig->SideNodeIndex(side, 1);//NodeIndex(TPZCompElPr3d::SideNodes[s][1]);
+            //TPZGeoEl1d *gel = new TPZGeoEl1d(nodes,bc,*orig->Mesh());
+            TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EOned, nodes, bc, index);
+            TPZGeoElSide(gel, 0).SetConnectivity(TPZGeoElSide(orig, TPZShapePrism::ContainedSideLocId(side, 0)));
+            //(TPZGeoElSide(this,TPZCompElPr3d::SideNodes[s][0]));
+            TPZGeoElSide(gel, 1).SetConnectivity(TPZGeoElSide(orig, TPZShapePrism::ContainedSideLocId(side, 1)));
+            //(TPZGeoElSide(this,TPZCompElPr3d::SideNodes[s][1]));
+            TPZGeoElSide(gel, 2).SetConnectivity(TPZGeoElSide(orig, side));//(TPZGeoElSide(this,side));
+            result = gel;//->CreateCompEl(cmesh,index);
+        } else if (side > 14) {//side = 15 a 19 : faces
+            TPZManVector<int64_t> nodes(4);//4o = -1 para face triangular
+            int iside;
+            for (iside = 0; iside < 4; iside++) {
+                nodes[iside] = orig->SideNodeIndex(side, iside);
+            }
+            TPZGeoEl *gelt;
+            TPZGeoEl *gelq;
+            if (side > 15 && side < 19) {
+                gelq = orig->Mesh()->CreateGeoElement(EQuadrilateral, nodes, bc, index);
+                //gelq = new TPZGeoElQ2d(nodes,bc,*orig->Mesh());
+
+                for (iside = 0; iside < 8; iside++) {
+                    TPZGeoElSide(gelq, iside).SetConnectivity(
+                            TPZGeoElSide(orig, TPZShapePrism::ContainedSideLocId(side, iside)));
+                }
+                TPZGeoElSide(gelq, 8).SetConnectivity(TPZGeoElSide(orig, side));
+                result = gelq;
+            } else {
+                nodes.Resize(3);
+                gelt = orig->Mesh()->CreateGeoElement(ETriangle, nodes, bc, index);
+                //			gelt = new TPZGeoElT2d(nodes,bc,*orig->Mesh());
+                int iside;
+                for (iside = 0; iside < 6; iside++) {
+                    TPZGeoElSide(gelt, iside).SetConnectivity(
+                            TPZGeoElSide(orig, TPZShapePrism::ContainedSideLocId(side, iside)));
+                }
+                TPZGeoElSide(gelt, 6).SetConnectivity(TPZGeoElSide(orig, side));
+                result = gelt;
+            }
+        } else {
+            PZError << "TPZGeoPrism::CreateBCGeoEl. Side = " << side << endl;
+            return 0;
+        }
+        //	cout << "\n\nBoundary element " << bc << "  created for prism side " << side << endl;
+        //	result->Print(cout);
+        //	cout << "\n\nPrism Element\n";
+
+
+        return result;
+    }
+
+    void TPZGeoPrism::FixSingularity(int side, TPZVec<REAL> &OriginalPoint, TPZVec<REAL> &ChangedPoint) {
+        ChangedPoint.Resize(OriginalPoint.NElements(), 0.);
+        ChangedPoint = OriginalPoint;
+
+        switch (side) {
+            case 6: {
+                if (OriginalPoint[0] == 0. && OriginalPoint[1] == 1.) {
+                    ChangedPoint[0] = tol;
+                    ChangedPoint[1] = 1. - 2. * tol;
+                }
+                break;
+            }
+
+            case 7: {
+                if (OriginalPoint[0] == 0. && OriginalPoint[1] == 0.) {
+                    ChangedPoint[0] = tol;
+                    ChangedPoint[1] = tol;
+                }
+                break;
+            }
+
+            case 8: {
+                if (OriginalPoint[0] == 1. && OriginalPoint[1] == 0.) {
+                    ChangedPoint[0] = 1. - tol;
+                    ChangedPoint[1] = tol / 2.;
+                }
+                break;
+            }
+
+            case 12: {
+                if (OriginalPoint[0] == 0. && OriginalPoint[1] == 1.) {
+                    ChangedPoint[0] = tol;
+                    ChangedPoint[1] = 1. - 2. * tol;
+                }
+                break;
+            }
+
+            case 13: {
+                if (OriginalPoint[0] == 0. && OriginalPoint[1] == 0.) {
+                    ChangedPoint[0] = tol;
+                    ChangedPoint[1] = tol;
+                }
+                break;
+            }
+
+            case 14: {
+                if (OriginalPoint[0] == 1. && OriginalPoint[1] == 0.) {
+                    ChangedPoint[0] = 1. - tol;
+                    ChangedPoint[1] = tol / 2.;
+                }
+                break;
+            }
+
+            case 16: {
+                if (OriginalPoint[0] == 0. && OriginalPoint[1] == 1.) {
+                    ChangedPoint[0] = tol;
+                    ChangedPoint[1] = 1. - 2. * tol;
+                }
+                break;
+            }
+
+            case 17: {
+                if (OriginalPoint[0] == 0. && OriginalPoint[1] == 0.) {
+                    ChangedPoint[0] = tol;
+                    ChangedPoint[1] = tol;
+                }
+                break;
+            }
+
+            case 18: {
+                if (OriginalPoint[0] == 1. && OriginalPoint[1] == 0.) {
+                    ChangedPoint[0] = 1. - tol;
+                    ChangedPoint[1] = tol / 2.;
+                }
+                break;
+            }
         }
     }
 
-	TPZGeoEl *TPZGeoPrism::CreateBCGeoEl(TPZGeoEl *orig,int side,int bc) {
-		TPZGeoEl *result = 0;
-		if(side<0 || side>20) {
-			cout << "TPZGeoPrism::CreateBCCompEl bad side = " << side << " not implemented\n";		
-			return result;
-		}
-		
-		if(side==20) {
-			cout << "TPZGeoPrism::CreateBCCompEl with side = 20 not implemented\n";
-			return result;
-		}
-		
-		int64_t index;
-		if(side<6) {
-			TPZManVector<int64_t> nodeindexes(1);
-			TPZGeoEl *gel;
-			//		int nodestore [4];
-			nodeindexes[0] = orig->NodeIndex(side);
-			gel = orig->Mesh()->CreateGeoElement(EPoint,nodeindexes,bc,index);
-			//gel = new TPZGeoElPoint(nodeindexes,bc,*orig->Mesh());
-			TPZGeoElSide(gel,0).SetConnectivity(TPZGeoElSide(orig,side));
-			result = gel;
-		} else if (side > 5 && side < 15) {//side = 6 a 14 : arestas
-			TPZManVector<int64_t> nodes(2);
-			nodes[0] = orig->SideNodeIndex(side,0);//(TPZCompElPr3d::SideNodes[s][0]);
-			nodes[1] = orig->SideNodeIndex(side,1);//NodeIndex(TPZCompElPr3d::SideNodes[s][1]);
-			//TPZGeoEl1d *gel = new TPZGeoEl1d(nodes,bc,*orig->Mesh());
-			TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EOned,nodes,bc,index);
-			TPZGeoElSide(gel,0).SetConnectivity(TPZGeoElSide(orig,TPZShapePrism::ContainedSideLocId(side,0)));
-			//(TPZGeoElSide(this,TPZCompElPr3d::SideNodes[s][0]));
-			TPZGeoElSide(gel,1).SetConnectivity(TPZGeoElSide(orig,TPZShapePrism::ContainedSideLocId(side,1)));
-			//(TPZGeoElSide(this,TPZCompElPr3d::SideNodes[s][1]));
-			TPZGeoElSide(gel,2).SetConnectivity(TPZGeoElSide(orig,side));//(TPZGeoElSide(this,side));
-			result = gel;//->CreateCompEl(cmesh,index);
-		} 
-		else if (side > 14) {//side = 15 a 19 : faces
-			TPZManVector<int64_t> nodes(4);//4o = -1 para face triangular
-			int iside;
-			for (iside=0;iside<4;iside++){
-				nodes[iside] = orig->SideNodeIndex(side,iside);
-			}
-			TPZGeoEl *gelt;
-			TPZGeoEl *gelq;
-			if(side>15 && side<19) {
-				gelq = orig->Mesh()->CreateGeoElement(EQuadrilateral,nodes,bc,index);
-				//gelq = new TPZGeoElQ2d(nodes,bc,*orig->Mesh());
-				
-				for (iside=0;iside<8;iside++){
-					TPZGeoElSide(gelq,iside).SetConnectivity(TPZGeoElSide(orig,TPZShapePrism::ContainedSideLocId(side,iside)));
-				}
-				TPZGeoElSide(gelq,8).SetConnectivity(TPZGeoElSide(orig,side));
-				result = gelq;
-			} else {
-				nodes.Resize(3);
-				gelt = orig->Mesh()->CreateGeoElement(ETriangle,nodes,bc,index);
-				//			gelt = new TPZGeoElT2d(nodes,bc,*orig->Mesh());
-				int iside;
-				for (iside=0;iside<6;iside++){
-					TPZGeoElSide(gelt,iside).SetConnectivity(TPZGeoElSide(orig,TPZShapePrism::ContainedSideLocId(side,iside)));
-				}
-				TPZGeoElSide(gelt,6).SetConnectivity(TPZGeoElSide(orig,side));
-				result = gelt;
-			}
-		} else {
-			PZError << "TPZGeoPrism::CreateBCGeoEl. Side = " << side << endl;
-			return 0;
-		}
-		//	cout << "\n\nBoundary element " << bc << "  created for prism side " << side << endl;
-		//	result->Print(cout);
-		//	cout << "\n\nPrism Element\n";
-		
-		
-		return result;
-	}
-	
-	void TPZGeoPrism::FixSingularity(int side, TPZVec<REAL>& OriginalPoint, TPZVec<REAL>& ChangedPoint)
-	{
-		ChangedPoint.Resize(OriginalPoint.NElements(),0.);
-		ChangedPoint = OriginalPoint;
-		
-		switch(side)
-		{
-			case 6:
-			{
-				if(OriginalPoint[0] == 0. && OriginalPoint[1] == 1.)
-				{
-					ChangedPoint[0] = tol;
-					ChangedPoint[1] = 1. - 2.*tol;
-				}
-				break;
-			}
-				
-			case 7:
-			{
-				if(OriginalPoint[0] == 0. && OriginalPoint[1] == 0.)
-				{
-					ChangedPoint[0] = tol;
-					ChangedPoint[1] = tol;
-				}
-				break;
-			}
-				
-			case 8:
-			{
-				if(OriginalPoint[0] == 1. && OriginalPoint[1] == 0.)
-				{
-					ChangedPoint[0] = 1.-tol;
-					ChangedPoint[1] = tol/2.;
-				}
-				break;
-			}
-				
-			case 12:
-			{
-				if(OriginalPoint[0] == 0. && OriginalPoint[1] == 1.)
-				{
-					ChangedPoint[0] = tol;
-					ChangedPoint[1] = 1. - 2.*tol;
-				}
-				break;
-			}
-				
-			case 13:
-			{
-				if(OriginalPoint[0] == 0. && OriginalPoint[1] == 0.)
-				{
-					ChangedPoint[0] = tol;
-					ChangedPoint[1] = tol;
-				}
-				break;
-			}
-				
-			case 14:
-			{
-				if(OriginalPoint[0] == 1. && OriginalPoint[1] == 0.)
-				{
-					ChangedPoint[0] = 1.-tol;
-					ChangedPoint[1] = tol/2.;
-				}
-				break;
-			}
-				
-			case 16:
-			{
-				if(OriginalPoint[0] == 0. && OriginalPoint[1] == 1.)
-				{
-					ChangedPoint[0] = tol;
-					ChangedPoint[1] = 1. - 2.*tol;
-				}
-				break;
-			}
-				
-			case 17:
-			{
-				if(OriginalPoint[0] == 0. && OriginalPoint[1] == 0.)
-				{
-					ChangedPoint[0] = tol;
-					ChangedPoint[1] = tol;
-				}
-				break;
-			}
-				
-			case 18:
-			{
-				if(OriginalPoint[0] == 1. && OriginalPoint[1] == 0.)
-				{
-					ChangedPoint[0] = 1.-tol;
-					ChangedPoint[1] = tol/2.;
-				}
-				break;
-			}
-		}
-	}
-	
-	/**
-	 * Creates a geometric element according to the type of the father element
-	 */
-	TPZGeoEl *TPZGeoPrism::CreateGeoElement(TPZGeoMesh &mesh, MElementType type,
-											TPZVec<int64_t>& nodeindexes,
-											int matid,
-											int64_t& index)
-	{
-		return CreateGeoElementPattern(mesh,type,nodeindexes,matid,index);
-	}
-	
+    /**
+     * Creates a geometric element according to the type of the father element
+     */
+    TPZGeoEl *TPZGeoPrism::CreateGeoElement(TPZGeoMesh &mesh, MElementType type,
+                                            TPZVec<int64_t> &nodeindexes,
+                                            int matid,
+                                            int64_t &index) {
+        return CreateGeoElementPattern(mesh, type, nodeindexes, matid, index);
+    }
+
     /// create an example element based on the topology
     /* @param gmesh mesh in which the element should be inserted
      @param matid material id of the element
      @param lowercorner (in/out) on input lower corner o the cube where the element should be created, on exit position of the next cube
      @param size (in) size of space where the element should be created
      */
-    void TPZGeoPrism::InsertExampleElement(TPZGeoMesh &gmesh, int matid, TPZVec<REAL> &lowercorner, TPZVec<REAL> &size)
-    {
-        TPZManVector<REAL,3> co(3),shift(3),scale(3);
-        TPZManVector<int64_t,3> nodeindexes(8);
-        for (int i=0; i<3; i++) {
-            scale[i] = size[i]/3.;
-            shift[i] = 1./2.+lowercorner[i];
+    void
+    TPZGeoPrism::InsertExampleElement(TPZGeoMesh &gmesh, int matid, TPZVec<REAL> &lowercorner, TPZVec<REAL> &size) {
+        TPZManVector<REAL, 3> co(3), shift(3), scale(3);
+        TPZManVector<int64_t, 3> nodeindexes(8);
+        for (int i = 0; i < 3; i++) {
+            scale[i] = size[i] / 3.;
+            shift[i] = 1. / 2. + lowercorner[i];
         }
-        
-        for (int i=0; i<NCornerNodes; i++) {
+
+        for (int i = 0; i < NCornerNodes; i++) {
             ParametricDomainNodeCoord(i, co);
-            for (int j=0; j<3; j++) {
-                co[j] = shift[j]+scale[j]*co[j]+(rand()*0.2/RAND_MAX)-0.1;
+            for (int j = 0; j < 3; j++) {
+                co[j] = shift[j] + scale[j] * co[j] + (rand() * 0.2 / RAND_MAX) - 0.1;
             }
             nodeindexes[i] = gmesh.NodeVec().AllocateNewElement();
             gmesh.NodeVec()[nodeindexes[i]].Initialize(co, gmesh);
@@ -354,27 +214,17 @@ namespace pzgeom {
         int64_t index;
         CreateGeoElement(gmesh, EPrisma, nodeindexes, matid, index);
     }
-    
-    int TPZGeoPrism::ClassId() const{
+
+    int TPZGeoPrism::ClassId() const {
         return Hash("TPZGeoPrism") ^ TPZNodeRep<6, pztopology::TPZPrism>::ClassId() << 1;
     }
-    
-    void TPZGeoPrism::Read(TPZStream& buf, void* context) {
-        TPZNodeRep<6, pztopology::TPZPrism>::Read(buf,context);
+
+    void TPZGeoPrism::Read(TPZStream &buf, void *context) {
+        TPZNodeRep<6, pztopology::TPZPrism>::Read(buf, context);
     }
 
-    void TPZGeoPrism::Write(TPZStream& buf, int withclassid) const {
-        TPZNodeRep<6, pztopology::TPZPrism>::Write(buf,withclassid);
+    void TPZGeoPrism::Write(TPZStream &buf, int withclassid) const {
+        TPZNodeRep<6, pztopology::TPZPrism>::Write(buf, withclassid);
     }
-
-    template void TPZGeoPrism::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
 
 };
-
-#ifdef _AUTODIFF
-template<class T=REAL>
-class Fad;
-
-template void pzgeom::TPZGeoPrism::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
-        TPZVec<Fad<REAL>> &);
-#endif

--- a/Geom/pzgeoprism.h
+++ b/Geom/pzgeoprism.h
@@ -60,18 +60,6 @@ namespace pzgeom {
         {
         }
 
-        /**
-         * This method calculates the influence (a.k.a. the blend function) of the side side regarding an
-         * interior point qsi. It is used by the TPZGeoBlend class.
-         * @param side the index of the side
-         * @param xi coordinates of the interior point
-         * @param correctionFactor influence (0 <= correctionFactor <= 1)
-         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
-         */
-        template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
-                                      TPZVec<T> &corrFactorDxi);
-
         static bool IsLinearMapping(int side)
         {
             return true;
@@ -79,11 +67,6 @@ namespace pzgeom {
         
         /** @brief Returns the type name of the element */
         static std::string TypeName() { return "Prism";}
-        
-        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
-        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
-            TShape(loc, phi, dphi);
-        }
         
         /* @brief Compute x mapping from local parametric coordinates */
         template<class T>
@@ -122,10 +105,6 @@ namespace pzgeom {
         /** @brief Compute gradient of x mapping from element nodes and local parametric coordinates */
         template<class T>
         static void GradX(const TPZFMatrix<REAL> &nodes,TPZVec<T> &loc, TPZFMatrix<T> &gradx);
-        
-        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
-        template<class T>
-        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
         
         
         /**
@@ -167,38 +146,7 @@ namespace pzgeom {
                                           TPZVec<int64_t>& nodeindexes,
                                           int matid, int64_t& index);
     };
-    
-    template<class T>
-    inline void TPZGeoPrism::TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi) {
-        T qsi = loc[0], eta = loc[1] , zeta  = loc[2];
-        
-        phi(0,0)  = .5*(1.-qsi-eta)*(1.-zeta);
-        phi(1,0)  = .5*qsi*(1.-zeta);
-        phi(2,0)  = .5*eta*(1.-zeta);
-        phi(3,0)  = .5*(1.-qsi-eta)*(1.+zeta);
-        phi(4,0)  = .5*qsi*(1.+zeta);
-        phi(5,0)  = .5*eta*(1.+zeta);
-        
-        dphi(0,0) = -.5*(1.-zeta);
-        dphi(1,0) = -.5*(1.-zeta);
-        dphi(2,0) = -.5*(1.-qsi-eta);
-        dphi(0,1) =  .5*(1.-zeta);
-        dphi(1,1) =  .0;
-        dphi(2,1) = -.5*qsi;
-        dphi(0,2) =  .0;
-        dphi(1,2) =  .5*(1.-zeta);
-        dphi(2,2) = -.5*eta;
-        dphi(0,3) = -.5*(1.+zeta);
-        dphi(1,3) = -.5*(1.+zeta);
-        dphi(2,3) =  .5*(1.-qsi-eta);
-        dphi(0,4) =  .5*(1.+zeta);
-        dphi(1,4) =  .0;
-        dphi(2,4) =  .5*qsi;
-        dphi(0,5) =  .0;
-        dphi(1,5) =  .5*(1.+zeta);
-        dphi(2,5) =  .5*eta;
-        
-    }
+
     
     template<class T>
     inline void TPZGeoPrism::X(const TPZFMatrix<REAL> &nodes,TPZVec<T> &loc,TPZVec<T> &x){

--- a/Geom/pzgeopyramid.cpp
+++ b/Geom/pzgeopyramid.cpp
@@ -23,92 +23,9 @@ using namespace pzshape;
 using namespace std;
 
 namespace pzgeom {
-	
-	const double tol = pzgeom_TPZNodeRep_tol;
 
-    template<class T>
-    void TPZGeoPyramid::CalcSideInfluence(const int &side, const TPZVec<T> &xiVec, T &correctionFactor,
-                                          TPZVec<T> &corrFactorDxi){
-        #ifdef PZDEBUG
-        std::ostringstream sout;
-        if(side < NNodes || side >= NSides){
-            sout<<"The side\t"<<side<<"is invalid. Aborting..."<<std::endl;
+    const double tol = pzgeom_TPZNodeRep_tol;
 
-            PZError<<std::endl<<sout.str()<<std::endl;
-            DebugStop();
-        }
-
-        if(!IsInParametricDomain(xiVec,tol)){
-            sout<<"The method CalcSideInfluence expects the point qsi to correspond to coordinates of a point";
-            sout<<" inside the parametric domain. Aborting...";
-            PZError<<std::endl<<sout.str()<<std::endl;
-            #ifdef LOG4CXX
-            LOGPZ_FATAL(logger,sout.str().c_str());
-            #endif
-            DebugStop();
-        }
-        #endif
-        TPZFNMatrix<4,T> phi(NNodes,1);
-        TPZFNMatrix<8,T> dphi(Dimension,NNodes);
-        TPZGeoPyramid::TShape(xiVec,phi,dphi);
-        correctionFactor = 0;
-        corrFactorDxi.Resize(TPZGeoPyramid::Dimension,(T)0);
-        for(int i = 0; i < TPZGeoPyramid::NSideNodes(side);i++){
-            const int currentNode = TPZGeoPyramid::SideNodeLocId(side, i);
-            correctionFactor += phi(currentNode,0);
-            corrFactorDxi[0] +=  dphi(0,currentNode);
-            corrFactorDxi[1] +=  dphi(1,currentNode);
-            corrFactorDxi[2] +=  dphi(2,currentNode);
-        }
-
-        const T &zeta = xiVec[2];
-        switch(side){
-            case  0:
-            case  1:
-            case  2:
-            case  3:
-            case  4:
-                correctionFactor = 0;
-                corrFactorDxi[0] = 0;
-                corrFactorDxi[1] = 0;
-                corrFactorDxi[2] = 0;
-                return;
-            case  5:
-            case  6:
-            case  7:
-            case  8:
-                corrFactorDxi[0] *= (1 - zeta);
-                corrFactorDxi[1] *= (1 - zeta);
-                corrFactorDxi[2] =  (1 - zeta) * corrFactorDxi[2] - correctionFactor;
-                correctionFactor *= 1.-zeta;
-                return;
-            case  9:
-            case 10:
-            case 11:
-            case 12:
-                corrFactorDxi[0] *=  2 * correctionFactor;
-                corrFactorDxi[1] *=  2 * correctionFactor;
-                corrFactorDxi[2] *=  2 * correctionFactor;
-                correctionFactor *= correctionFactor;
-                return;
-            case 13:
-                return;//correct
-            case 14:
-            case 15:
-            case 16:
-            case 17:
-                corrFactorDxi[0] *=  3 * correctionFactor * correctionFactor;
-                corrFactorDxi[1] *=  3 * correctionFactor * correctionFactor;
-                corrFactorDxi[2] *=  3 * correctionFactor * correctionFactor;
-                correctionFactor *= correctionFactor * correctionFactor;
-                return;
-            case 18:
-                correctionFactor = 1;
-                corrFactorDxi[0] = 0;
-                corrFactorDxi[1] = 0;
-                corrFactorDxi[2] = 0;
-        }
-    }
 //    void TPZGeoPyramid::Shape(TPZVec<REAL> &pt,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi) {
 //        if(fabs(pt[0])<1.e-10 && fabs(pt[1])<1.e-10 && pt[2]==1.) {
 //            //para testes com transforma�es geometricas-->>Que  o que faz o RefPattern!!
@@ -173,288 +90,245 @@ namespace pzgeom {
 //        dphi(1,4) =  0.0;
 //        dphi(2,4) =  1.0;
 //    }
-    
-	
-	TPZGeoEl *TPZGeoPyramid::CreateBCGeoEl(TPZGeoEl *orig,int side,int bc) {
-		if(side<0 || side>18) {
-			cout << "TPZGeoPyramid::CreateBCGeoEl Bad parameter side = " 
-			<< side << "not implemented\n";
-			return 0;
-		}
-		
-		if(side==18) {
-			cout << "TPZGeoPyramid::CreateBCCompEl with side = 18 not implemented\n";
-			return 0;
-		}
-		
-		if(side<5) {
-			TPZManVector<int64_t> nodeindexes(1);
-			//		TPZGeoElPoint *gel;
-			nodeindexes[0] = orig->NodeIndex(side);
-			int64_t index;
-			TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EPoint,nodeindexes,bc,index);
-			//		gel = new TPZGeoElPoint(nodeindexes,bc,*orig->Mesh());
-			TPZGeoElSide origside(orig,side);
-			TPZGeoElSide(gel,0).SetConnectivity(origside);
-			return gel;
-		} 
-		else if (side > 4 && side < 13) {//side =5 a 12 : lados
-			TPZManVector<int64_t> nodes(2);
-			nodes[0] = orig->SideNodeIndex(side,0);
-			nodes[1] = orig->SideNodeIndex(side,1);
-			int64_t index;
-			TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EOned,nodes,bc,index);
-			//		TPZGeoEl1d *gel = new TPZGeoEl1d(nodes,bc,*orig->Mesh());
-			TPZGeoElSide(gel,0).SetConnectivity(TPZGeoElSide(orig,TPZShapePiram::ContainedSideLocId(side,0)));
-			TPZGeoElSide(gel,1).SetConnectivity(TPZGeoElSide(orig,TPZShapePiram::ContainedSideLocId(side,1)));
-			TPZGeoElSide(gel,2).SetConnectivity(TPZGeoElSide(orig,side));
-			return gel;
-		}
-		else if (side > 12) {//side = 13 a 17 : faces
-			TPZManVector<int64_t> nodes(4);//4o = -1 para face triangular
-			int iside;
-			for (iside=0;iside<4;iside++){
-				nodes[iside] = orig->SideNodeIndex(side,iside);
-			}
-			if(side==13) {
-				int64_t index;
-				TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EQuadrilateral,nodes,bc,index);
-				//      		gelq = new TPZGeoElQ2d(nodes,bc,*orig->Mesh());
-				for (iside=0; iside<8; iside++){
-					TPZGeoElSide(gel,iside).SetConnectivity(TPZGeoElSide(orig,TPZShapePiram::ContainedSideLocId(side,iside)));
-				}
-				TPZGeoElSide(gel,8).SetConnectivity(TPZGeoElSide(orig,side));
-				return gel;
-			} 
-			else {
-				nodes.Resize(3);
-				int64_t index;
-				TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(ETriangle,nodes,bc,index);
-				//			gelt = new TPZGeoElT2d(nodes,bc,*orig->Mesh());
-				for (iside=0; iside<6; iside++){
-					TPZGeoElSide(gel,iside).SetConnectivity(TPZGeoElSide(orig,TPZShapePiram::ContainedSideLocId(side,iside)));
-				}
-				TPZGeoElSide(gel,6).SetConnectivity(TPZGeoElSide(orig,side));
-				return gel;
-			}
-		} 
-		else 
-			PZError << "TPZGeoPyramid::CreateBCGeoEl. Side = " << side << endl;
-		return 0;
-	}
-	
-	void TPZGeoPyramid::FixSingularity(int side, TPZVec<REAL>& OriginalPoint, TPZVec<REAL>& ChangedPoint)
-	{
-		ChangedPoint.Resize(OriginalPoint.NElements(),0.);
-		ChangedPoint = OriginalPoint;
-		
-		switch(side)
-		{
-			case 5:
-			{
-				if(OriginalPoint[2] ==  1.)
-				{
-					ChangedPoint[2] = 1. - tol;
-				}
-				break;
-			}
-				
-			case 6:
-			{
-				if(OriginalPoint[2] ==  1.)
-				{
-					ChangedPoint[2] = 1. - tol;
-				}
-				break;
-			}
-				
-			case 7:
-			{
-				if(OriginalPoint[2] ==  1.)
-				{
-					ChangedPoint[2] = 1. - tol;
-				}
-				break;
-			}
-				
-			case 8:
-			{
-				if(OriginalPoint[2] ==  1.)
-				{
-					ChangedPoint[2] = 1. - tol;
-				}
-				break;
-			}
-				
-			case 9:
-			{
-				if( ChangedPoint[0] == 1. && ChangedPoint[1] == -1. )
-				{
-					ChangedPoint[0] =  1. - tol;
-					ChangedPoint[1] = -1. + tol;
-				}
-				if( ChangedPoint[0] == 1. && ChangedPoint[1] == 1. )
-				{
-					ChangedPoint[0] = 1. - tol;
-					ChangedPoint[1] = 1. - tol;
-				}
-				if( ChangedPoint[0] == -1. && ChangedPoint[1] == 1. )
-				{
-					ChangedPoint[0] = -1. + tol;
-					ChangedPoint[1] =  1. - tol;
-				}
-				if(OriginalPoint[2] ==  1.)
-				{
-					ChangedPoint[2] = 1. - tol;
-				}
-				break;
-			}
-				
-			case 10:
-			{
-				if( ChangedPoint[0] == -1. && ChangedPoint[1] == -1. )
-				{
-					ChangedPoint[0] = -1. + tol;
-					ChangedPoint[1] = -1. + tol;
-				}
-				if( ChangedPoint[0] == -1. && ChangedPoint[1] == 1. )
-				{
-					ChangedPoint[0] = -1. + tol;
-					ChangedPoint[1] =  1. - tol;
-				}
-				if( ChangedPoint[0] ==  1. && ChangedPoint[1] == 1. )
-				{
-					ChangedPoint[0] = 1. - tol;
-					ChangedPoint[1] = 1. - tol;
-				}
-				if(OriginalPoint[2] ==  1.)
-				{
-					ChangedPoint[2] = 1. - tol;
-				}
-				break;
-			}
-				
-			case 11:
-			{
-				if( ChangedPoint[0] ==  1. && ChangedPoint[1] == -1. )
-				{
-					ChangedPoint[0] =  1. - tol;
-					ChangedPoint[1] = -1. + tol;
-				}
-				if( ChangedPoint[0] == -1. && ChangedPoint[1] == -1. )
-				{
-					ChangedPoint[0] = -1. + tol;
-					ChangedPoint[1] = -1. + tol;
-				}
-				if( ChangedPoint[0] == -1. && ChangedPoint[1] ==  1. )
-				{
-					ChangedPoint[0] = -1. + tol;
-					ChangedPoint[1] =  1. - tol;
-				}
-				if(OriginalPoint[2] ==  1.)
-				{
-					ChangedPoint[2] = 1. - tol;
-				}
-				break;
-			}
-				
-			case 12:
-			{
-				if( ChangedPoint[0] ==  1. && ChangedPoint[1] ==  1. )
-				{
-					ChangedPoint[0] = 1. - tol;
-					ChangedPoint[1] = 1. - tol;
-				}
-				if( ChangedPoint[0] ==  1. && ChangedPoint[1] == -1. )
-				{
-					ChangedPoint[0] =  1. - tol;
-					ChangedPoint[1] = -1. + tol;
-				}
-				if( ChangedPoint[0] == -1. && ChangedPoint[1] == -1. )
-				{
-					ChangedPoint[0] = -1. + tol;
-					ChangedPoint[1] = -1. + tol;
-				}
-				if(OriginalPoint[2] ==  1.)
-				{
-					ChangedPoint[2] = 1. - tol;
-				}
-				break;
-			}
-				
-			case 13:
-			{
-				if( ChangedPoint[2] ==  1. )
-				{
-					ChangedPoint[2] = 1. - tol;
-				}
-				break;
-			}
-				
-			case 14:
-			{
-				if( ChangedPoint[2] ==  1. )
-				{
-					ChangedPoint[2] = 1. - tol;
-				}
-				if( (ChangedPoint[0] ==  1. && ChangedPoint[0] ==  1.) || (ChangedPoint[0] ==  -1. && ChangedPoint[0] ==  1.) )
-				{
-					ChangedPoint[1] = 1. - tol;
-				}
-				break;
-			}
-				
-			case 15:
-			{
-				if( ChangedPoint[2] ==  1. )
-				{
-					ChangedPoint[2] = 1. - tol;
-				}
-				if( (ChangedPoint[0] ==  -1. && ChangedPoint[0] ==  1.) || (ChangedPoint[0] ==  -1. && ChangedPoint[0] ==  -1.) )
-				{
-					ChangedPoint[0] = -1. + tol;
-				}
-				break;
-			}
-				
-			case 16:
-			{
-				if( ChangedPoint[2] ==  1. )
-				{
-					ChangedPoint[2] = 1. - tol;
-				}
-				if( (ChangedPoint[0] ==  1. && ChangedPoint[0] == -1.) || (ChangedPoint[0] ==  -1. && ChangedPoint[0] == -1.) )
-				{
-					ChangedPoint[1] = -1. + tol;
-				}
-				break;
-			}
-				
-			case 17:
-			{
-				if( ChangedPoint[2] ==  1. )
-				{
-					ChangedPoint[2] = 1. - tol;
-				}
-				if( (ChangedPoint[0] ==  1. && ChangedPoint[0] ==  1.) || (ChangedPoint[0] ==  1. && ChangedPoint[0] ==  -1.) )
-				{
-					ChangedPoint[0] = 1. - tol;
-				}
-				break;
-			}
-		}
-	}
-	
-	/**
-	 * Creates a geometric element according to the type of the father element
-	 */
-	TPZGeoEl *TPZGeoPyramid::CreateGeoElement(TPZGeoMesh &mesh, MElementType type,
-											  TPZVec<int64_t>& nodeindexes,
-											  int matid,
-											  int64_t& index)
-	{
-		return CreateGeoElementPattern(mesh,type,nodeindexes,matid,index);
-	}
+
+
+    TPZGeoEl *TPZGeoPyramid::CreateBCGeoEl(TPZGeoEl *orig, int side, int bc) {
+        if (side < 0 || side > 18) {
+            cout << "TPZGeoPyramid::CreateBCGeoEl Bad parameter side = "
+                 << side << "not implemented\n";
+            return 0;
+        }
+
+        if (side == 18) {
+            cout << "TPZGeoPyramid::CreateBCCompEl with side = 18 not implemented\n";
+            return 0;
+        }
+
+        if (side < 5) {
+            TPZManVector<int64_t> nodeindexes(1);
+            //		TPZGeoElPoint *gel;
+            nodeindexes[0] = orig->NodeIndex(side);
+            int64_t index;
+            TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EPoint, nodeindexes, bc, index);
+            //		gel = new TPZGeoElPoint(nodeindexes,bc,*orig->Mesh());
+            TPZGeoElSide origside(orig, side);
+            TPZGeoElSide(gel, 0).SetConnectivity(origside);
+            return gel;
+        } else if (side > 4 && side < 13) {//side =5 a 12 : lados
+            TPZManVector<int64_t> nodes(2);
+            nodes[0] = orig->SideNodeIndex(side, 0);
+            nodes[1] = orig->SideNodeIndex(side, 1);
+            int64_t index;
+            TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EOned, nodes, bc, index);
+            //		TPZGeoEl1d *gel = new TPZGeoEl1d(nodes,bc,*orig->Mesh());
+            TPZGeoElSide(gel, 0).SetConnectivity(TPZGeoElSide(orig, TPZShapePiram::ContainedSideLocId(side, 0)));
+            TPZGeoElSide(gel, 1).SetConnectivity(TPZGeoElSide(orig, TPZShapePiram::ContainedSideLocId(side, 1)));
+            TPZGeoElSide(gel, 2).SetConnectivity(TPZGeoElSide(orig, side));
+            return gel;
+        } else if (side > 12) {//side = 13 a 17 : faces
+            TPZManVector<int64_t> nodes(4);//4o = -1 para face triangular
+            int iside;
+            for (iside = 0; iside < 4; iside++) {
+                nodes[iside] = orig->SideNodeIndex(side, iside);
+            }
+            if (side == 13) {
+                int64_t index;
+                TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EQuadrilateral, nodes, bc, index);
+                //      		gelq = new TPZGeoElQ2d(nodes,bc,*orig->Mesh());
+                for (iside = 0; iside < 8; iside++) {
+                    TPZGeoElSide(gel, iside).SetConnectivity(
+                            TPZGeoElSide(orig, TPZShapePiram::ContainedSideLocId(side, iside)));
+                }
+                TPZGeoElSide(gel, 8).SetConnectivity(TPZGeoElSide(orig, side));
+                return gel;
+            } else {
+                nodes.Resize(3);
+                int64_t index;
+                TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(ETriangle, nodes, bc, index);
+                //			gelt = new TPZGeoElT2d(nodes,bc,*orig->Mesh());
+                for (iside = 0; iside < 6; iside++) {
+                    TPZGeoElSide(gel, iside).SetConnectivity(
+                            TPZGeoElSide(orig, TPZShapePiram::ContainedSideLocId(side, iside)));
+                }
+                TPZGeoElSide(gel, 6).SetConnectivity(TPZGeoElSide(orig, side));
+                return gel;
+            }
+        } else
+            PZError << "TPZGeoPyramid::CreateBCGeoEl. Side = " << side << endl;
+        return 0;
+    }
+
+    void TPZGeoPyramid::FixSingularity(int side, TPZVec<REAL> &OriginalPoint, TPZVec<REAL> &ChangedPoint) {
+        ChangedPoint.Resize(OriginalPoint.NElements(), 0.);
+        ChangedPoint = OriginalPoint;
+
+        switch (side) {
+            case 5: {
+                if (OriginalPoint[2] == 1.) {
+                    ChangedPoint[2] = 1. - tol;
+                }
+                break;
+            }
+
+            case 6: {
+                if (OriginalPoint[2] == 1.) {
+                    ChangedPoint[2] = 1. - tol;
+                }
+                break;
+            }
+
+            case 7: {
+                if (OriginalPoint[2] == 1.) {
+                    ChangedPoint[2] = 1. - tol;
+                }
+                break;
+            }
+
+            case 8: {
+                if (OriginalPoint[2] == 1.) {
+                    ChangedPoint[2] = 1. - tol;
+                }
+                break;
+            }
+
+            case 9: {
+                if (ChangedPoint[0] == 1. && ChangedPoint[1] == -1.) {
+                    ChangedPoint[0] = 1. - tol;
+                    ChangedPoint[1] = -1. + tol;
+                }
+                if (ChangedPoint[0] == 1. && ChangedPoint[1] == 1.) {
+                    ChangedPoint[0] = 1. - tol;
+                    ChangedPoint[1] = 1. - tol;
+                }
+                if (ChangedPoint[0] == -1. && ChangedPoint[1] == 1.) {
+                    ChangedPoint[0] = -1. + tol;
+                    ChangedPoint[1] = 1. - tol;
+                }
+                if (OriginalPoint[2] == 1.) {
+                    ChangedPoint[2] = 1. - tol;
+                }
+                break;
+            }
+
+            case 10: {
+                if (ChangedPoint[0] == -1. && ChangedPoint[1] == -1.) {
+                    ChangedPoint[0] = -1. + tol;
+                    ChangedPoint[1] = -1. + tol;
+                }
+                if (ChangedPoint[0] == -1. && ChangedPoint[1] == 1.) {
+                    ChangedPoint[0] = -1. + tol;
+                    ChangedPoint[1] = 1. - tol;
+                }
+                if (ChangedPoint[0] == 1. && ChangedPoint[1] == 1.) {
+                    ChangedPoint[0] = 1. - tol;
+                    ChangedPoint[1] = 1. - tol;
+                }
+                if (OriginalPoint[2] == 1.) {
+                    ChangedPoint[2] = 1. - tol;
+                }
+                break;
+            }
+
+            case 11: {
+                if (ChangedPoint[0] == 1. && ChangedPoint[1] == -1.) {
+                    ChangedPoint[0] = 1. - tol;
+                    ChangedPoint[1] = -1. + tol;
+                }
+                if (ChangedPoint[0] == -1. && ChangedPoint[1] == -1.) {
+                    ChangedPoint[0] = -1. + tol;
+                    ChangedPoint[1] = -1. + tol;
+                }
+                if (ChangedPoint[0] == -1. && ChangedPoint[1] == 1.) {
+                    ChangedPoint[0] = -1. + tol;
+                    ChangedPoint[1] = 1. - tol;
+                }
+                if (OriginalPoint[2] == 1.) {
+                    ChangedPoint[2] = 1. - tol;
+                }
+                break;
+            }
+
+            case 12: {
+                if (ChangedPoint[0] == 1. && ChangedPoint[1] == 1.) {
+                    ChangedPoint[0] = 1. - tol;
+                    ChangedPoint[1] = 1. - tol;
+                }
+                if (ChangedPoint[0] == 1. && ChangedPoint[1] == -1.) {
+                    ChangedPoint[0] = 1. - tol;
+                    ChangedPoint[1] = -1. + tol;
+                }
+                if (ChangedPoint[0] == -1. && ChangedPoint[1] == -1.) {
+                    ChangedPoint[0] = -1. + tol;
+                    ChangedPoint[1] = -1. + tol;
+                }
+                if (OriginalPoint[2] == 1.) {
+                    ChangedPoint[2] = 1. - tol;
+                }
+                break;
+            }
+
+            case 13: {
+                if (ChangedPoint[2] == 1.) {
+                    ChangedPoint[2] = 1. - tol;
+                }
+                break;
+            }
+
+            case 14: {
+                if (ChangedPoint[2] == 1.) {
+                    ChangedPoint[2] = 1. - tol;
+                }
+                if ((ChangedPoint[0] == 1. && ChangedPoint[0] == 1.) ||
+                    (ChangedPoint[0] == -1. && ChangedPoint[0] == 1.)) {
+                    ChangedPoint[1] = 1. - tol;
+                }
+                break;
+            }
+
+            case 15: {
+                if (ChangedPoint[2] == 1.) {
+                    ChangedPoint[2] = 1. - tol;
+                }
+                if ((ChangedPoint[0] == -1. && ChangedPoint[0] == 1.) ||
+                    (ChangedPoint[0] == -1. && ChangedPoint[0] == -1.)) {
+                    ChangedPoint[0] = -1. + tol;
+                }
+                break;
+            }
+
+            case 16: {
+                if (ChangedPoint[2] == 1.) {
+                    ChangedPoint[2] = 1. - tol;
+                }
+                if ((ChangedPoint[0] == 1. && ChangedPoint[0] == -1.) ||
+                    (ChangedPoint[0] == -1. && ChangedPoint[0] == -1.)) {
+                    ChangedPoint[1] = -1. + tol;
+                }
+                break;
+            }
+
+            case 17: {
+                if (ChangedPoint[2] == 1.) {
+                    ChangedPoint[2] = 1. - tol;
+                }
+                if ((ChangedPoint[0] == 1. && ChangedPoint[0] == 1.) ||
+                    (ChangedPoint[0] == 1. && ChangedPoint[0] == -1.)) {
+                    ChangedPoint[0] = 1. - tol;
+                }
+                break;
+            }
+        }
+    }
+
+    /**
+     * Creates a geometric element according to the type of the father element
+     */
+    TPZGeoEl *TPZGeoPyramid::CreateGeoElement(TPZGeoMesh &mesh, MElementType type,
+                                              TPZVec<int64_t> &nodeindexes,
+                                              int matid,
+                                              int64_t &index) {
+        return CreateGeoElementPattern(mesh, type, nodeindexes, matid, index);
+    }
 
     /// create an example element based on the topology
     /* @param gmesh mesh in which the element should be inserted
@@ -462,19 +336,19 @@ namespace pzgeom {
      @param lowercorner (in/out) on input lower corner o the cube where the element should be created, on exit position of the next cube
      @param size (in) size of space where the element should be created
      */
-    void TPZGeoPyramid::InsertExampleElement(TPZGeoMesh &gmesh, int matid, TPZVec<REAL> &lowercorner, TPZVec<REAL> &size)
-    {
-        TPZManVector<REAL,3> co(3),shift(3),scale(3);
-        TPZManVector<int64_t,3> nodeindexes(8);
-        for (int i=0; i<3; i++) {
-            scale[i] = size[i]/3.;
-            shift[i] = 1./2.+lowercorner[i];
+    void
+    TPZGeoPyramid::InsertExampleElement(TPZGeoMesh &gmesh, int matid, TPZVec<REAL> &lowercorner, TPZVec<REAL> &size) {
+        TPZManVector<REAL, 3> co(3), shift(3), scale(3);
+        TPZManVector<int64_t, 3> nodeindexes(8);
+        for (int i = 0; i < 3; i++) {
+            scale[i] = size[i] / 3.;
+            shift[i] = 1. / 2. + lowercorner[i];
         }
-        
-        for (int i=0; i<NCornerNodes; i++) {
+
+        for (int i = 0; i < NCornerNodes; i++) {
             ParametricDomainNodeCoord(i, co);
-            for (int j=0; j<3; j++) {
-                co[j] = shift[j]+scale[j]*co[j]+(rand()*0.2/RAND_MAX)-0.1;
+            for (int j = 0; j < 3; j++) {
+                co[j] = shift[j] + scale[j] * co[j] + (rand() * 0.2 / RAND_MAX) - 0.1;
             }
             nodeindexes[i] = gmesh.NodeVec().AllocateNewElement();
             gmesh.NodeVec()[nodeindexes[i]].Initialize(co, gmesh);
@@ -482,27 +356,17 @@ namespace pzgeom {
         int64_t index;
         CreateGeoElement(gmesh, EPiramide, nodeindexes, matid, index);
     }
-    
-    int TPZGeoPyramid::ClassId() const{
+
+    int TPZGeoPyramid::ClassId() const {
         return Hash("TPZGeoPyramid") ^ TPZNodeRep<5, pztopology::TPZPyramid>::ClassId() << 1;
     }
-    
-    void TPZGeoPyramid::Read(TPZStream& buf, void* context) {
-        TPZNodeRep<5, pztopology::TPZPyramid>::Read(buf,context);
+
+    void TPZGeoPyramid::Read(TPZStream &buf, void *context) {
+        TPZNodeRep<5, pztopology::TPZPyramid>::Read(buf, context);
     }
 
-    void TPZGeoPyramid::Write(TPZStream& buf, int withclassid) const {
-        TPZNodeRep<5, pztopology::TPZPyramid>::Write(buf,withclassid);
+    void TPZGeoPyramid::Write(TPZStream &buf, int withclassid) const {
+        TPZNodeRep<5, pztopology::TPZPyramid>::Write(buf, withclassid);
     }
-
-    template void TPZGeoPyramid::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
 
 };
-
-#ifdef _AUTODIFF
-template<class T=REAL>
-class Fad;
-
-template void pzgeom::TPZGeoPyramid::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
-        TPZVec<Fad<REAL>> &);
-#endif

--- a/Geom/pzgeopyramid.h
+++ b/Geom/pzgeopyramid.h
@@ -67,25 +67,10 @@ namespace pzgeom {
         {
             return true;
         }
-        /**
-         * This method calculates the influence (a.k.a. the blend function) of the side side regarding an
-         * interior point qsi. It is used by the TPZGeoBlend class.
-         * @param side the index of the side
-         * @param xi coordinates of the interior point
-         * @param correctionFactor influence (0 <= correctionFactor <= 1)
-         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
-         */
-        template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
-                                      TPZVec<T> &corrFactorDxi);
 
 		/** @brief Returns the type name of the element */
 		static std::string TypeName() { return "Pyramid";}
-		
-        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
-        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
-            TShape(loc, phi, dphi);
-        }
+
         
         /* @brief Compute x mapping from local parametric coordinates */
         template<class T>
@@ -133,11 +118,7 @@ namespace pzgeom {
         /** @brief Compute gradient of x mapping from element nodes and local parametric coordinates */
         template<class T>
         static void GradX(const TPZFMatrix<REAL> &nodes,TPZVec<T> &loc, TPZFMatrix<T> &gradx);
-        
-        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
-        template<class T>
-        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
-		
+
 		/**
 		 * @brief Method which creates a geometric boundary condition 
 		 * element based on the current geometric element, 
@@ -170,69 +151,7 @@ namespace pzgeom {
 										  int matid,
 										  int64_t& index);
 	};
-    
-    template<class T>
-    inline void TPZGeoPyramid::TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi) {
-        T xi = loc[0], eta = loc[1] , zeta  = loc[2];
-        
-        if (zeta> 1.) {
-            DebugStop();
-        }
-        
-        T T0xz = .5*(1.-zeta-xi) / (1.-zeta);
-        T T0yz = .5*(1.-zeta-eta) / (1.-zeta);
-        T T1xz = .5*(1.-zeta+xi) / (1.-zeta);
-        T T1yz = .5*(1.-zeta+eta) / (1.-zeta);
-        if (IsZero(xi)) {
-            T0xz = 0.5;
-            T1xz = 0.5;
-        }
-        if (IsZero(eta)) {
-            T0yz = 0.5;
-            T1yz = 0.5;
-        }
-        T lmez = (1.-zeta);
-        
-        phi(0,0)  = T0xz*T0yz*lmez;
-        phi(1,0)  = T1xz*T0yz*lmez;
-        phi(2,0)  = T1xz*T1yz*lmez;
-        phi(3,0)  = T0xz*T1yz*lmez;
-        phi(4,0)  = zeta;
-        
-        T lmexmez = 1.-xi-zeta;
-        T lmeymez = 1.-eta-zeta;
-        T lmaxmez = 1.+xi-zeta;
-        T lmaymez = 1.+eta-zeta;
-        
-        if (IsZero(lmez) && !IsZero(lmexmez) && !IsZero(lmeymez) &&
-            !IsZero(lmaxmez) && !IsZero(lmaymez)) {
-            DebugStop();
-        }
-        if (IsZero(lmez)) {
-            lmexmez = 0.999;
-            lmeymez = 0.999;
-            lmaxmez = 0.999;
-            lmaymez = 0.999;
-            lmez = 0.001;
-        }
-        
-        dphi(0,0) = -.25*lmeymez / lmez;
-        dphi(1,0) = -.25*lmexmez / lmez;
-        dphi(2,0) = -.25*(lmeymez+lmexmez-lmexmez*lmeymez/lmez) / lmez;
-        dphi(0,1) =  .25*lmeymez / lmez;
-        dphi(1,1) = -.25*lmaxmez / lmez;
-        dphi(2,1) = -.25*(lmeymez+lmaxmez-lmaxmez*lmeymez/lmez) / lmez;
-        dphi(0,2) =  .25*lmaymez / lmez;
-        dphi(1,2) =  .25*lmaxmez / lmez;
-        dphi(2,2) = -.25*(lmaymez+lmaxmez-lmaxmez*lmaymez/lmez) / lmez;
-        dphi(0,3) = -.25*lmaymez / lmez;
-        dphi(1,3) =  .25*lmexmez / lmez;
-        dphi(2,3) = -.25*(lmaymez+lmexmez-lmexmez*lmaymez/lmez) / lmez;
-        dphi(0,4) =  0.0;
-        dphi(1,4) =  0.0;
-        dphi(2,4) =  1.0;
-        
-    }
+
     
     template<class T>
     inline void TPZGeoPyramid::X(const TPZFMatrix<REAL> &nodes,TPZVec<T> &loc,TPZVec<T> &x){

--- a/Geom/pzgeoquad.cpp
+++ b/Geom/pzgeoquad.cpp
@@ -20,363 +20,296 @@ using namespace std;
 namespace pzgeom {
     const REAL tol = pzgeom_TPZNodeRep_tol;
 
-    template<class T>
-    void TPZGeoQuad::CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
-                                       TPZVec<T> &corrFactorDxi){
-#ifdef PZDEBUG
-        std::ostringstream sout;
-        if(side < NNodes || side >= NSides){
-            sout<<"The side\t"<<side<<"is invalid. Aborting..."<<std::endl;
 
-            PZError<<std::endl<<sout.str()<<std::endl;
-            DebugStop();
+    //coord é uma matrix 3x4
+    void TPZGeoQuad::VecHdiv(TPZFMatrix<REAL> &coord, TPZFMatrix<REAL> &fNormalVec, TPZVec<int> &fVectorSide) {
+        if (coord.Rows() != 3) {
+            cout << "Erro na dimensao das linhas de coord" << endl;
         }
+        if (coord.Cols() != 4) {
+            cout << "Erro na dimensao das colunas de coord" << endl;
+        }
+        TPZVec<REAL> p1(3), p2(3), p3(3), p4(3), result(3);
+        for (int j = 0; j < 3; j++) {
+            p1[j] = coord.GetVal(j, 0);
+            p2[j] = coord.GetVal(j, 1);
+            p3[j] = coord.GetVal(j, 2);
+            p4[j] = coord.GetVal(j, 3);
+        }
+        fNormalVec.Resize(18, 3);
+        fVectorSide.Resize(18);
+        int64_t count = 0;
+        //primeira face
+        for (int j = 0; j < 3; j++)//v0
+        {
+            fNormalVec(0, j) = coord.GetVal(j, 0) - coord.GetVal(j, 3);
 
-        if(!IsInParametricDomain(xi,tol)){
-            sout<<"The method CalcSideInfluence expects the point xi to correspond to coordinates of a point";
-            sout<<" inside the parametric domain. Aborting...";
-            PZError<<std::endl<<sout.str()<<std::endl;
-            #ifdef LOG4CXX
-            LOGPZ_FATAL(logger,sout.str().c_str());
-            #endif
-            DebugStop();
         }
-#endif
-        TPZFNMatrix<4,T> phi(NNodes,1);
-        TPZFNMatrix<8,T> dphi(Dimension,NNodes);
-        TPZGeoQuad::TShape(xi,phi,dphi);
-        corrFactorDxi.Resize(TPZGeoQuad::Dimension, (T) 0);
-        int i = -1;
-        switch(side){
-            case 0:
-            case 1:
-            case 2:
-            case 3:
-                correctionFactor = 0;
-                return;
-            case 4:
-                i = 0;
-                break;
-            case 5:
-                i = 1;
-                break;
-            case 6:
-                i = 2;
-                break;
-            case 7:
-                i = 3;
-                break;
-            case 8:
-                correctionFactor = 1;
-                return;
+        fVectorSide[count] = 0;
+        count++;
+        for (int j = 0; j < 3; j++)//v1
+        {
+            fNormalVec(1, j) = coord.GetVal(j, 1) - coord.GetVal(j, 2);
         }
-        correctionFactor = phi(i,0) + phi((i+1)%NNodes,0);
-        corrFactorDxi[0] = dphi(0,i) + dphi(0,(i+1)%NNodes);
-        corrFactorDxi[1] = dphi(1,i) + dphi(1,(i+1)%NNodes);
-    }
-	
-	//coord é uma matrix 3x4
-	void TPZGeoQuad::VecHdiv(TPZFMatrix<REAL> & coord, TPZFMatrix<REAL> & fNormalVec,TPZVec<int> & fVectorSide){
-		if(coord.Rows()!=3)
-		{
-			cout<< "Erro na dimensao das linhas de coord"<< endl;
-		}
-		if(coord.Cols()!=4)
-		{
-			cout<< "Erro na dimensao das colunas de coord"<< endl;
-		}
-		TPZVec<REAL> p1(3), p2(3), p3(3), p4(3),result(3);
-		for(int j=0;j<3;j++)
-		{
-			p1[j]=coord.GetVal(j,0);
-			p2[j]=coord.GetVal(j,1);
-			p3[j]=coord.GetVal(j,2);
-			p4[j]=coord.GetVal(j,3);
-		}
-		fNormalVec.Resize(18, 3);
-		fVectorSide.Resize(18);
-		int64_t count=0;
-		//primeira face
-		for(int j=0;j<3;j++)//v0
-		{
-			fNormalVec(0,j) = coord.GetVal(j,0)- coord.GetVal(j,3);
-			
-		}
-		fVectorSide[count]=0;
-		count++;
-		for(int j=0;j<3;j++)//v1
-		{
-			fNormalVec(1,j) = coord.GetVal(j,1)- coord.GetVal(j,2);
-		}
-		fVectorSide[count]=1;
-		count++;
-		//v2
-		ComputeNormal(p1,p2,p3,result);
-		fNormalVec(2,0) = -result[0];
-		fNormalVec(2,1) = -result[1];
-		fNormalVec(2,2) = -result[2];
-		fVectorSide[count]=4;
-		count++;
-		//segunda face
-		for(int j=0;j<3;j++)//v3
-		{
-			fNormalVec(3,j) = coord.GetVal(j,1)- coord.GetVal(j,0);
-		}
-		fVectorSide[count]=1;
-		count++;
-		for(int j=0;j<3;j++)//v4
-		{
-			fNormalVec(4,j) = coord.GetVal(j,2)- coord.GetVal(j,3);
-		}
-		fVectorSide[count]=2;
-		count++;
-		//v5
-		ComputeNormal(p2,p3,p4,result);
-		fNormalVec(5,0) = -result[0];
-		fNormalVec(5,1) = -result[1];
-		fNormalVec(5,2) = -result[2];
-		fVectorSide[count]=5;
-		count++;
-		//terceira face
-		for(int j=0;j<3;j++)//v6
-		{
-			fNormalVec(6,j) = coord.GetVal(j,2)- coord.GetVal(j,1);
-		}
-		fVectorSide[count]=2;
-		count++;
-		for(int j=0;j<3;j++)//v7
-		{
-			fNormalVec(7,j) = coord.GetVal(j,3)- coord.GetVal(j,0);
-		}
-		fVectorSide[count]=3;
-		count++;
-		//v8
-		ComputeNormal(p3,p4,p1,result);
-		fNormalVec(8,0) = -result[0];
-		fNormalVec(8,1) = -result[1];
-		fNormalVec(8,2) = -result[2];
-		fVectorSide[count]=6;
-		count++;
-		//quarta face
-		for(int j=0;j<3;j++)//v9
-		{
-			fNormalVec(9,j) = coord.GetVal(j,3)- coord.GetVal(j,2);
-		}
-		fVectorSide[count]=3;
-		count++;
-		for(int j=0;j<3;j++)//v10
-		{
-			fNormalVec(10,j) = coord.GetVal(j,0)- coord.GetVal(j,1);
-		}
-		fVectorSide[count]=0;
-		count++;
-		//v11
-		ComputeNormal(p4,p1,p2,result);
-		fNormalVec(11,0) = -result[0];
-		fNormalVec(11,1) = -result[1];
-		fNormalVec(11,2) = -result[2];
-		fVectorSide[count]=7;
-		count++;
-		
-		// internos tangentes
-		for(int j=0;j<3;j++)//v12
-		{
-			fNormalVec(12,j) = coord.GetVal(j,1)- coord.GetVal(j,0);
-		}  
-		fVectorSide[count]=4;
-		count++;
-		for(int j=0;j<3;j++)//v13
-		{
-			fNormalVec(13,j) = coord.GetVal(j,2)- coord.GetVal(j,1);
-		}	
-		fVectorSide[count]=5;
-		count++;
-		for(int j=0;j<3;j++)//v14
-		{
-			fNormalVec(14,j) = coord.GetVal(j,3)- coord.GetVal(j,2);
-		}	
-		fVectorSide[count]=6;
-		count++;
-		for(int j=0;j<3;j++)//v15
-		{
-			fNormalVec(15,j) = coord.GetVal(j,0)- coord.GetVal(j,3);
-		}	
-		fVectorSide[count]=7;
-		count++;
-		//internos meio
-		TPZVec<REAL> midle(3,0.);
-		midle[0]=0.25*(coord.GetVal(0,2)+coord.GetVal(0,3)+coord.GetVal(0,0)+coord.GetVal(0,1));
-		midle[1]=0.25*(coord.GetVal(1,2)+coord.GetVal(1,3)+coord.GetVal(1,0)+coord.GetVal(1,1));		
-		midle[2]=0.25*(coord.GetVal(2,2)+coord.GetVal(2,3)+coord.GetVal(2,0)+coord.GetVal(2,1));
-		TPZFMatrix<REAL> jacobian;
-		TPZFMatrix<REAL> axes;
-		TPZFMatrix<REAL> jacinv;
+        fVectorSide[count] = 1;
+        count++;
+        //v2
+        ComputeNormal(p1, p2, p3, result);
+        fNormalVec(2, 0) = -result[0];
+        fNormalVec(2, 1) = -result[1];
+        fNormalVec(2, 2) = -result[2];
+        fVectorSide[count] = 4;
+        count++;
+        //segunda face
+        for (int j = 0; j < 3; j++)//v3
+        {
+            fNormalVec(3, j) = coord.GetVal(j, 1) - coord.GetVal(j, 0);
+        }
+        fVectorSide[count] = 1;
+        count++;
+        for (int j = 0; j < 3; j++)//v4
+        {
+            fNormalVec(4, j) = coord.GetVal(j, 2) - coord.GetVal(j, 3);
+        }
+        fVectorSide[count] = 2;
+        count++;
+        //v5
+        ComputeNormal(p2, p3, p4, result);
+        fNormalVec(5, 0) = -result[0];
+        fNormalVec(5, 1) = -result[1];
+        fNormalVec(5, 2) = -result[2];
+        fVectorSide[count] = 5;
+        count++;
+        //terceira face
+        for (int j = 0; j < 3; j++)//v6
+        {
+            fNormalVec(6, j) = coord.GetVal(j, 2) - coord.GetVal(j, 1);
+        }
+        fVectorSide[count] = 2;
+        count++;
+        for (int j = 0; j < 3; j++)//v7
+        {
+            fNormalVec(7, j) = coord.GetVal(j, 3) - coord.GetVal(j, 0);
+        }
+        fVectorSide[count] = 3;
+        count++;
+        //v8
+        ComputeNormal(p3, p4, p1, result);
+        fNormalVec(8, 0) = -result[0];
+        fNormalVec(8, 1) = -result[1];
+        fNormalVec(8, 2) = -result[2];
+        fVectorSide[count] = 6;
+        count++;
+        //quarta face
+        for (int j = 0; j < 3; j++)//v9
+        {
+            fNormalVec(9, j) = coord.GetVal(j, 3) - coord.GetVal(j, 2);
+        }
+        fVectorSide[count] = 3;
+        count++;
+        for (int j = 0; j < 3; j++)//v10
+        {
+            fNormalVec(10, j) = coord.GetVal(j, 0) - coord.GetVal(j, 1);
+        }
+        fVectorSide[count] = 0;
+        count++;
+        //v11
+        ComputeNormal(p4, p1, p2, result);
+        fNormalVec(11, 0) = -result[0];
+        fNormalVec(11, 1) = -result[1];
+        fNormalVec(11, 2) = -result[2];
+        fVectorSide[count] = 7;
+        count++;
+
+        // internos tangentes
+        for (int j = 0; j < 3; j++)//v12
+        {
+            fNormalVec(12, j) = coord.GetVal(j, 1) - coord.GetVal(j, 0);
+        }
+        fVectorSide[count] = 4;
+        count++;
+        for (int j = 0; j < 3; j++)//v13
+        {
+            fNormalVec(13, j) = coord.GetVal(j, 2) - coord.GetVal(j, 1);
+        }
+        fVectorSide[count] = 5;
+        count++;
+        for (int j = 0; j < 3; j++)//v14
+        {
+            fNormalVec(14, j) = coord.GetVal(j, 3) - coord.GetVal(j, 2);
+        }
+        fVectorSide[count] = 6;
+        count++;
+        for (int j = 0; j < 3; j++)//v15
+        {
+            fNormalVec(15, j) = coord.GetVal(j, 0) - coord.GetVal(j, 3);
+        }
+        fVectorSide[count] = 7;
+        count++;
+        //internos meio
+        TPZVec<REAL> midle(3, 0.);
+        midle[0] = 0.25 * (coord.GetVal(0, 2) + coord.GetVal(0, 3) + coord.GetVal(0, 0) + coord.GetVal(0, 1));
+        midle[1] = 0.25 * (coord.GetVal(1, 2) + coord.GetVal(1, 3) + coord.GetVal(1, 0) + coord.GetVal(1, 1));
+        midle[2] = 0.25 * (coord.GetVal(2, 2) + coord.GetVal(2, 3) + coord.GetVal(2, 0) + coord.GetVal(2, 1));
+        TPZFMatrix<REAL> jacobian;
+        TPZFMatrix<REAL> axes;
+        TPZFMatrix<REAL> jacinv;
         DebugStop();
         //Jacobian(coord,midle,jacobian,axes,detjac,jacinv);
-		fNormalVec(16,0)=axes(0,0);
-		fNormalVec(16,1)=axes(0,1);
-		fNormalVec(16,2)=axes(0,2);
-		fNormalVec(17,0)=axes(1,0);
-		fNormalVec(17,1)=axes(1,1);
-		fNormalVec(17,2)=axes(1,2);
-		fVectorSide[count]=8;
-		fVectorSide[count+1]=8;
-		
-		
-		//normalization
-		for(int k=0;k<16;k++)
-		{
-			REAL temp=0.;
-			temp = sqrt( fNormalVec(k,0)*fNormalVec(k,0) + fNormalVec(k,1)*fNormalVec(k,1) + fNormalVec(k,2)*fNormalVec(k,2));
-			fNormalVec(k,0) *=1./temp;	
-			fNormalVec(k,1) *=1./temp;	
-		}
-		// produto normal == 1
-		for(int kk=0;kk<4;kk++)
-		{
-			REAL temp1=0.;
-			REAL temp2=0.;
-			temp1 =  fNormalVec(kk*3,0)*fNormalVec(kk*3+2,0) + fNormalVec(kk*3,1)*fNormalVec(kk*3+2,1);
-			temp2 =  fNormalVec(kk*3+1,0)*fNormalVec(kk*3+2,0) + fNormalVec(kk*3+1,1)*fNormalVec(kk*3+2,1);
-			fNormalVec(kk*3,0) *=1./temp1;	
-			fNormalVec(kk*3,1) *=1./temp1;
-			fNormalVec(kk*3+1,0) *=1./temp2;
-			fNormalVec(kk*3+1,1) *=1./temp2;
-		}	
+        fNormalVec(16, 0) = axes(0, 0);
+        fNormalVec(16, 1) = axes(0, 1);
+        fNormalVec(16, 2) = axes(0, 2);
+        fNormalVec(17, 0) = axes(1, 0);
+        fNormalVec(17, 1) = axes(1, 1);
+        fNormalVec(17, 2) = axes(1, 2);
+        fVectorSide[count] = 8;
+        fVectorSide[count + 1] = 8;
+
+
+        //normalization
+        for (int k = 0; k < 16; k++) {
+            REAL temp = 0.;
+            temp = sqrt(fNormalVec(k, 0) * fNormalVec(k, 0) + fNormalVec(k, 1) * fNormalVec(k, 1) +
+                        fNormalVec(k, 2) * fNormalVec(k, 2));
+            fNormalVec(k, 0) *= 1. / temp;
+            fNormalVec(k, 1) *= 1. / temp;
+        }
+        // produto normal == 1
+        for (int kk = 0; kk < 4; kk++) {
+            REAL temp1 = 0.;
+            REAL temp2 = 0.;
+            temp1 = fNormalVec(kk * 3, 0) * fNormalVec(kk * 3 + 2, 0) +
+                    fNormalVec(kk * 3, 1) * fNormalVec(kk * 3 + 2, 1);
+            temp2 = fNormalVec(kk * 3 + 1, 0) * fNormalVec(kk * 3 + 2, 0) +
+                    fNormalVec(kk * 3 + 1, 1) * fNormalVec(kk * 3 + 2, 1);
+            fNormalVec(kk * 3, 0) *= 1. / temp1;
+            fNormalVec(kk * 3, 1) *= 1. / temp1;
+            fNormalVec(kk * 3 + 1, 0) *= 1. / temp2;
+            fNormalVec(kk * 3 + 1, 1) *= 1. / temp2;
+        }
 #ifdef LOG4CXX
         if (logger->isDebugEnabled())
-		{
-			std::stringstream sout;
-			fNormalVec.Print("fNormalVec", sout);	
-			sout << " fVectorSide" << fVectorSide;
-			LOGPZ_DEBUG(logger,sout.str())
-		}
-#endif 
-		
-	}
-	void TPZGeoQuad::VectorialProduct(TPZVec<REAL> &v1, TPZVec<REAL> &v2,TPZVec<REAL> &result){
-		if(v1.NElements()!=3||v2.NElements()!=3)
-		{
-			cout << " o tamanho do vetores eh diferente de 3"<< endl;
-		}
-		REAL x1=v1[0], y1=v1[1],z1=v1[2];
-		REAL x2=v2[0], y2=v2[1],z2=v2[2];
-		result.Resize(v1.NElements());
-		result[0]=y1*z2-z1*y2;
-		result[1]=z1*x2-x1*z2;	
-		result[2]=x1*y2-y1*x2;	
-	}
-	
-	void TPZGeoQuad::ComputeNormal(TPZVec<REAL> &p1, TPZVec<REAL> &p2,TPZVec<REAL> &p3,TPZVec<REAL> &result){
-		TPZVec<REAL> v1(3);
-		TPZVec<REAL> v2(3);
-		TPZVec<REAL> normal(3);
-		v1[0]=p1[0]-p2[0];
-		v1[1]=p1[1]-p2[1];
-		v1[2]=p1[2]-p2[2];
-		v2[0]=p2[0]-p3[0];
-		v2[1]=p2[1]-p3[1];
-		v2[2]=p2[2]-p3[2];
-		VectorialProduct(v1,v2,normal);
-		VectorialProduct(v1,normal,result);	
-	}
-	
-	
-	TPZGeoEl *TPZGeoQuad::CreateBCGeoEl(TPZGeoEl *orig,int side,int bc) {
-		if(side==8) {//8
-			TPZManVector<int64_t> nodes(4);
-			int i;
-			for (i=0;i<4;i++) {
-				nodes[i] = orig->SideNodeIndex(side,i);
-			}
-			int64_t index;
-			TPZGeoEl *gel = orig->CreateGeoElement(EQuadrilateral,nodes,bc,index);
-			int iside;
-			for (iside = 0; iside <8; iside++){
-				TPZGeoElSide(gel,iside).SetConnectivity(TPZGeoElSide(orig,pztopology::TPZQuadrilateral::ContainedSideLocId(side,iside)));
-			}
-			TPZGeoElSide(gel,8).SetConnectivity(TPZGeoElSide(orig,side));
-			return gel;
-		}
-		else if(side>-1 && side<4) {//side = 0,1,2,3
-			TPZManVector<int64_t> nodeindexes(1);
-			nodeindexes[0] = orig->SideNodeIndex(side,0);
-			int64_t index;
-			TPZGeoEl *gel = orig->CreateGeoElement(EPoint,nodeindexes,bc,index);
-			TPZGeoElSide(gel,0).SetConnectivity(TPZGeoElSide(orig,side));
-			return gel;
-		}
-		else if(side>3 && side<8) {
-			TPZManVector<int64_t> nodes(2);
-			nodes[0] = orig->SideNodeIndex(side,0);
-			nodes[1] = orig->SideNodeIndex(side,1);
-			int64_t index;
-			TPZGeoEl *gel = orig->CreateGeoElement(EOned,nodes,bc,index);
-			TPZGeoElSide(gel,0).SetConnectivity(TPZGeoElSide(orig,pztopology::TPZQuadrilateral::ContainedSideLocId(side,0)));
-			TPZGeoElSide(gel,1).SetConnectivity(TPZGeoElSide(orig,pztopology::TPZQuadrilateral::ContainedSideLocId(side,1)));
-			TPZGeoElSide(gel,2).SetConnectivity(TPZGeoElSide(orig,side));
-			return gel;
-		}
-		else PZError << "TPZGeoQuad::CreateBCCompEl has no bc.\n";
-		return 0;
-	}
-	
-    void TPZGeoQuad::InsertExampleElement(TPZGeoMesh &gmesh, int matid, TPZVec<REAL> &lowercorner, TPZVec<REAL> &size)
-    {
-        TPZManVector<int64_t,4> nodeindexes(4);
-        TPZManVector<REAL,3> co(lowercorner);
-        for (int i=0; i<3; i++) {
-            co[i] += 0.2*size[i];   
+        {
+            std::stringstream sout;
+            fNormalVec.Print("fNormalVec", sout);
+            sout << " fVectorSide" << fVectorSide;
+            LOGPZ_DEBUG(logger,sout.str())
         }
-        
+#endif
+
+    }
+
+    void TPZGeoQuad::VectorialProduct(TPZVec<REAL> &v1, TPZVec<REAL> &v2, TPZVec<REAL> &result) {
+        if (v1.NElements() != 3 || v2.NElements() != 3) {
+            cout << " o tamanho do vetores eh diferente de 3" << endl;
+        }
+        REAL x1 = v1[0], y1 = v1[1], z1 = v1[2];
+        REAL x2 = v2[0], y2 = v2[1], z2 = v2[2];
+        result.Resize(v1.NElements());
+        result[0] = y1 * z2 - z1 * y2;
+        result[1] = z1 * x2 - x1 * z2;
+        result[2] = x1 * y2 - y1 * x2;
+    }
+
+    void TPZGeoQuad::ComputeNormal(TPZVec<REAL> &p1, TPZVec<REAL> &p2, TPZVec<REAL> &p3, TPZVec<REAL> &result) {
+        TPZVec<REAL> v1(3);
+        TPZVec<REAL> v2(3);
+        TPZVec<REAL> normal(3);
+        v1[0] = p1[0] - p2[0];
+        v1[1] = p1[1] - p2[1];
+        v1[2] = p1[2] - p2[2];
+        v2[0] = p2[0] - p3[0];
+        v2[1] = p2[1] - p3[1];
+        v2[2] = p2[2] - p3[2];
+        VectorialProduct(v1, v2, normal);
+        VectorialProduct(v1, normal, result);
+    }
+
+
+    TPZGeoEl *TPZGeoQuad::CreateBCGeoEl(TPZGeoEl *orig, int side, int bc) {
+        if (side == 8) {//8
+            TPZManVector<int64_t> nodes(4);
+            int i;
+            for (i = 0; i < 4; i++) {
+                nodes[i] = orig->SideNodeIndex(side, i);
+            }
+            int64_t index;
+            TPZGeoEl *gel = orig->CreateGeoElement(EQuadrilateral, nodes, bc, index);
+            int iside;
+            for (iside = 0; iside < 8; iside++) {
+                TPZGeoElSide(gel, iside).SetConnectivity(
+                        TPZGeoElSide(orig, pztopology::TPZQuadrilateral::ContainedSideLocId(side, iside)));
+            }
+            TPZGeoElSide(gel, 8).SetConnectivity(TPZGeoElSide(orig, side));
+            return gel;
+        } else if (side > -1 && side < 4) {//side = 0,1,2,3
+            TPZManVector<int64_t> nodeindexes(1);
+            nodeindexes[0] = orig->SideNodeIndex(side, 0);
+            int64_t index;
+            TPZGeoEl *gel = orig->CreateGeoElement(EPoint, nodeindexes, bc, index);
+            TPZGeoElSide(gel, 0).SetConnectivity(TPZGeoElSide(orig, side));
+            return gel;
+        } else if (side > 3 && side < 8) {
+            TPZManVector<int64_t> nodes(2);
+            nodes[0] = orig->SideNodeIndex(side, 0);
+            nodes[1] = orig->SideNodeIndex(side, 1);
+            int64_t index;
+            TPZGeoEl *gel = orig->CreateGeoElement(EOned, nodes, bc, index);
+            TPZGeoElSide(gel, 0).SetConnectivity(
+                    TPZGeoElSide(orig, pztopology::TPZQuadrilateral::ContainedSideLocId(side, 0)));
+            TPZGeoElSide(gel, 1).SetConnectivity(
+                    TPZGeoElSide(orig, pztopology::TPZQuadrilateral::ContainedSideLocId(side, 1)));
+            TPZGeoElSide(gel, 2).SetConnectivity(TPZGeoElSide(orig, side));
+            return gel;
+        } else
+            PZError << "TPZGeoQuad::CreateBCCompEl has no bc.\n";
+        return 0;
+    }
+
+    void TPZGeoQuad::InsertExampleElement(TPZGeoMesh &gmesh, int matid, TPZVec<REAL> &lowercorner, TPZVec<REAL> &size) {
+        TPZManVector<int64_t, 4> nodeindexes(4);
+        TPZManVector<REAL, 3> co(lowercorner);
+        for (int i = 0; i < 3; i++) {
+            co[i] += 0.2 * size[i];
+        }
+
         nodeindexes[0] = gmesh.NodeVec().AllocateNewElement();
         gmesh.NodeVec()[nodeindexes[0]].Initialize(co, gmesh);
-        co[0] += 0.6*size[0];
+        co[0] += 0.6 * size[0];
         nodeindexes[1] = gmesh.NodeVec().AllocateNewElement();
         gmesh.NodeVec()[nodeindexes[1]].Initialize(co, gmesh);
-        co[1] += 0.6*size[0];
-        co[0] += 0.1*size[0];
-        co[2] += 0.3*size[0];
+        co[1] += 0.6 * size[0];
+        co[0] += 0.1 * size[0];
+        co[2] += 0.3 * size[0];
         nodeindexes[2] = gmesh.NodeVec().AllocateNewElement();
         gmesh.NodeVec()[nodeindexes[2]].Initialize(co, gmesh);
-        for (int i=0; i<3; i++) co[i] = lowercorner[i]+0.2*size[i];
-        co[1] += 0.4*size[1];
-        co[2] -= 0.2*size[2];
+        for (int i = 0; i < 3; i++) co[i] = lowercorner[i] + 0.2 * size[i];
+        co[1] += 0.4 * size[1];
+        co[2] -= 0.2 * size[2];
         nodeindexes[3] = gmesh.NodeVec().AllocateNewElement();
         gmesh.NodeVec()[nodeindexes[3]].Initialize(co, gmesh);
         int64_t index;
         CreateGeoElement(gmesh, EQuadrilateral, nodeindexes, matid, index);
     }
 
-    
-	TPZGeoEl *TPZGeoQuad::CreateGeoElement(TPZGeoMesh &mesh, MElementType type,
-										   TPZVec<int64_t>& nodeindexes,
-										   int matid,
-										   int64_t& index)
-	{
-		return CreateGeoElementPattern(mesh,type,nodeindexes,matid,index);
-	}
-        
-        int TPZGeoQuad::ClassId() const{
-            return Hash("TPZGeoQuad") ^ TPZNodeRep<4, pztopology::TPZQuadrilateral>::ClassId() << 1;
+
+    TPZGeoEl *TPZGeoQuad::CreateGeoElement(TPZGeoMesh &mesh, MElementType type,
+                                           TPZVec<int64_t> &nodeindexes,
+                                           int matid,
+                                           int64_t &index) {
+        return CreateGeoElementPattern(mesh, type, nodeindexes, matid, index);
     }
 
-    void TPZGeoQuad::Read(TPZStream& buf, void* context) {
+    int TPZGeoQuad::ClassId() const {
+        return Hash("TPZGeoQuad") ^ TPZNodeRep<4, pztopology::TPZQuadrilateral>::ClassId() << 1;
+    }
+
+    void TPZGeoQuad::Read(TPZStream &buf, void *context) {
         TPZNodeRep<4, pztopology::TPZQuadrilateral>::Read(buf, context);
     }
 
-    void TPZGeoQuad::Write(TPZStream& buf, int withclassid) const {
+    void TPZGeoQuad::Write(TPZStream &buf, int withclassid) const {
         TPZNodeRep<4, pztopology::TPZQuadrilateral>::Write(buf, withclassid);
     }
 
-    template void TPZGeoQuad::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
-
 };
-
-#ifdef _AUTODIFF
-template<class T=REAL>
-class Fad;
-
-template void pzgeom::TPZGeoQuad::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
-        TPZVec<Fad<REAL>> &);
-#endif

--- a/Geom/pzgeoquad.h
+++ b/Geom/pzgeoquad.h
@@ -67,22 +67,6 @@ namespace pzgeom {
         
 		/** @brief Returns the type name of the element */
 		static std::string TypeName() { return "Quad";}
-        
-        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
-        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
-            TShape(loc, phi, dphi);
-        }
-        /**
-         * This method calculates the influence (a.k.a. the blend function) of the side side regarding an
-         * interior point qsi. It is used by the TPZGeoBlend class.
-         * @param side the index of the side
-         * @param xi coordinates of the interior point
-         * @param correctionFactor influence (0 <= correctionFactor <= 1)
-         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
-         */
-        template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
-                                      TPZVec<T> &corrFactorDxi);
         /* @brief Compute x mapping from local parametric coordinates */
         template<class T>
         void X(const TPZGeoEl &gel,TPZVec<T> &loc,TPZVec<T> &x) const
@@ -119,10 +103,6 @@ namespace pzgeom {
         /** @brief Compute gradient of x mapping from element nodes and local parametric coordinates */
         template<class T>
         static void GradX(const TPZFMatrix<REAL> &nodes,TPZVec<T> &loc, TPZFMatrix<T> &gradx);
-        
-        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
-        template<class T>
-        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
         
 		
         /**
@@ -168,30 +148,7 @@ namespace pzgeom {
                 void Read(TPZStream &buf, void *context) override;
                 void Write(TPZStream &buf, int withclassid) const override;
 	};
-    
-    template<class T>
-    inline void TPZGeoQuad::TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi) {
-        T qsi = loc[0], eta = loc[1];
-        
-        phi(0,0) = 0.25*(1.-qsi)*(1.-eta);
-        phi(1,0) = 0.25*(1.+qsi)*(1.-eta);
-        phi(2,0) = 0.25*(1.+qsi)*(1.+eta);
-        phi(3,0) = 0.25*(1.-qsi)*(1.+eta);
-        
-        dphi(0,0) = 0.25*(eta-1.);
-        dphi(1,0) = 0.25*(qsi-1.);
-        
-        dphi(0,1) = 0.25*(1.-eta);
-        dphi(1,1) =-0.25*(1.+qsi);
-        
-        dphi(0,2) = 0.25*(1.+eta);
-        dphi(1,2) = 0.25*(1.+qsi);
-        
-        dphi(0,3) =-0.25*(1.+eta);
-        dphi(1,3) = 0.25*(1.-qsi);
-        
-        
-    }
+
     
     template<class T>
     inline void TPZGeoQuad::X(const TPZFMatrix<REAL> &nodes,TPZVec<T> &loc,TPZVec<T> &x){

--- a/Geom/pzgeotetrahedra.cpp
+++ b/Geom/pzgeotetrahedra.cpp
@@ -20,265 +20,170 @@ static LoggerPtr logger(Logger::getLogger("pz.geom.pzgeotetrahedra"));
 #endif
 
 namespace pzgeom {
-	
-	const double tol = pzgeom_TPZNodeRep_tol;
+
+    const double tol = pzgeom_TPZNodeRep_tol;
 
 
-    template<class T>
-    void TPZGeoTetrahedra::CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
-                                             TPZVec<T> &corrFactorDxi){
-        #ifdef PZDEBUG
-        std::ostringstream sout;
-        if(side < NNodes || side >= NSides){
-            sout<<"The side\t"<<side<<"is invalid. Aborting..."<<std::endl;
 
-            PZError<<std::endl<<sout.str()<<std::endl;
-            DebugStop();
+    TPZGeoEl *TPZGeoTetrahedra::CreateBCGeoEl(TPZGeoEl *orig, int side, int bc) {
+        if (side < 0 || side > 14) {
+            cout << "TPZGeoTetrahedra::CreateBCCompEl with bad side = " << side << "not implemented\n";
+            return 0;
         }
 
-        if(!IsInParametricDomain(xi,tol)){
-            sout<<"The method CalcSideInfluence expects the point xi to correspond to coordinates of a point";
-            sout<<" inside the parametric domain. Aborting...";
-            PZError<<std::endl<<sout.str()<<std::endl;
-            #ifdef LOG4CXX
-            LOGPZ_FATAL(logger,sout.str().c_str());
-            #endif
-            DebugStop();
+        if (side == 14) {
+            cout << "TPZGeoTetrahedra::CreateBCCompEl with side = 14 not implemented\n";
+            return 0;
         }
-        #endif
-        TPZFNMatrix<4,T> phi(NNodes,1);
-        TPZFNMatrix<8,T> dphi(Dimension,NNodes);
-        TPZGeoTetrahedra::TShape(xi,phi,dphi);
-        corrFactorDxi.Resize(TPZGeoTetrahedra::Dimension,(T)0);
-        correctionFactor = 0;
-        for(int i = 0; i < TPZGeoTetrahedra::NSideNodes(side);i++){
-            const int currentNode = TPZGeoTetrahedra::SideNodeLocId(side, i);
-            correctionFactor += phi(currentNode,0);
-            corrFactorDxi[0] +=  dphi(0,currentNode);
-            corrFactorDxi[1] +=  dphi(1,currentNode);
-            corrFactorDxi[2] +=  dphi(2,currentNode);
-        }
-        switch(side){
-            case 0:
-            case 1:
-            case 2:
-            case 3:
-                corrFactorDxi[0] = 0;
-                corrFactorDxi[1] = 0;
-                corrFactorDxi[2] = 0;
-                correctionFactor = 0;
-                return;
-            case  4:
-            case  5:
-            case  6:
-            case  7:
-            case  8:
-            case  9:
-                corrFactorDxi[0] *=  2 * correctionFactor;
-                corrFactorDxi[1] *=  2 * correctionFactor;
-                corrFactorDxi[2] *=  2 * correctionFactor;
-                correctionFactor *= correctionFactor;
-                return;
-            case 10:
-            case 11:
-            case 12:
-            case 13:
-                corrFactorDxi[0] *=  3 * correctionFactor * correctionFactor;
-                corrFactorDxi[1] *=  3 * correctionFactor * correctionFactor;
-                corrFactorDxi[2] *=  3 * correctionFactor * correctionFactor;
-                correctionFactor *= correctionFactor * correctionFactor;
-                return;
-            case 14:
-                corrFactorDxi[0] = 0;
-                corrFactorDxi[1] = 0;
-                corrFactorDxi[2] = 0;
-                correctionFactor = 1;
-                return;
+        if (side < 4) {
+            TPZManVector<int64_t> nodeindexes(1);
+            //		TPZGeoElPoint *gel;
+            nodeindexes[0] = orig->NodeIndex(side);
+            int64_t index;
+            TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EPoint, nodeindexes, bc, index);
+            //		gel = new TPZGeoElPoint(nodeindexes,bc,*orig->Mesh());
+            TPZGeoElSide(gel, 0).SetConnectivity(TPZGeoElSide(orig, side));
+            return gel;
+        } else if (side > 3 && side < 10) {//side =4 a 9 : lados
+            TPZManVector<int64_t> nodes(2);
+            nodes[0] = orig->SideNodeIndex(side, 0);
+            nodes[1] = orig->SideNodeIndex(side, 1);
+            int64_t index;
+            TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EOned, nodes, bc, index);
+            //		TPZGeoEl1d *gel = new TPZGeoEl1d(nodes,bc,*orig->Mesh());
+            TPZGeoElSide(gel, 0).SetConnectivity(TPZGeoElSide(orig, TPZShapeTetra::ContainedSideLocId(side, 0)));
+            TPZGeoElSide(gel, 1).SetConnectivity(TPZGeoElSide(orig, TPZShapeTetra::ContainedSideLocId(side, 1)));
+            TPZGeoElSide(gel, 2).SetConnectivity(TPZGeoElSide(orig, side));
+            return gel;
+        } else if (side > 9) {//side = 10 a 13 : faces
+            TPZManVector<int64_t> nodes(3);
+            int in;
+            for (in = 0; in < 3; in++) {
+                nodes[in] = orig->SideNodeIndex(side, in);
+            }
+            int64_t index;
+            TPZGeoEl *gel = orig->CreateGeoElement(ETriangle, nodes, bc, index);
+            //		TPZGeoElT2d *gel = new TPZGeoElT2d(nodes,bc,*orig->Mesh());
+            for (in = 0; in < 6; in++) {
+                TPZGeoElSide(gel, in).SetConnectivity(TPZGeoElSide(orig, TPZShapeTetra::ContainedSideLocId(side, in)));
+            }
+            TPZGeoElSide(gel, 6).SetConnectivity(TPZGeoElSide(orig, side));
+            return gel;
+        } else
+            PZError << "TPZGeoTetrahedra::CreateBCGeoEl. Side = " << side << endl;
+        return 0;
+    }
+
+    void TPZGeoTetrahedra::FixSingularity(int side, TPZVec<REAL> &OriginalPoint, TPZVec<REAL> &ChangedPoint) {
+        ChangedPoint.Resize(OriginalPoint.NElements(), 0.);
+        ChangedPoint = OriginalPoint;
+
+        switch (side) {
+            case 4: {
+                if (OriginalPoint[1] == 1. || OriginalPoint[2] == 1.) {
+                    REAL den = 0.25 + OriginalPoint[1] * OriginalPoint[1] + OriginalPoint[2] * OriginalPoint[2];
+                    ChangedPoint[0] = (0.5 * tol) / sqrt(den);
+                    ChangedPoint[1] = OriginalPoint[1] - (OriginalPoint[1] * tol) / sqrt(den);
+                    ChangedPoint[2] = OriginalPoint[2] - (OriginalPoint[2] * tol) / sqrt(den);
+                }
+                break;
+            }
+
+            case 5: {
+                if (OriginalPoint[0] + OriginalPoint[1] == 0.) {
+                    REAL den = 0.5 + OriginalPoint[2] * OriginalPoint[2];
+                    ChangedPoint[0] = (0.5 * tol) / sqrt(den);
+                    ChangedPoint[1] = (0.5 * tol) / sqrt(den);
+                    ChangedPoint[2] = OriginalPoint[2] - (OriginalPoint[2] * tol) / sqrt(den);
+                }
+                break;
+            }
+
+            case 6: {
+                if (OriginalPoint[0] == 1. || OriginalPoint[2] == 1.) {
+                    REAL den = 0.25 + OriginalPoint[0] * OriginalPoint[0] + OriginalPoint[2] * OriginalPoint[2];
+                    ChangedPoint[0] = OriginalPoint[0] - (OriginalPoint[0] * tol) / sqrt(den);
+                    ChangedPoint[1] = (0.5 * tol) / sqrt(den);
+                    ChangedPoint[2] = OriginalPoint[2] - (OriginalPoint[2] * tol) / sqrt(den);
+                }
+                break;
+            }
+
+            case 7: {
+                if (OriginalPoint[0] == 1. || OriginalPoint[1] == 1.) {
+                    REAL den = 0.25 + OriginalPoint[0] * OriginalPoint[0] + OriginalPoint[1] * OriginalPoint[1];
+                    ChangedPoint[0] = OriginalPoint[0] - (OriginalPoint[0] * tol) / sqrt(den);
+                    ChangedPoint[1] = OriginalPoint[1] - (OriginalPoint[1] * tol) / sqrt(den);
+                    ChangedPoint[2] = (0.5 * tol) / sqrt(den);
+                }
+                break;
+            }
+
+            case 8: {
+                if (OriginalPoint[0] + OriginalPoint[2] == 0.) {
+                    REAL den = 0.5 + OriginalPoint[1] * OriginalPoint[1];
+                    ChangedPoint[0] = (0.5 * tol) / sqrt(den);
+                    ChangedPoint[1] = OriginalPoint[1] - (OriginalPoint[1] * tol) / sqrt(den);
+                    ChangedPoint[2] = (0.5 * tol) / sqrt(den);
+                }
+                break;
+            }
+
+            case 9: {
+                if (OriginalPoint[1] + OriginalPoint[2] == 0.) {
+                    REAL den = 0.5 + OriginalPoint[0] * OriginalPoint[0];
+                    ChangedPoint[0] = OriginalPoint[0] - (OriginalPoint[0] * tol) / sqrt(den);
+                    ChangedPoint[1] = (0.5 * tol) / sqrt(den);
+                    ChangedPoint[2] = (0.5 * tol) / sqrt(den);
+                }
+                break;
+            }
+
+            case 10: {
+                if (OriginalPoint[2] == 1.) {
+                    ChangedPoint[0] = tol / sqrt(11.);
+                    ChangedPoint[1] = tol / sqrt(11.);
+                    ChangedPoint[2] = 1. - (3. * tol) / sqrt(11.);
+                }
+                break;
+            }
+
+            case 11: {
+                if (OriginalPoint[1] == 1.) {
+                    ChangedPoint[0] = tol / sqrt(11.);
+                    ChangedPoint[1] = 1. - (3. * tol) / sqrt(11.);
+                    ChangedPoint[2] = tol / sqrt(11.);
+                }
+                break;
+            }
+
+            case 12: {
+                if (OriginalPoint[0] + OriginalPoint[1] + OriginalPoint[2] == 0.) {
+                    ChangedPoint[0] = tol;
+                    ChangedPoint[1] = tol;
+                    ChangedPoint[2] = tol;
+                }
+                break;
+            }
+
+            case 13: {
+                if (OriginalPoint[0] == 1.) {
+                    ChangedPoint[0] = 1. - (3. * tol) / sqrt(11.);
+                    ChangedPoint[1] = tol / sqrt(11.);
+                    ChangedPoint[2] = tol / sqrt(11.);
+                }
+                break;
+            }
         }
     }
 
-	TPZGeoEl *TPZGeoTetrahedra::CreateBCGeoEl(TPZGeoEl *orig,int side,int bc) {
-		if(side<0 || side>14){
-			cout << "TPZGeoTetrahedra::CreateBCCompEl with bad side = " << side << "not implemented\n";	
-			return 0;
-		}
-		
-		if(side==14) {
-			cout << "TPZGeoTetrahedra::CreateBCCompEl with side = 14 not implemented\n";
-			return 0;
-		}
-		if(side<4) {
-			TPZManVector<int64_t> nodeindexes(1);
-			//		TPZGeoElPoint *gel;
-			nodeindexes[0] = orig->NodeIndex(side);
-			int64_t index;
-			TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EPoint,nodeindexes,bc,index);
-			//		gel = new TPZGeoElPoint(nodeindexes,bc,*orig->Mesh());
-			TPZGeoElSide(gel,0).SetConnectivity(TPZGeoElSide(orig,side));
-			return gel;
-		} else if (side > 3 && side < 10) {//side =4 a 9 : lados
-			TPZManVector<int64_t> nodes(2);
-			nodes[0] = orig->SideNodeIndex(side,0);
-			nodes[1] = orig->SideNodeIndex(side,1);
-			int64_t index;
-			TPZGeoEl *gel = orig->Mesh()->CreateGeoElement(EOned,nodes,bc,index);
-			//		TPZGeoEl1d *gel = new TPZGeoEl1d(nodes,bc,*orig->Mesh());
-			TPZGeoElSide(gel,0).SetConnectivity(TPZGeoElSide(orig,TPZShapeTetra::ContainedSideLocId(side,0)));
-			TPZGeoElSide(gel,1).SetConnectivity(TPZGeoElSide(orig,TPZShapeTetra::ContainedSideLocId(side,1)));
-			TPZGeoElSide(gel,2).SetConnectivity(TPZGeoElSide(orig,side));
-			return gel;
-		} else if (side > 9) {//side = 10 a 13 : faces
-			TPZManVector<int64_t> nodes(3);
-			int in;
-			for (in=0;in<3;in++){
-				nodes[in] = orig->SideNodeIndex(side,in);
-			}
-			int64_t index;
-			TPZGeoEl *gel = orig->CreateGeoElement(ETriangle,nodes,bc,index);
-			//		TPZGeoElT2d *gel = new TPZGeoElT2d(nodes,bc,*orig->Mesh());
-			for (in=0;in<6;in++){
-				TPZGeoElSide(gel,in).SetConnectivity(TPZGeoElSide(orig,TPZShapeTetra::ContainedSideLocId(side,in)));
-			}
-			TPZGeoElSide(gel,6).SetConnectivity(TPZGeoElSide(orig,side));
-			return gel;
-		} 
-		else PZError << "TPZGeoTetrahedra::CreateBCGeoEl. Side = " << side << endl;
-		return 0;
-	}
-	
-	void TPZGeoTetrahedra::FixSingularity(int side, TPZVec<REAL>& OriginalPoint, TPZVec<REAL>& ChangedPoint)
-	{
-		ChangedPoint.Resize(OriginalPoint.NElements(),0.);
-		ChangedPoint = OriginalPoint;
-		
-		switch(side)
-		{
-			case 4:
-			{
-				if(OriginalPoint[1] == 1. || OriginalPoint[2] == 1.)
-				{
-					REAL den = 0.25 + OriginalPoint[1]*OriginalPoint[1] + OriginalPoint[2]*OriginalPoint[2];
-					ChangedPoint[0] = (0.5*tol)/sqrt(den);
-					ChangedPoint[1] = OriginalPoint[1] - (OriginalPoint[1]*tol) / sqrt(den);
-					ChangedPoint[2] = OriginalPoint[2] - (OriginalPoint[2]*tol)/sqrt(den);
-				}
-				break;
-			}
-				
-			case 5:
-			{
-				if(OriginalPoint[0] + OriginalPoint[1] == 0.)
-				{
-					REAL den = 0.5 + OriginalPoint[2]*OriginalPoint[2];
-					ChangedPoint[0] = (0.5*tol)/sqrt(den);
-					ChangedPoint[1] = (0.5*tol)/sqrt(den);
-					ChangedPoint[2] = OriginalPoint[2] - (OriginalPoint[2]*tol)/sqrt(den);
-				}
-				break;
-			}
-				
-			case 6:
-			{
-				if(OriginalPoint[0] == 1. || OriginalPoint[2] == 1.)
-				{
-					REAL den = 0.25 + OriginalPoint[0]*OriginalPoint[0] + OriginalPoint[2]*OriginalPoint[2];
-					ChangedPoint[0] = OriginalPoint[0] - (OriginalPoint[0]*tol)/sqrt(den);
-					ChangedPoint[1] = (0.5*tol)/sqrt(den);
-					ChangedPoint[2] = OriginalPoint[2] - (OriginalPoint[2]*tol)/sqrt(den);
-				}
-				break;
-			}
-				
-			case 7:
-			{
-				if(OriginalPoint[0]== 1. || OriginalPoint[1] == 1.)
-				{
-					REAL den = 0.25 + OriginalPoint[0]*OriginalPoint[0] + OriginalPoint[1]*OriginalPoint[1];
-					ChangedPoint[0] = OriginalPoint[0] - (OriginalPoint[0]*tol)/sqrt(den);
-					ChangedPoint[1] = OriginalPoint[1] - (OriginalPoint[1]*tol)/sqrt(den);
-					ChangedPoint[2] = (0.5*tol)/sqrt(den);
-				}
-				break;
-			}
-				
-			case 8:
-			{
-				if(OriginalPoint[0] + OriginalPoint[2] == 0.)
-				{
-					REAL den = 0.5 + OriginalPoint[1]*OriginalPoint[1];
-					ChangedPoint[0] = (0.5*tol)/sqrt(den);
-					ChangedPoint[1] = OriginalPoint[1] - (OriginalPoint[1]*tol)/sqrt(den);
-					ChangedPoint[2] = (0.5*tol)/sqrt(den);
-				}
-				break;
-			}
-				
-			case 9:
-			{
-				if(OriginalPoint[1] + OriginalPoint[2] == 0.)
-				{
-					REAL den = 0.5 + OriginalPoint[0]*OriginalPoint[0];
-					ChangedPoint[0] = OriginalPoint[0] - (OriginalPoint[0]*tol)/sqrt(den);
-					ChangedPoint[1] = (0.5*tol)/sqrt(den);
-					ChangedPoint[2] = (0.5*tol)/sqrt(den);
-				}
-				break;
-			}
-				
-			case 10:
-			{
-				if(OriginalPoint[2] == 1.)
-				{
-					ChangedPoint[0] = tol/sqrt(11.);
-					ChangedPoint[1] = tol/sqrt(11.);
-					ChangedPoint[2] = 1. - (3.*tol)/sqrt(11.);
-				}
-				break;
-			}
-				
-			case 11:
-			{
-				if(OriginalPoint[1] == 1.)
-				{
-					ChangedPoint[0] = tol/sqrt(11.);
-					ChangedPoint[1] = 1. - (3.*tol)/sqrt(11.);
-					ChangedPoint[2] = tol/sqrt(11.);
-				}
-				break;
-			}
-				
-			case 12:
-			{
-				if(OriginalPoint[0] + OriginalPoint[1] + OriginalPoint[2] == 0.)
-				{
-					ChangedPoint[0] = tol;
-					ChangedPoint[1] = tol;
-					ChangedPoint[2] = tol;
-				}
-				break;
-			}
-				
-			case 13:
-			{
-				if(OriginalPoint[0] == 1.)
-				{
-					ChangedPoint[0] = 1. - (3.*tol)/sqrt(11.);
-					ChangedPoint[1] = tol/sqrt(11.);
-					ChangedPoint[2] = tol/sqrt(11.);
-				}
-				break;
-			}
-		}
-	}
-	
-	/** Creates a geometric element according to the type of the father element */
-	TPZGeoEl *TPZGeoTetrahedra::CreateGeoElement(TPZGeoMesh &mesh, MElementType type,
-												 TPZVec<int64_t>& nodeindexes,
-												 int matid,
-												 int64_t& index)
-    {
-		return CreateGeoElementPattern(mesh,type,nodeindexes,matid,index);
-	}
+    /** Creates a geometric element according to the type of the father element */
+    TPZGeoEl *TPZGeoTetrahedra::CreateGeoElement(TPZGeoMesh &mesh, MElementType type,
+                                                 TPZVec<int64_t> &nodeindexes,
+                                                 int matid,
+                                                 int64_t &index) {
+        return CreateGeoElementPattern(mesh, type, nodeindexes, matid, index);
+    }
 
     /// create an example element based on the topology
     /* @param gmesh mesh in which the element should be inserted
@@ -286,19 +191,19 @@ namespace pzgeom {
      @param lowercorner (in/out) on input lower corner o the cube where the element should be created, on exit position of the next cube
      @param size (in) size of space where the element should be created
      */
-    void TPZGeoTetrahedra::InsertExampleElement(TPZGeoMesh &gmesh, int matid, TPZVec<REAL> &lowercorner, TPZVec<REAL> &size)
-    {
-        TPZManVector<REAL,3> co(3),shift(3),scale(3);
-        TPZManVector<int64_t,3> nodeindexes(8);
-        for (int i=0; i<3; i++) {
-            scale[i] = size[i]/3.;
-            shift[i] = 1./2.+lowercorner[i];
+    void TPZGeoTetrahedra::InsertExampleElement(TPZGeoMesh &gmesh, int matid, TPZVec<REAL> &lowercorner,
+                                                TPZVec<REAL> &size) {
+        TPZManVector<REAL, 3> co(3), shift(3), scale(3);
+        TPZManVector<int64_t, 3> nodeindexes(8);
+        for (int i = 0; i < 3; i++) {
+            scale[i] = size[i] / 3.;
+            shift[i] = 1. / 2. + lowercorner[i];
         }
-        
-        for (int i=0; i<NCornerNodes; i++) {
+
+        for (int i = 0; i < NCornerNodes; i++) {
             ParametricDomainNodeCoord(i, co);
-            for (int j=0; j<3; j++) {
-                co[j] = shift[j]+scale[j]*co[j]+(rand()*0.2/RAND_MAX)-0.1;
+            for (int j = 0; j < 3; j++) {
+                co[j] = shift[j] + scale[j] * co[j] + (rand() * 0.2 / RAND_MAX) - 0.1;
             }
             nodeindexes[i] = gmesh.NodeVec().AllocateNewElement();
             gmesh.NodeVec()[nodeindexes[i]].Initialize(co, gmesh);
@@ -306,28 +211,18 @@ namespace pzgeom {
         int64_t index;
         CreateGeoElement(gmesh, ETetraedro, nodeindexes, matid, index);
     }
-    
-    int TPZGeoTetrahedra::ClassId() const{
-        return Hash("TPZGeoTetrahedra") ^ TPZNodeRep<4,pztopology::TPZTetrahedron>::ClassId() << 1;
+
+    int TPZGeoTetrahedra::ClassId() const {
+        return Hash("TPZGeoTetrahedra") ^ TPZNodeRep<4, pztopology::TPZTetrahedron>::ClassId() << 1;
     }
 
-    void TPZGeoTetrahedra::Read(TPZStream& buf, void* context) {
-        TPZNodeRep<4,pztopology::TPZTetrahedron>::Read(buf,context);
+    void TPZGeoTetrahedra::Read(TPZStream &buf, void *context) {
+        TPZNodeRep<4, pztopology::TPZTetrahedron>::Read(buf, context);
     }
 
-    void TPZGeoTetrahedra::Write(TPZStream& buf, int withclassid) const {
-        TPZNodeRep<4,pztopology::TPZTetrahedron>::Write(buf,withclassid);
+    void TPZGeoTetrahedra::Write(TPZStream &buf, int withclassid) const {
+        TPZNodeRep<4, pztopology::TPZTetrahedron>::Write(buf, withclassid);
     }
 
-
-    template void TPZGeoTetrahedra::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
 
 };
-
-#ifdef _AUTODIFF
-template<class T=REAL>
-class Fad;
-
-template void pzgeom::TPZGeoTetrahedra::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &,
-        Fad<REAL> &, TPZVec<Fad<REAL>> &);
-#endif

--- a/Geom/pzgeotetrahedra.h
+++ b/Geom/pzgeotetrahedra.h
@@ -72,25 +72,9 @@ namespace pzgeom {
             return true;
         }
 
-        /**
-         * This method calculates the influence (a.k.a. the blend function) of the side side regarding an
-         * interior point qsi. It is used by the TPZGeoBlend class.
-         * @param side the index of the side
-         * @param xi coordinates of the interior point
-         * @param correctionFactor influence (0 <= correctionFactor <= 1)
-         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
-         */
-        template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
-                                      TPZVec<T> &corrFactorDxi);
-
 		/** @brief Returns the type name of the element */
 		static std::string TypeName() { return "Tetrahedron";}
-		
-        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
-        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
-            TShape(loc, phi, dphi);
-        }
+
 		
         /* @brief Compute x mapping from local parametric coordinates */
         template<class T>
@@ -117,10 +101,6 @@ namespace pzgeom {
         /** @brief Compute gradient of x mapping from element nodes and local parametric coordinates */
         template<class T>
         static void GradX(const TPZFMatrix<REAL> &nodes,TPZVec<T> &loc, TPZFMatrix<T> &gradx);
-        
-        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
-        template<class T>
-        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
         
 		/**
 		 * @brief Method which creates a geometric boundary condition 
@@ -154,29 +134,7 @@ namespace pzgeom {
 										  int64_t& index);
 	};
     
-    template<class T>
-    inline void TPZGeoTetrahedra::TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi) {
-        T qsi = loc[0], eta = loc[1] , zeta  = loc[2];
-        
-        phi(0,0)  = 1.0-qsi-eta-zeta;
-        phi(1,0)  = qsi;
-        phi(2,0)  = eta;
-        phi(3,0)  = zeta;
-        
-        dphi(0,0) = -1.0;
-        dphi(1,0) = -1.0;
-        dphi(2,0) = -1.0;
-        dphi(0,1) =  1.0;
-        dphi(1,1) =  0.0;
-        dphi(2,1) =  0.0;
-        dphi(0,2) =  0.0;
-        dphi(1,2) =  1.0;
-        dphi(2,2) =  0.0;
-        dphi(0,3) =  0.0;
-        dphi(1,3) =  0.0;
-        dphi(2,3) =  1.0;
-        
-    }
+
     
     template<class T>
     inline void TPZGeoTetrahedra::X(const TPZFMatrix<REAL> &nodes,TPZVec<T> &loc,TPZVec<T> &x){

--- a/Geom/pzgeotriangle.cpp
+++ b/Geom/pzgeotriangle.cpp
@@ -25,67 +25,7 @@ using namespace std;
 namespace pzgeom {
 	
 	const REAL tol = pzgeom_TPZNodeRep_tol;
-    template<class T>
-    void TPZGeoTriangle::CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
-            TPZVec<T> &correctionFactorDxi){
-#ifdef PZDEBUG
-        std::ostringstream sout;
-        if(side < NNodes || side >= NSides){
-            sout<<"The side\t"<<side<<"is invalid. Aborting..."<<std::endl;
-            PZError<<std::endl<<sout.str()<<std::endl;
-            DebugStop();
-        }
 
-        if(!pztopology::TPZTriangle::IsInParametricDomain(xi,tol)){
-            sout<<"The method CalcSideInfluence expects the point xi to correspond to coordinates of a point";
-            sout<<" inside the parametric domain. Aborting...";
-            PZError<<std::endl<<sout.str()<<std::endl;
-            #ifdef LOG4CXX
-            LOGPZ_FATAL(logger,sout.str().c_str());
-            #endif
-            DebugStop();
-        }
-#endif
-        TPZFNMatrix<4,T> phi(NNodes,1);
-        TPZFNMatrix<8,T> dphi(Dimension,NNodes);
-        TPZGeoTriangle::TShape(xi,phi,dphi);
-        correctionFactorDxi.Resize(TPZGeoTriangle::Dimension, (T) 0);
-        int i = -1;
-        switch(side){
-            case 0:
-            case 1:
-            case 2:
-                correctionFactor = 0;
-                return;
-            case 3:
-                i = 0;
-                break;
-            case 4:
-                i = 1;
-                break;
-            case 5:
-                i = 2;
-                break;
-            case 6:
-                correctionFactor = 1;
-                return;
-        }
-        correctionFactor = phi(i,0) + phi((i+1)%NNodes,0);
-        correctionFactor *= correctionFactor;
-        correctionFactorDxi[0] = 2 * ( phi(i,0) + phi((i+1)%NNodes,0) ) * ( dphi(0,i) + dphi(0,(i+1)%NNodes) );
-        correctionFactorDxi[1] = 2 * ( phi(i,0) + phi((i+1)%NNodes,0) ) * ( dphi(1,i) + dphi(1,(i+1)%NNodes) );
-
-    }
-
-	void TPZGeoTriangle::Shape(TPZVec<REAL> &param,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi) {
-		REAL qsi = param[0], eta = param[1];
-		phi(0,0) = 1.-qsi-eta;
-		phi(1,0) = qsi;
-		phi(2,0) = eta;
-		dphi(0,0) = dphi(1,0) = -1.;
-		dphi(0,1) = dphi(1,2) =  1.;
-		dphi(1,1) = dphi(0,2) =  0.;
-	}
 	
 	void TPZGeoTriangle::Jacobian(const TPZFMatrix<REAL> & coord, TPZVec<REAL> &param,TPZFMatrix<REAL> &jacobian,TPZFMatrix<REAL> &axes,REAL &detjac,TPZFMatrix<REAL> &jacinv){
 		
@@ -431,14 +371,6 @@ namespace pzgeom {
 
 
 
-    template void TPZGeoTriangle::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
 
 };
 
-#ifdef _AUTODIFF
-template<class T=REAL>
-class Fad;
-
-template void pzgeom::TPZGeoTriangle::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
-        TPZVec<Fad<REAL>> &);
-#endif

--- a/Geom/pzgeotriangle.h
+++ b/Geom/pzgeotriangle.h
@@ -63,17 +63,6 @@ namespace pzgeom {
 		{
 		}
 
-        /**
-         * This method calculates the influence (a.k.a. the blend function) of the side side regarding an
-         * interior point qsi. It is used by the TPZGeoBlend class.
-         * @param side the index of the side
-         * @param xi coordinates of the interior point
-         * @param correctionFactor influence (0 <= correctionFactor <= 1)
-         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
-         */
-         template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
-                TPZVec<T> &corrFactorDxi);
 
         void Jacobian(const TPZFMatrix<REAL> & coord, TPZVec<REAL> &param,TPZFMatrix<REAL> &jacobian,TPZFMatrix<REAL> &axes,REAL &detjac,TPZFMatrix<REAL> &jacinv);
 
@@ -85,8 +74,6 @@ namespace pzgeom {
 		/** @brief Returns the type name of the element */
 		static std::string TypeName() { return "Triangle";}
 
-        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
-        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi);
 
         /* @brief Compute x mapping from local parametric coordinates */
         template<class T>
@@ -127,9 +114,6 @@ namespace pzgeom {
         template<class T>
         static void GradX(const TPZFMatrix<REAL> &nodes,TPZVec<T> &loc, TPZFMatrix<T> &gradx);
 
-        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
-        template<class T>
-        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
 
 //        /** @brief Compute the jacoabina associated to the x mapping from local parametric coordinates  */
 //        static void Jacobian(const TPZFMatrix<REAL> &nodes,TPZVec<REAL> &param,TPZFMatrix<REAL> &jacobian,
@@ -187,16 +171,6 @@ namespace pzgeom {
 
 	};
 
-    template<class T>
-    inline void TPZGeoTriangle::TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi) {
-        T qsi = loc[0], eta = loc[1];
-        phi(0,0) = 1.0-qsi-eta;
-        phi(1,0) = qsi;
-        phi(2,0) = eta;
-        dphi(0,0) = dphi(1,0) = -1.0;
-        dphi(0,1) = dphi(1,2) =  1.0;
-        dphi(1,1) = dphi(0,2) =  0.0;
-    }
 
     template<class T>
     inline void TPZGeoTriangle::GradX(const TPZFMatrix<REAL> &nodes,TPZVec<T> &loc, TPZFMatrix<T> &gradx){

--- a/Geom/pznoderep.h
+++ b/Geom/pznoderep.h
@@ -62,10 +62,10 @@ namespace pzgeom {
         static void GetSideShapeFunction(int side, TPZVec<T> &qsiSide, TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi );
 
 //        template<class T>
-//        static void CalcSideInfluence(const int &side, const TPZVec<T> &qsiInterior, T &sideInfluence,
-//                TPZVec<T> &correctionFactorDxi){
+//        static void BlendFactorForSide(const int &side, const TPZVec<T> &qsiInterior, T &sideInfluence,
+//                TPZVec<T> &blendFactorDxi){
 //            std::ostringstream sout;
-//            sout<<"The method CalcSideInfluence is not implemented for the desired element type."<<std::endl;
+//            sout<<"The method BlendFactorForSide is not implemented for the desired element type."<<std::endl;
 //            sout<<"The method is used in TPZGeoBlend elements. Check their usage. Aborting..."<<std::endl;
 //
 //            PZError<<sout.str()<<std::endl;

--- a/Geom/pznoderep.h
+++ b/Geom/pznoderep.h
@@ -61,16 +61,16 @@ namespace pzgeom {
         template<class T>
         static void GetSideShapeFunction(int side, TPZVec<T> &qsiSide, TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi );
 
-        template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &qsiInterior, T &sideInfluence,
-                TPZVec<T> &correctionFactorDxi){
-            std::ostringstream sout;
-            sout<<"The method CalcSideInfluence is not implemented for the desired element type."<<std::endl;
-            sout<<"The method is used in TPZGeoBlend elements. Check their usage. Aborting..."<<std::endl;
-
-            PZError<<sout.str()<<std::endl;
-            DebugStop();
-        }
+//        template<class T>
+//        static void CalcSideInfluence(const int &side, const TPZVec<T> &qsiInterior, T &sideInfluence,
+//                TPZVec<T> &correctionFactorDxi){
+//            std::ostringstream sout;
+//            sout<<"The method CalcSideInfluence is not implemented for the desired element type."<<std::endl;
+//            sout<<"The method is used in TPZGeoBlend elements. Check their usage. Aborting..."<<std::endl;
+//
+//            PZError<<sout.str()<<std::endl;
+//            DebugStop();
+//        }
 
         virtual void SetNeighbourInfo(int side, TPZGeoElSide &neigh, TPZTransform<> &trans) {
             std::cout << "Element that is NOT TPZGeoBlend trying to Set Neighbour Information on Geometric Mesh!\n";

--- a/Topology/tpzcube.cpp
+++ b/Topology/tpzcube.cpp
@@ -426,9 +426,9 @@ namespace pztopology {
     }
 
     template<class T>
-    void TPZCube::CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+    void TPZCube::BlendFactorForSide(const int &side, const TPZVec<T> &xi, T &blendFactor,
                                        TPZVec<T> &corrFactorDxi){
-        const REAL tol = pztopology::gTolerance;
+        const REAL tol = pztopology::GetTolerance();
         std::ostringstream sout;
         if(side < NCornerNodes || side >= NSides){
             sout<<"The side\t"<<side<<"is invalid. Aborting..."<<std::endl;
@@ -439,7 +439,7 @@ namespace pztopology {
         #ifdef PZDEBUG
 
         if(!IsInParametricDomain(xi,tol)){
-            sout<<"The method CalcSideInfluence expects the point xi to correspond to coordinates of a point";
+            sout<<"The method BlendFactorForSide expects the point xi to correspond to coordinates of a point";
             sout<<" inside the parametric domain. Aborting...";
             PZError<<std::endl<<sout.str()<<std::endl;
             #ifdef LOG4CXX
@@ -453,17 +453,17 @@ namespace pztopology {
             TPZFNMatrix<4,T> phi(NCornerNodes,1);
             TPZFNMatrix<8,T> dphi(Dimension,NCornerNodes);
             TPZCube::TShape(xi,phi,dphi);
-            correctionFactor = 0;
+            blendFactor = 0;
             for(int i = 0; i < TPZCube::NSideNodes(side);i++){
                 const int currentNode = TPZCube::SideNodeLocId(side, i);
-                correctionFactor += phi(currentNode,0);
+                blendFactor += phi(currentNode,0);
                 corrFactorDxi[0] +=  dphi(0,currentNode);
                 corrFactorDxi[1] +=  dphi(1,currentNode);
                 corrFactorDxi[2] +=  dphi(2,currentNode);
             }
 
         }else{
-            correctionFactor = 1;
+            blendFactor = 1;
         }
     }
 
@@ -1574,14 +1574,14 @@ template bool pztopology::TPZCube::MapToSide<REAL>(int side, TPZVec<REAL> &Inter
 
 template void pztopology::TPZCube::TShape<REAL>(const TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi);
 
-template void pztopology::TPZCube::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
+template void pztopology::TPZCube::BlendFactorForSide<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
 #ifdef _AUTODIFF
 template<class T=REAL>
 class Fad;
 
 template bool pztopology::TPZCube::MapToSide<Fad<REAL> >(int side, TPZVec<Fad<REAL> > &InternalPar, TPZVec<Fad<REAL> > &SidePar, TPZFMatrix<Fad<REAL> > &JacToSide);
 
-template void pztopology::TPZCube::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
+template void pztopology::TPZCube::BlendFactorForSide<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
                                                                    TPZVec<Fad<REAL>> &);
 template void pztopology::TPZCube::TShape<Fad<REAL>>(const TPZVec<Fad<REAL>> &loc,TPZFMatrix<Fad<REAL>> &phi,TPZFMatrix<Fad<REAL>> &dphi);
 #endif

--- a/Topology/tpzcube.h
+++ b/Topology/tpzcube.h
@@ -85,7 +85,25 @@ namespace pztopology {
 		static int NContainedSides(int side);
 		/** @brief Returns the local connect number of the connect "c" along side "side" */
 		static int ContainedSideLocId(int side, int c);
-		
+
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
+            TShape(loc, phi, dphi);
+        }
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        template<class T>
+        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
+        /**
+         * This method calculates the influence (a.k.a. the blend function) of the side side regarding an
+         * interior point qsi. It is used by the TPZGeoBlend class.
+         * @param side the index of the side
+         * @param xi coordinates of the interior point
+         * @param correctionFactor influence (0 <= correctionFactor <= 1)
+         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+         */
+        template<class T>
+        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+                                      TPZVec<T> &corrFactorDxi);
 		/** @} */
 
 		/** @name About points at the parametric spaces

--- a/Topology/tpzcube.h
+++ b/Topology/tpzcube.h
@@ -98,11 +98,11 @@ namespace pztopology {
          * interior point qsi. It is used by the TPZGeoBlend class.
          * @param side the index of the side
          * @param xi coordinates of the interior point
-         * @param correctionFactor influence (0 <= correctionFactor <= 1)
-         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+         * @param blendFactor influence (0 <= blendFactor <= 1)
+         * * @param corrFactorDxi derivative of the blendFactor in respect to xi
          */
         template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+        static void BlendFactorForSide(const int &side, const TPZVec<T> &xi, T &blendFactor,
                                       TPZVec<T> &corrFactorDxi);
 		/** @} */
 

--- a/Topology/tpzline.cpp
+++ b/Topology/tpzline.cpp
@@ -75,9 +75,9 @@ namespace pztopology {
     }
 
     template<class T>
-    void TPZLine::CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
-                                        TPZVec<T> &correctionFactorDxi){
-        const REAL tol = pztopology::gTolerance;
+    void TPZLine::BlendFactorForSide(const int &side, const TPZVec<T> &xi, T &blendFactor,
+                                        TPZVec<T> &blendFactorDxi){
+        const REAL tol = pztopology::GetTolerance();
 #ifdef PZDEBUG
         std::ostringstream sout;
         if(side < NCornerNodes || side >= NSides){
@@ -87,7 +87,7 @@ namespace pztopology {
         }
 
         if(!pztopology::TPZLine::IsInParametricDomain(xi,tol)){
-            sout<<"The method CalcSideInfluence expects the point xi to correspond to coordinates of a point";
+            sout<<"The method BlendFactorForSide expects the point xi to correspond to coordinates of a point";
             sout<<" inside the parametric domain. Aborting...";
             PZError<<std::endl<<sout.str()<<std::endl;
             #ifdef LOG4CXX
@@ -99,19 +99,19 @@ namespace pztopology {
         TPZFNMatrix<4,T> phi(NCornerNodes,1);
         TPZFNMatrix<8,T> dphi(Dimension,NCornerNodes);
         TPZLine::TShape(xi,phi,dphi);
-        correctionFactorDxi.Resize(TPZLine::Dimension, (T) 0);
+        blendFactorDxi.Resize(TPZLine::Dimension, (T) 0);
         switch(side){
             case 0:
-                correctionFactor = phi(0,0);
-                correctionFactorDxi[0] = dphi(0,0);
+                blendFactor = phi(0,0);
+                blendFactorDxi[0] = dphi(0,0);
                 break;
             case 1:
-                correctionFactor = phi(1,0);
-                correctionFactorDxi[0] = dphi(0,1);
+                blendFactor = phi(1,0);
+                blendFactorDxi[0] = dphi(0,1);
                 break;
             case 2:
-                correctionFactor = 1;
-                correctionFactorDxi[0] = 0;
+                blendFactor = 1;
+                blendFactorDxi[0] = 0;
                 break;
         }
         return;
@@ -543,14 +543,14 @@ template bool pztopology::TPZLine::MapToSide<REAL>(int side, TPZVec<REAL> &Inter
 
 template void pztopology::TPZLine::TShape<REAL>(const TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi);
 
-template void pztopology::TPZLine::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
+template void pztopology::TPZLine::BlendFactorForSide<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
 #ifdef _AUTODIFF
 template<class T=REAL>
 class Fad;
 
 template bool pztopology::TPZLine::MapToSide<Fad<REAL> >(int side, TPZVec<Fad<REAL> > &InternalPar, TPZVec<Fad<REAL> > &SidePar, TPZFMatrix<Fad<REAL> > &JacToSide);
 
-template void pztopology::TPZLine::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
+template void pztopology::TPZLine::BlendFactorForSide<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
                                                                    TPZVec<Fad<REAL>> &);
 template void pztopology::TPZLine::TShape<Fad<REAL>>(const TPZVec<Fad<REAL>> &loc,TPZFMatrix<Fad<REAL>> &phi,TPZFMatrix<Fad<REAL>> &dphi);
 #endif

--- a/Topology/tpzline.cpp
+++ b/Topology/tpzline.cpp
@@ -77,7 +77,7 @@ namespace pztopology {
     template<class T>
     void TPZLine::CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
                                         TPZVec<T> &correctionFactorDxi){
-
+        const REAL tol = pztopology::gTolerance;
 #ifdef PZDEBUG
         std::ostringstream sout;
         if(side < NCornerNodes || side >= NSides){
@@ -86,7 +86,7 @@ namespace pztopology {
             DebugStop();
         }
 
-        if(!pztopology::TPZLine::IsInParametricDomain(xi,gTolerance)){
+        if(!pztopology::TPZLine::IsInParametricDomain(xi,tol)){
             sout<<"The method CalcSideInfluence expects the point xi to correspond to coordinates of a point";
             sout<<" inside the parametric domain. Aborting...";
             PZError<<std::endl<<sout.str()<<std::endl;

--- a/Topology/tpzline.cpp
+++ b/Topology/tpzline.cpp
@@ -64,9 +64,59 @@ namespace pztopology {
     
     static int bilinearounao [3] =   {0,0,1};
     static int direcaoksioueta [3] = {0,0,0};
-    
 
-    
+    template<class T>
+    inline void TPZLine::TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi) {
+        T x = loc[0];
+        phi(0,0) = (1.0-x)/2.;
+        phi(1,0) = (1.0+x)/2.;
+        dphi(0,0) = -0.5;
+        dphi(0,1) = 0.5;
+    }
+
+    template<class T>
+    void TPZLine::CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+                                        TPZVec<T> &correctionFactorDxi){
+
+#ifdef PZDEBUG
+        std::ostringstream sout;
+        if(side < NCornerNodes || side >= NSides){
+            sout<<"The side\t"<<side<<"is invalid. Aborting..."<<std::endl;
+            PZError<<std::endl<<sout.str()<<std::endl;
+            DebugStop();
+        }
+
+        if(!pztopology::TPZLine::IsInParametricDomain(xi,gTolerance)){
+            sout<<"The method CalcSideInfluence expects the point xi to correspond to coordinates of a point";
+            sout<<" inside the parametric domain. Aborting...";
+            PZError<<std::endl<<sout.str()<<std::endl;
+            #ifdef LOG4CXX
+            LOGPZ_FATAL(logger,sout.str().c_str());
+            #endif
+            DebugStop();
+        }
+#endif
+        TPZFNMatrix<4,T> phi(NCornerNodes,1);
+        TPZFNMatrix<8,T> dphi(Dimension,NCornerNodes);
+        TPZLine::TShape(xi,phi,dphi);
+        correctionFactorDxi.Resize(TPZLine::Dimension, (T) 0);
+        switch(side){
+            case 0:
+                correctionFactor = phi(0,0);
+                correctionFactorDxi[0] = dphi(0,0);
+                break;
+            case 1:
+                correctionFactor = phi(1,0);
+                correctionFactorDxi[0] = dphi(0,1);
+                break;
+            case 2:
+                correctionFactor = 1;
+                correctionFactorDxi[0] = 0;
+                break;
+        }
+        return;
+    }
+
 	int TPZLine::NSideNodes(int side)
 	{
 		return nsidenodes[side];
@@ -489,10 +539,18 @@ namespace pztopology {
     
 }
 
-template
-bool pztopology::TPZLine::MapToSide<REAL>(int side, TPZVec<REAL> &InternalPar, TPZVec<REAL> &SidePar, TPZFMatrix<REAL> &JacToSide);
+template bool pztopology::TPZLine::MapToSide<REAL>(int side, TPZVec<REAL> &InternalPar, TPZVec<REAL> &SidePar, TPZFMatrix<REAL> &JacToSide);
 
+template void pztopology::TPZLine::TShape<REAL>(const TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi);
+
+template void pztopology::TPZLine::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
 #ifdef _AUTODIFF
-template
-bool pztopology::TPZLine::MapToSide<Fad<REAL> >(int side, TPZVec<Fad<REAL> > &InternalPar, TPZVec<Fad<REAL> > &SidePar, TPZFMatrix<Fad<REAL> > &JacToSide);
+template<class T=REAL>
+class Fad;
+
+template bool pztopology::TPZLine::MapToSide<Fad<REAL> >(int side, TPZVec<Fad<REAL> > &InternalPar, TPZVec<Fad<REAL> > &SidePar, TPZFMatrix<Fad<REAL> > &JacToSide);
+
+template void pztopology::TPZLine::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
+                                                                   TPZVec<Fad<REAL>> &);
+template void pztopology::TPZLine::TShape<Fad<REAL>>(const TPZVec<Fad<REAL>> &loc,TPZFMatrix<Fad<REAL>> &phi,TPZFMatrix<Fad<REAL>> &dphi);
 #endif

--- a/Topology/tpzline.h
+++ b/Topology/tpzline.h
@@ -68,11 +68,11 @@ namespace pztopology {
         * interior point qsi. It is used by the TPZGeoBlend class.
         * @param side the index of the side
         * @param xi coordinates of the interior point
-        * @param correctionFactor influence (0 <= correctionFactor <= 1)
-        * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+        * @param blendFactor influence (0 <= blendFactor <= 1)
+        * * @param corrFactorDxi derivative of the blendFactor in respect to xi
         */
         template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+        static void BlendFactorForSide(const int &side, const TPZVec<T> &xi, T &blendFactor,
                                       TPZVec<T> &corrFactorDxi);
 		/** @brief Returns the dimension of the side */
 		static int SideDimension(int side);

--- a/Topology/tpzline.h
+++ b/Topology/tpzline.h
@@ -52,9 +52,28 @@ namespace pztopology {
 		virtual ~TPZLine() {
 		}
 
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
+            TShape(loc, phi, dphi);
+        }
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        template<class T>
+        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
+
 		/** @name About sides of the topological element
 		 * @{ */
 
+        /**
+        * This method calculates the influence (a.k.a. the blend function) of the side side regarding an
+        * interior point qsi. It is used by the TPZGeoBlend class.
+        * @param side the index of the side
+        * @param xi coordinates of the interior point
+        * @param correctionFactor influence (0 <= correctionFactor <= 1)
+        * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+        */
+        template<class T>
+        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+                                      TPZVec<T> &corrFactorDxi);
 		/** @brief Returns the dimension of the side */
 		static int SideDimension(int side);
 

--- a/Topology/tpzpoint.cpp
+++ b/Topology/tpzpoint.cpp
@@ -12,7 +12,23 @@
 #endif
 
 namespace pztopology {
-	
+
+    template<class T>
+    void TPZPoint::TShape(const TPZVec<T> &pt,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi)
+    {
+        phi(0,0) = (T)1.;
+    }
+
+    template<class T>
+    void TPZPoint::CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+                                       TPZVec<T> &corrFactorDxi){
+        std::ostringstream sout;
+        sout<<"This method should not be called for a point element. Aborting..."<<std::endl;
+
+        PZError<<std::endl<<sout.str()<<std::endl;
+        DebugStop();
+    }
+
 	TPZIntPoints *TPZPoint::CreateSideIntegrationRule(int side, int order)
 	{
 		return new IntruleType(order);
@@ -119,10 +135,17 @@ namespace pztopology {
     
 }
 
-template
-bool pztopology::TPZPoint::MapToSide<REAL>(int side, TPZVec<REAL> &InternalPar, TPZVec<REAL> &SidePar, TPZFMatrix<REAL> &JacToSide);
+template bool pztopology::TPZPoint::MapToSide<REAL>(int side, TPZVec<REAL> &InternalPar, TPZVec<REAL> &SidePar, TPZFMatrix<REAL> &JacToSide);
+
+template void pztopology::TPZPoint::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
+
+template void pztopology::TPZPoint::TShape<REAL>(const TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi);
 
 #ifdef _AUTODIFF
-template
-bool pztopology::TPZPoint::MapToSide<Fad<REAL> >(int side, TPZVec<Fad<REAL> > &InternalPar, TPZVec<Fad<REAL> > &SidePar, TPZFMatrix<Fad<REAL> > &JacToSide);
+template bool pztopology::TPZPoint::MapToSide<Fad<REAL> >(int side, TPZVec<Fad<REAL> > &InternalPar, TPZVec<Fad<REAL> > &SidePar, TPZFMatrix<Fad<REAL> > &JacToSide);
+
+template void pztopology::TPZPoint::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
+                                                                   TPZVec<Fad<REAL>> &);
+
+template void pztopology::TPZPoint::TShape<Fad<REAL>>(const TPZVec<Fad<REAL>> &loc,TPZFMatrix<Fad<REAL>> &phi,TPZFMatrix<Fad<REAL>> &dphi);
 #endif

--- a/Topology/tpzpoint.cpp
+++ b/Topology/tpzpoint.cpp
@@ -20,7 +20,7 @@ namespace pztopology {
     }
 
     template<class T>
-    void TPZPoint::CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+    void TPZPoint::BlendFactorForSide(const int &side, const TPZVec<T> &xi, T &blendFactor,
                                        TPZVec<T> &corrFactorDxi){
         std::ostringstream sout;
         sout<<"This method should not be called for a point element. Aborting..."<<std::endl;
@@ -137,14 +137,14 @@ namespace pztopology {
 
 template bool pztopology::TPZPoint::MapToSide<REAL>(int side, TPZVec<REAL> &InternalPar, TPZVec<REAL> &SidePar, TPZFMatrix<REAL> &JacToSide);
 
-template void pztopology::TPZPoint::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
+template void pztopology::TPZPoint::BlendFactorForSide<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
 
 template void pztopology::TPZPoint::TShape<REAL>(const TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi);
 
 #ifdef _AUTODIFF
 template bool pztopology::TPZPoint::MapToSide<Fad<REAL> >(int side, TPZVec<Fad<REAL> > &InternalPar, TPZVec<Fad<REAL> > &SidePar, TPZFMatrix<Fad<REAL> > &JacToSide);
 
-template void pztopology::TPZPoint::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
+template void pztopology::TPZPoint::BlendFactorForSide<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
                                                                    TPZVec<Fad<REAL>> &);
 
 template void pztopology::TPZPoint::TShape<Fad<REAL>>(const TPZVec<Fad<REAL>> &loc,TPZFMatrix<Fad<REAL>> &phi,TPZFMatrix<Fad<REAL>> &dphi);

--- a/Topology/tpzpoint.h
+++ b/Topology/tpzpoint.h
@@ -63,11 +63,11 @@ namespace pztopology {
          * interior point qsi. It is used by the TPZGeoBlend class.
          * @param side the index of the side
          * @param xi coordinates of the interior point
-         * @param correctionFactor influence (0 <= correctionFactor <= 1)
-         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+         * @param blendFactor influence (0 <= blendFactor <= 1)
+         * * @param corrFactorDxi derivative of the blendFactor in respect to xi
          */
         template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+        static void BlendFactorForSide(const int &side, const TPZVec<T> &xi, T &blendFactor,
                                       TPZVec<T> &corrFactorDxi);
 
 		/** @brief Returns the dimension of the side */

--- a/Topology/tpzpoint.h
+++ b/Topology/tpzpoint.h
@@ -48,9 +48,28 @@ namespace pztopology {
 		virtual ~TPZPoint() {
 		}
 
+        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
+            TShape(loc, phi, dphi);
+        }
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        template<class T>
+        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
+
 		/** @name About sides of the topological element
 		 * @{ */
-		
+
+        /**
+         * This method calculates the influence (a.k.a. the blend function) of the side side regarding an
+         * interior point qsi. It is used by the TPZGeoBlend class.
+         * @param side the index of the side
+         * @param xi coordinates of the interior point
+         * @param correctionFactor influence (0 <= correctionFactor <= 1)
+         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+         */
+        template<class T>
+        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+                                      TPZVec<T> &corrFactorDxi);
+
 		/** @brief Returns the dimension of the side */
 		static int SideDimension(int side) {
 			return 0;

--- a/Topology/tpzprism.cpp
+++ b/Topology/tpzprism.cpp
@@ -361,9 +361,9 @@ namespace pztopology {
     }
 
     template<class T>
-    void TPZPrism::CalcSideInfluence(const int &side, const TPZVec<T> &xiVec, T &correctionFactor,
+    void TPZPrism::BlendFactorForSide(const int &side, const TPZVec<T> &xiVec, T &blendFactor,
                                         TPZVec<T> &corrFactorDxi){
-        const REAL tol = pztopology::gTolerance;
+        const REAL tol = pztopology::GetTolerance();
         #ifdef PZDEBUG
         std::ostringstream sout;
         if(side < NCornerNodes || side >= NSides){
@@ -374,7 +374,7 @@ namespace pztopology {
         }
 
         if(!IsInParametricDomain(xiVec,tol)){
-            sout<<"The method CalcSideInfluence expects the point qsi to correspond to coordinates of a point";
+            sout<<"The method BlendFactorForSide expects the point qsi to correspond to coordinates of a point";
             sout<<" inside the parametric domain. Aborting...";
             PZError<<std::endl<<sout.str()<<std::endl;
             #ifdef LOG4CXX
@@ -394,88 +394,88 @@ namespace pztopology {
             case  3:
             case  4:
             case  5:
-                correctionFactor = 0;
+                blendFactor = 0;
                 return;
             case  6:
-                correctionFactor = 0.5*(1.-zeta)*(1.-eta)*(1.-eta);
+                blendFactor = 0.5*(1.-zeta)*(1.-eta)*(1.-eta);
                 corrFactorDxi[0] = 0;
                 corrFactorDxi[1] = -1.*(1 - eta)*(1 - zeta);
                 corrFactorDxi[2] = -0.5*((1 - eta)*(1 - eta));
                 return;
             case  7:
-                correctionFactor = 0.5*(1.-zeta)*(xi+eta)*(xi+eta);
+                blendFactor = 0.5*(1.-zeta)*(xi+eta)*(xi+eta);
                 corrFactorDxi[0] =1.*(eta + xi)*(1 - zeta);
                 corrFactorDxi[1] =1.*(eta + xi)*(1 - zeta);
                 corrFactorDxi[2] =-0.5*((eta + xi)*(eta + xi));
                 return;
             case  8:
-                correctionFactor = 0.5*(1.-zeta)*(1.-xi)*(1.-xi);
+                blendFactor = 0.5*(1.-zeta)*(1.-xi)*(1.-xi);
                 corrFactorDxi[0] =-1.*(1 - xi)*(1 - zeta);
                 corrFactorDxi[1] =0;
                 corrFactorDxi[2] =-0.5*((1 - xi)*(1 - xi));
                 return;
             case  9:
-                correctionFactor = 1. - xi - eta;
+                blendFactor = 1. - xi - eta;
                 corrFactorDxi[0] = -1;
                 corrFactorDxi[1] = -1;
                 corrFactorDxi[2] = 0;
                 return;
             case 10:
-                correctionFactor = xi;
+                blendFactor = xi;
                 corrFactorDxi[0] = 1;
                 corrFactorDxi[1] = 0;
                 corrFactorDxi[2] = 0;
                 return;
             case 11:
-                correctionFactor = eta;
+                blendFactor = eta;
                 corrFactorDxi[0] = 0;
                 corrFactorDxi[1] = 1;
                 corrFactorDxi[2] = 0;
                 return;
             case 12:
-                correctionFactor = 0.5*(1.+zeta)*(1.-eta)*(1.-eta);
+                blendFactor = 0.5*(1.+zeta)*(1.-eta)*(1.-eta);
                 corrFactorDxi[0] = 0;
                 corrFactorDxi[1] = -1.*(1 - eta)*(1 + zeta);
                 corrFactorDxi[2] = 0.5*((1 - eta)*(1 - eta));
                 return;
             case 13:
-                correctionFactor = 0.5*(1.+zeta)*(xi+eta)*(xi+eta);
+                blendFactor = 0.5*(1.+zeta)*(xi+eta)*(xi+eta);
                 corrFactorDxi[0] = 1.*(eta + xi)*(1 + zeta);
                 corrFactorDxi[1] = 1.*(eta + xi)*(1 + zeta);
                 corrFactorDxi[2] = 0.5*((eta + xi)*(eta + xi));
                 return;
             case 14:
-                correctionFactor = 0.5*(1.+zeta)*(1.-xi)*(1.-xi);
+                blendFactor = 0.5*(1.+zeta)*(1.-xi)*(1.-xi);
                 corrFactorDxi[0] = -1.*(1 - xi)*(1 + zeta);
                 corrFactorDxi[1] = 0;
                 corrFactorDxi[2] = 0.5*((1 - xi)*(1 - xi));
                 return;
             case 15:
-                correctionFactor = 0.5*(1.-zeta);
+                blendFactor = 0.5*(1.-zeta);
                 corrFactorDxi[0] = 0;
                 corrFactorDxi[1] = 0;
                 corrFactorDxi[2] = -0.5;
                 return;
             case 16:
-                correctionFactor = 1.-eta;
+                blendFactor = 1.-eta;
                 corrFactorDxi[0] = 0;
                 corrFactorDxi[1] = -1;
                 corrFactorDxi[2] = 0;
                 return;
             case 17:
-                correctionFactor = xi+eta;
+                blendFactor = xi+eta;
                 corrFactorDxi[0] = 1;
                 corrFactorDxi[1] = 1;
                 corrFactorDxi[2] = 0;
                 return;
             case 18:
-                correctionFactor = 1.-xi;
+                blendFactor = 1.-xi;
                 corrFactorDxi[0] = -1;
                 corrFactorDxi[1] = 0;
                 corrFactorDxi[2] = 0;
                 return;
             case 19:
-                correctionFactor = 0.5*(1.+zeta);
+                blendFactor = 0.5*(1.+zeta);
                 corrFactorDxi[0] = 0;
                 corrFactorDxi[1] = 0;
                 corrFactorDxi[2] = 0.5;
@@ -1675,14 +1675,14 @@ template bool pztopology::TPZPrism::MapToSide<REAL>(int side, TPZVec<REAL> &Inte
 
 template void pztopology::TPZPrism::TShape<REAL>(const TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi);
 
-template void pztopology::TPZPrism::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
+template void pztopology::TPZPrism::BlendFactorForSide<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
 #ifdef _AUTODIFF
 template<class T=REAL>
 class Fad;
 
 template bool pztopology::TPZPrism::MapToSide<Fad<REAL> >(int side, TPZVec<Fad<REAL> > &InternalPar, TPZVec<Fad<REAL> > &SidePar, TPZFMatrix<Fad<REAL> > &JacToSide);
 
-template void pztopology::TPZPrism::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
+template void pztopology::TPZPrism::BlendFactorForSide<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
                                                                    TPZVec<Fad<REAL>> &);
 template void pztopology::TPZPrism::TShape<Fad<REAL>>(const TPZVec<Fad<REAL>> &loc,TPZFMatrix<Fad<REAL>> &phi,TPZFMatrix<Fad<REAL>> &dphi);
 #endif

--- a/Topology/tpzprism.h
+++ b/Topology/tpzprism.h
@@ -84,6 +84,25 @@ namespace pztopology {
 		/** @brief Returns the local connect number of the connect "c" along side "side" */
 		static int ContainedSideLocId(int side, int c);
 
+
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
+            TShape(loc, phi, dphi);
+        }
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        template<class T>
+        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
+        /**
+         * This method calculates the influence (a.k.a. the blend function) of the side side regarding an
+         * interior point qsi. It is used by the TPZGeoBlend class.
+         * @param side the index of the side
+         * @param xi coordinates of the interior point
+         * @param correctionFactor influence (0 <= correctionFactor <= 1)
+         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+         */
+        template<class T>
+        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+                                      TPZVec<T> &corrFactorDxi);
 		/** @} */
 		
 		/** @name About points at the parametric spaces

--- a/Topology/tpzprism.h
+++ b/Topology/tpzprism.h
@@ -97,11 +97,11 @@ namespace pztopology {
          * interior point qsi. It is used by the TPZGeoBlend class.
          * @param side the index of the side
          * @param xi coordinates of the interior point
-         * @param correctionFactor influence (0 <= correctionFactor <= 1)
-         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+         * @param blendFactor influence (0 <= blendFactor <= 1)
+         * * @param corrFactorDxi derivative of the blendFactor in respect to xi
          */
         template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+        static void BlendFactorForSide(const int &side, const TPZVec<T> &xi, T &blendFactor,
                                       TPZVec<T> &corrFactorDxi);
 		/** @} */
 		

--- a/Topology/tpzpyramid.h
+++ b/Topology/tpzpyramid.h
@@ -80,7 +80,26 @@ namespace pztopology {
 		static int NContainedSides(int side);
 		/** @brief Returns the local connect number of the connect "c" along side "side" */
 		static int ContainedSideLocId(int side, int c);
-		
+
+
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
+            TShape(loc, phi, dphi);
+        }
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        template<class T>
+        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
+        /**
+         * This method calculates the influence (a.k.a. the blend function) of the side side regarding an
+         * interior point qsi. It is used by the TPZGeoBlend class.
+         * @param side the index of the side
+         * @param xi coordinates of the interior point
+         * @param correctionFactor influence (0 <= correctionFactor <= 1)
+         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+         */
+        template<class T>
+        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+                                      TPZVec<T> &corrFactorDxi);
 		/** @} */
 
 		/** @name About points at the parametric spaces

--- a/Topology/tpzpyramid.h
+++ b/Topology/tpzpyramid.h
@@ -94,11 +94,11 @@ namespace pztopology {
          * interior point qsi. It is used by the TPZGeoBlend class.
          * @param side the index of the side
          * @param xi coordinates of the interior point
-         * @param correctionFactor influence (0 <= correctionFactor <= 1)
-         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+         * @param blendFactor influence (0 <= blendFactor <= 1)
+         * * @param corrFactorDxi derivative of the blendFactor in respect to xi
          */
         template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+        static void BlendFactorForSide(const int &side, const TPZVec<T> &xi, T &blendFactor,
                                       TPZVec<T> &corrFactorDxi);
 		/** @} */
 

--- a/Topology/tpzquadrilateral.cpp
+++ b/Topology/tpzquadrilateral.cpp
@@ -185,9 +185,9 @@ namespace pztopology {
     }
 
     template<class T>
-    void TPZQuadrilateral::CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+    void TPZQuadrilateral::BlendFactorForSide(const int &side, const TPZVec<T> &xi, T &blendFactor,
                                        TPZVec<T> &corrFactorDxi){
-        const REAL tol = pztopology::gTolerance;
+        const REAL tol = pztopology::GetTolerance();
 #ifdef PZDEBUG
         std::ostringstream sout;
         if(side < NCornerNodes || side >= NSides){
@@ -198,7 +198,7 @@ namespace pztopology {
         }
 
         if(!IsInParametricDomain(xi,tol)){
-            sout<<"The method CalcSideInfluence expects the point xi to correspond to coordinates of a point";
+            sout<<"The method BlendFactorForSide expects the point xi to correspond to coordinates of a point";
             sout<<" inside the parametric domain. Aborting...";
             PZError<<std::endl<<sout.str()<<std::endl;
             #ifdef LOG4CXX
@@ -217,7 +217,7 @@ namespace pztopology {
             case 1:
             case 2:
             case 3:
-                correctionFactor = 0;
+                blendFactor = 0;
                 return;
             case 4:
                 i = 0;
@@ -232,10 +232,10 @@ namespace pztopology {
                 i = 3;
                 break;
             case 8:
-                correctionFactor = 1;
+                blendFactor = 1;
                 return;
         }
-        correctionFactor = phi(i,0) + phi((i+1)%NCornerNodes,0);
+        blendFactor = phi(i,0) + phi((i+1)%NCornerNodes,0);
         corrFactorDxi[0] = dphi(0,i) + dphi(0,(i+1)%NCornerNodes);
         corrFactorDxi[1] = dphi(1,i) + dphi(1,(i+1)%NCornerNodes);
     }
@@ -1213,14 +1213,14 @@ template bool pztopology::TPZQuadrilateral::MapToSide<REAL>(int side, TPZVec<REA
 
 template void pztopology::TPZQuadrilateral::TShape<REAL>(const TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi);
 
-template void pztopology::TPZQuadrilateral::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
+template void pztopology::TPZQuadrilateral::BlendFactorForSide<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
 #ifdef _AUTODIFF
 template<class T=REAL>
 class Fad;
 
 template bool pztopology::TPZQuadrilateral::MapToSide<Fad<REAL> >(int side, TPZVec<Fad<REAL> > &InternalPar, TPZVec<Fad<REAL> > &SidePar, TPZFMatrix<Fad<REAL> > &JacToSide);
 
-template void pztopology::TPZQuadrilateral::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
+template void pztopology::TPZQuadrilateral::BlendFactorForSide<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
                                                                    TPZVec<Fad<REAL>> &);
 template void pztopology::TPZQuadrilateral::TShape<Fad<REAL>>(const TPZVec<Fad<REAL>> &loc,TPZFMatrix<Fad<REAL>> &phi,TPZFMatrix<Fad<REAL>> &dphi);
 #endif

--- a/Topology/tpzquadrilateral.h
+++ b/Topology/tpzquadrilateral.h
@@ -101,11 +101,11 @@ namespace pztopology {
          * interior point qsi. It is used by the TPZGeoBlend class.
          * @param side the index of the side
          * @param xi coordinates of the interior point
-         * @param correctionFactor influence (0 <= correctionFactor <= 1)
-         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+         * @param blendFactor influence (0 <= blendFactor <= 1)
+         * * @param corrFactorDxi derivative of the blendFactor in respect to xi
          */
         template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+        static void BlendFactorForSide(const int &side, const TPZVec<T> &xi, T &blendFactor,
                                       TPZVec<T> &corrFactorDxi);
 		/** @} */
 		

--- a/Topology/tpzquadrilateral.h
+++ b/Topology/tpzquadrilateral.h
@@ -87,7 +87,26 @@ namespace pztopology {
 		
 		/** @brief returns the local side number of the side "c" contained in the closure of side "side" */
 		static int ContainedSideLocId(int side, int c);
-		
+
+
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
+            TShape(loc, phi, dphi);
+        }
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        template<class T>
+        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
+        /**
+         * This method calculates the influence (a.k.a. the blend function) of the side side regarding an
+         * interior point qsi. It is used by the TPZGeoBlend class.
+         * @param side the index of the side
+         * @param xi coordinates of the interior point
+         * @param correctionFactor influence (0 <= correctionFactor <= 1)
+         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+         */
+        template<class T>
+        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+                                      TPZVec<T> &corrFactorDxi);
 		/** @} */
 		
 		/** @name About points at the parametric spaces

--- a/Topology/tpztetrahedron.cpp
+++ b/Topology/tpztetrahedron.cpp
@@ -266,10 +266,10 @@ namespace pztopology {
 
     }
     template<class T>
-    void TPZTetrahedron::CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+    void TPZTetrahedron::BlendFactorForSide(const int &side, const TPZVec<T> &xi, T &blendFactor,
                                              TPZVec<T> &corrFactorDxi) {
 
-        const REAL tol = pztopology::gTolerance;
+        const REAL tol = pztopology::GetTolerance();
         #ifdef PZDEBUG
         std::ostringstream sout;
         if (side < NCornerNodes || side >= NSides) {
@@ -280,7 +280,7 @@ namespace pztopology {
         }
 
         if (!IsInParametricDomain(xi, tol)) {
-            sout << "The method CalcSideInfluence expects the point xi to correspond to coordinates of a point";
+            sout << "The method BlendFactorForSide expects the point xi to correspond to coordinates of a point";
             sout << " inside the parametric domain. Aborting...";
             PZError << std::endl << sout.str() << std::endl;
             #ifdef LOG4CXX
@@ -293,10 +293,10 @@ namespace pztopology {
         TPZFNMatrix<8, T> dphi(Dimension, NCornerNodes);
         TPZTetrahedron::TShape(xi, phi, dphi);
         corrFactorDxi.Resize(TPZTetrahedron::Dimension, (T) 0);
-        correctionFactor = 0;
+        blendFactor = 0;
         for (int i = 0; i < TPZTetrahedron::NSideNodes(side); i++) {
             const int currentNode = TPZTetrahedron::SideNodeLocId(side, i);
-            correctionFactor += phi(currentNode, 0);
+            blendFactor += phi(currentNode, 0);
             corrFactorDxi[0] += dphi(0, currentNode);
             corrFactorDxi[1] += dphi(1, currentNode);
             corrFactorDxi[2] += dphi(2, currentNode);
@@ -309,7 +309,7 @@ namespace pztopology {
                 corrFactorDxi[0] = 0;
                 corrFactorDxi[1] = 0;
                 corrFactorDxi[2] = 0;
-                correctionFactor = 0;
+                blendFactor = 0;
                 return;
             case 4:
             case 5:
@@ -317,25 +317,25 @@ namespace pztopology {
             case 7:
             case 8:
             case 9:
-                corrFactorDxi[0] *= 2 * correctionFactor;
-                corrFactorDxi[1] *= 2 * correctionFactor;
-                corrFactorDxi[2] *= 2 * correctionFactor;
-                correctionFactor *= correctionFactor;
+                corrFactorDxi[0] *= 2 * blendFactor;
+                corrFactorDxi[1] *= 2 * blendFactor;
+                corrFactorDxi[2] *= 2 * blendFactor;
+                blendFactor *= blendFactor;
                 return;
             case 10:
             case 11:
             case 12:
             case 13:
-                corrFactorDxi[0] *= 3 * correctionFactor * correctionFactor;
-                corrFactorDxi[1] *= 3 * correctionFactor * correctionFactor;
-                corrFactorDxi[2] *= 3 * correctionFactor * correctionFactor;
-                correctionFactor *= correctionFactor * correctionFactor;
+                corrFactorDxi[0] *= 3 * blendFactor * blendFactor;
+                corrFactorDxi[1] *= 3 * blendFactor * blendFactor;
+                corrFactorDxi[2] *= 3 * blendFactor * blendFactor;
+                blendFactor *= blendFactor * blendFactor;
                 return;
             case 14:
                 corrFactorDxi[0] = 0;
                 corrFactorDxi[1] = 0;
                 corrFactorDxi[2] = 0;
-                correctionFactor = 1;
+                blendFactor = 1;
                 return;
         }
     }
@@ -1448,14 +1448,14 @@ template bool pztopology::TPZTetrahedron::MapToSide<REAL>(int side, TPZVec<REAL>
 
 template void pztopology::TPZTetrahedron::TShape<REAL>(const TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi);
 
-template void pztopology::TPZTetrahedron::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
+template void pztopology::TPZTetrahedron::BlendFactorForSide<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
 #ifdef _AUTODIFF
 template<class T=REAL>
 class Fad;
 
 template bool pztopology::TPZTetrahedron::MapToSide<Fad<REAL> >(int side, TPZVec<Fad<REAL> > &InternalPar, TPZVec<Fad<REAL> > &SidePar, TPZFMatrix<Fad<REAL> > &JacToSide);
 
-template void pztopology::TPZTetrahedron::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
+template void pztopology::TPZTetrahedron::BlendFactorForSide<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
                                                                    TPZVec<Fad<REAL>> &);
 template void pztopology::TPZTetrahedron::TShape<Fad<REAL>>(const TPZVec<Fad<REAL>> &loc,TPZFMatrix<Fad<REAL>> &phi,TPZFMatrix<Fad<REAL>> &dphi);
 #endif

--- a/Topology/tpztetrahedron.h
+++ b/Topology/tpztetrahedron.h
@@ -94,11 +94,11 @@ namespace pztopology {
          * interior point qsi. It is used by the TPZGeoBlend class.
          * @param side the index of the side
          * @param xi coordinates of the interior point
-         * @param correctionFactor influence (0 <= correctionFactor <= 1)
-         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+         * @param blendFactor influence (0 <= blendFactor <= 1)
+         * * @param corrFactorDxi derivative of the blendFactor in respect to xi
          */
         template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+        static void BlendFactorForSide(const int &side, const TPZVec<T> &xi, T &blendFactor,
                                       TPZVec<T> &corrFactorDxi);
 		/** @} */
 		

--- a/Topology/tpztetrahedron.h
+++ b/Topology/tpztetrahedron.h
@@ -81,6 +81,25 @@ namespace pztopology {
 		/** @brief Returns the local connect number of the connect "c" along side "side" */
 		static int ContainedSideLocId(int side, int c);
 
+
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
+            TShape(loc, phi, dphi);
+        }
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        template<class T>
+        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
+        /**
+         * This method calculates the influence (a.k.a. the blend function) of the side side regarding an
+         * interior point qsi. It is used by the TPZGeoBlend class.
+         * @param side the index of the side
+         * @param xi coordinates of the interior point
+         * @param correctionFactor influence (0 <= correctionFactor <= 1)
+         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+         */
+        template<class T>
+        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+                                      TPZVec<T> &corrFactorDxi);
 		/** @} */
 		
 		/** @name About points at the parametric spaces

--- a/Topology/tpztriangle.cpp
+++ b/Topology/tpztriangle.cpp
@@ -36,7 +36,7 @@ namespace pztopology {
     template<class T>
     void TPZTriangle::CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
                                            TPZVec<T> &correctionFactorDxi){
-
+    const REAL tol = pztopology::gTolerance;
 #ifdef PZDEBUG
         std::ostringstream sout;
         if(side < NCornerNodes || side >= NSides){
@@ -45,7 +45,7 @@ namespace pztopology {
             DebugStop();
         }
 
-        if(!pztopology::TPZTriangle::IsInParametricDomain(xi,gTolerance)){
+        if(!pztopology::TPZTriangle::IsInParametricDomain(xi,tol)){
             sout<<"The method CalcSideInfluence expects the point xi to correspond to coordinates of a point";
             sout<<" inside the parametric domain. Aborting...";
             PZError<<std::endl<<sout.str()<<std::endl;

--- a/Topology/tpztriangle.cpp
+++ b/Topology/tpztriangle.cpp
@@ -34,9 +34,9 @@ namespace pztopology {
     }
 
     template<class T>
-    void TPZTriangle::CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
-                                           TPZVec<T> &correctionFactorDxi){
-    const REAL tol = pztopology::gTolerance;
+    void TPZTriangle::BlendFactorForSide(const int &side, const TPZVec<T> &xi, T &blendFactor,
+                                           TPZVec<T> &blendFactorDxi){
+    const REAL tol = pztopology::GetTolerance();
 #ifdef PZDEBUG
         std::ostringstream sout;
         if(side < NCornerNodes || side >= NSides){
@@ -46,7 +46,7 @@ namespace pztopology {
         }
 
         if(!pztopology::TPZTriangle::IsInParametricDomain(xi,tol)){
-            sout<<"The method CalcSideInfluence expects the point xi to correspond to coordinates of a point";
+            sout<<"The method BlendFactorForSide expects the point xi to correspond to coordinates of a point";
             sout<<" inside the parametric domain. Aborting...";
             PZError<<std::endl<<sout.str()<<std::endl;
             #ifdef LOG4CXX
@@ -58,13 +58,13 @@ namespace pztopology {
         TPZFNMatrix<4,T> phi(NCornerNodes,1);
         TPZFNMatrix<8,T> dphi(Dimension,NCornerNodes);
         TPZTriangle::TShape(xi,phi,dphi);
-        correctionFactorDxi.Resize(TPZTriangle::Dimension, (T) 0);
+        blendFactorDxi.Resize(TPZTriangle::Dimension, (T) 0);
         int i = -1;
         switch(side){
             case 0:
             case 1:
             case 2:
-                correctionFactor = 0;
+                blendFactor = 0;
                 return;
             case 3:
                 i = 0;
@@ -76,13 +76,13 @@ namespace pztopology {
                 i = 2;
                 break;
             case 6:
-                correctionFactor = 1;
+                blendFactor = 1;
                 return;
         }
-        correctionFactor = phi(i,0) + phi((i+1)%NCornerNodes,0);
-        correctionFactor *= correctionFactor;
-        correctionFactorDxi[0] = 2 * ( phi(i,0) + phi((i+1)%NCornerNodes,0) ) * ( dphi(0,i) + dphi(0,(i+1)%NCornerNodes) );
-        correctionFactorDxi[1] = 2 * ( phi(i,0) + phi((i+1)%NCornerNodes,0) ) * ( dphi(1,i) + dphi(1,(i+1)%NCornerNodes) );
+        blendFactor = phi(i,0) + phi((i+1)%NCornerNodes,0);
+        blendFactor *= blendFactor;
+        blendFactorDxi[0] = 2 * ( phi(i,0) + phi((i+1)%NCornerNodes,0) ) * ( dphi(0,i) + dphi(0,(i+1)%NCornerNodes) );
+        blendFactorDxi[1] = 2 * ( phi(i,0) + phi((i+1)%NCornerNodes,0) ) * ( dphi(1,i) + dphi(1,(i+1)%NCornerNodes) );
 
     }
 
@@ -1112,14 +1112,14 @@ template bool pztopology::TPZTriangle::MapToSide<REAL>(int side, TPZVec<REAL> &I
 
 template void pztopology::TPZTriangle::TShape<REAL>(const TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi);
 
-template void pztopology::TPZTriangle::CalcSideInfluence<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
+template void pztopology::TPZTriangle::BlendFactorForSide<REAL>(const int &, const TPZVec<REAL> &, REAL &, TPZVec<REAL> &);
 #ifdef _AUTODIFF
 template<class T=REAL>
 class Fad;
 
 template bool pztopology::TPZTriangle::MapToSide<Fad<REAL> >(int side, TPZVec<Fad<REAL> > &InternalPar, TPZVec<Fad<REAL> > &SidePar, TPZFMatrix<Fad<REAL> > &JacToSide);
 
-template void pztopology::TPZTriangle::CalcSideInfluence<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
+template void pztopology::TPZTriangle::BlendFactorForSide<Fad<REAL>>(const int &, const TPZVec<Fad<REAL>> &, Fad<REAL> &,
                                                                    TPZVec<Fad<REAL>> &);
 template void pztopology::TPZTriangle::TShape<Fad<REAL>>(const TPZVec<Fad<REAL>> &loc,TPZFMatrix<Fad<REAL>> &phi,TPZFMatrix<Fad<REAL>> &dphi);
 #endif

--- a/Topology/tpztriangle.h
+++ b/Topology/tpztriangle.h
@@ -94,11 +94,11 @@ namespace pztopology {
          * interior point qsi. It is used by the TPZGeoBlend class.
          * @param side the index of the side
          * @param xi coordinates of the interior point
-         * @param correctionFactor influence (0 <= correctionFactor <= 1)
-         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+         * @param blendFactor influence (0 <= blendFactor <= 1)
+         * * @param corrFactorDxi derivative of the blendFactor in respect to xi
          */
         template<class T>
-        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+        static void BlendFactorForSide(const int &side, const TPZVec<T> &xi, T &blendFactor,
                                       TPZVec<T> &corrFactorDxi);
 
 		/** @} */

--- a/Topology/tpztriangle.h
+++ b/Topology/tpztriangle.h
@@ -82,6 +82,24 @@ namespace pztopology {
 		static int ContainedSideLocId(int side);
 		/** @brief Returns the local connect number of the connect "c" along side "side" */
 		static int ContainedSideLocId(int side, int c);
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        static void Shape(TPZVec<REAL> &loc,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
+            TShape(loc, phi, dphi);
+        }
+        /** @brief Compute the shape being used to construct the x mapping from local parametric coordinates  */
+        template<class T>
+        static void TShape(const TPZVec<T> &loc,TPZFMatrix<T> &phi,TPZFMatrix<T> &dphi);
+        /**
+         * This method calculates the influence (a.k.a. the blend function) of the side side regarding an
+         * interior point qsi. It is used by the TPZGeoBlend class.
+         * @param side the index of the side
+         * @param xi coordinates of the interior point
+         * @param correctionFactor influence (0 <= correctionFactor <= 1)
+         * * @param corrFactorDxi derivative of the correctionFactor in respect to xi
+         */
+        template<class T>
+        static void CalcSideInfluence(const int &side, const TPZVec<T> &xi, T &correctionFactor,
+                                      TPZVec<T> &corrFactorDxi);
 
 		/** @} */
 		


### PR DESCRIPTION
This pull request aims to bring the following changes to the master branch of NeoPZ:

- The methods `CalcSideInfluence` have now been renamed to `BlendFactorForSide` in other to be conforming with the nomenclature used elsewhere in NeoPZ
- The methods `BlendFactorForSide`, `Shape` and `TShape` have been moved from the `pzgeom` namespace to `pztopology` namespace. These changes have been discussed in LabMeC and aim to reinforce the concept of the `pztopology` namespace as static methods and variables related to the master element and *not* to the mapping to the deformed element.
- The variable `pztopology::gTolerance` has been created to unify the floating point tolerance to be used in topology-related calculations. It's default value is based on `std::numeric_limits<REAL>`. Working towards the Python interface, the methods `REAL pztopology::GetTolerance()` and `pztopology::SetTolerance(const REAL &)` have been created. A draft of a possible singleton to be used in case of future topology settings has been included in the comments on `pzreal.h`.