### PR TITLE
Refpattern quick fix

### DIFF
--- a/Refine/TPZRefPattern.cpp
+++ b/Refine/TPZRefPattern.cpp
@@ -1185,7 +1185,7 @@ void TPZRefPattern::CreateRefinementPattern(){
         TPZGeoEl* subEl = fRefPatternMesh.Element(iSubEl + 1);
         subEl->SetFather(fatherEl);
         subEl->SetFatherIndex(0);
-        fatherEl->SetSubElement(iSubEl, subEl);
+        // fatherEl->SetSubElement(iSubEl, subEl);
     }
 
     SetRefPatternMeshToMasterDomain();


### PR DESCRIPTION
I think TPZRefPattern::CreateRefinementPattern() is doing something that it shouldn't be doing...

Here's the workflow I'm visualizing:
-Set a mesh to create a RefPattern
-Call RefPattern constructor in that mesh which then calls CreateRefinementPattern
-In there, the method tries to set sub elements into the father element
-The refinement pattern hasn't been created yet, so this can't be done
-Get annoying error message, but methods returns and carries on

It doesn't break my code, but prints an error message each time I create a new refpattern
I commented the line in which subelements were being attributed to the father, and everything is back to normal.
Went a few steps into the code searching for something I might break doing this, but found no danger...

git blame tells me this was put in place by @orlandini during refpattern refactoring in commit e8fb118

[Não acho que vou quebrar código de ninguém com isso... mas quis aproveitar o exemplo simples para testar um pull request que eu nunca fiz hahah obrigado pela paciência de todos]