### PR TITLE
A next-neighbour operator

### DIFF
--- a/Mesh/pzgeoelside.h
+++ b/Mesh/pzgeoelside.h
@@ -229,6 +229,18 @@ public:
 	int operator>(const TPZGeoElSide &other) const {
 		return (fGeoEl > other.fGeoEl || (fGeoEl == other.fGeoEl && fSide > other.fSide));
 	}
+
+	/** @brief Next neighbour operator as post-increment */
+	TPZGeoElSide operator++(int){
+		TPZGeoElSide pre = *this;
+		*this = this->Neighbour();
+		return pre;
+	}
+	/** @brief Next neighbour operator as pre-increment */
+	TPZGeoElSide& operator++(){
+		*this = this->Neighbour();
+		return *this;
+	}
     
     /** @brief The conversion to bool indicates whether the object has an associated element */
     operator bool() const


### PR DESCRIPTION
### This looks nice... can we keep it?

I wanna be able to do `neig++` and `++neig` to get the next neighbour.

In a loop it would look like

```cpp
TPZGeoElSide gelside;
TPZGeoElSide neig = gelside.Neighbour();
while(neig != gelside){
    // [code]
    neig++
}
```

or my favourite

```cpp
TPZGeoElSide gelside;
TPZGeoElSide neig;
for(neig = gelside.Neighbour(); neig != gelside; neig++){
    // [code]
}
```