### PR TITLE
Complex numbers in NeoPZ

### DIFF
--- a/Analysis/pzanalysis.h
+++ b/Analysis/pzanalysis.h
@@ -45,6 +45,8 @@ protected:
 	TPZGeoMesh *fGeoMesh;
 	/** @brief Computational mesh */
 	TPZCompMesh *fCompMesh;
+    /** @brief Type of the solution (real/complex)*/
+    ESolType fSolType;
 	/** @brief Graphical mesh */
 	TPZGraphMesh *fGraphMesh[3];
 	/** @brief Load vector */
@@ -388,5 +390,9 @@ TPZMatrixSolver<STATE> *TPZAnalysis::BuildPreconditioner<STATE>(
     EPrecond preconditioner,bool overlap);
 extern template
 TPZMatrixSolver<STATE> &TPZAnalysis::MatrixSolver<STATE>();
-
+extern template
+TPZMatrixSolver<CSTATE> *TPZAnalysis::BuildPreconditioner<CSTATE>(
+    EPrecond preconditioner,bool overlap);
+extern template
+TPZMatrixSolver<CSTATE> &TPZAnalysis::MatrixSolver<CSTATE>();
 #endif

--- a/Analysis/pzblackoilanalysis.cpp
+++ b/Analysis/pzblackoilanalysis.cpp
@@ -8,7 +8,7 @@
 #include "TPZSpStructMatrix.h"
 #include "pzseqsolver.h"
 #include "checkconv.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "pzcmesh.h"
 
 using namespace std;
@@ -356,8 +356,7 @@ void TPZBlackOilAnalysis::Vazao(TPZBlackOilAnalysis &an, int matid, double & Vaz
 	TPZVec<REAL> qsi(3);
     TPZVec<STATE> sol(1);
 	
-	TPZElementMatrix ek(cmesh, TPZElementMatrix::EK), ef(cmesh, TPZElementMatrix::EF);
-	
+	TPZElementMatrixT<STATE> ek(cmesh, TPZElementMatrix::EK), ef(cmesh, TPZElementMatrix::EF);
 	const int nel = cmesh->NElements();
 	VazaoAguaSC = 0.;
 	VazaoOleoSC = 0.;

--- a/Analysis/pzeuleranalysis.cpp
+++ b/Analysis/pzeuleranalysis.cpp
@@ -12,6 +12,7 @@
 #include "TPZParFrontStructMatrix.h"
 #include "TPZFrontNonSym.h"
 #include "TPZBSpStructMatrix.h"
+#include "TPZElementMatrixT.h"
 #include "pzbdstrmatrix.h"
 #include "pzelmat.h"
 #include "tpzoutofrange.h"
@@ -588,10 +589,11 @@ int TPZEulerAnalysis::LineSearch(REAL &residual, TPZFMatrix<STATE> &sol0, TPZFMa
  */
 void TPZEulerAnalysis::CompareRhs()
 {
+	//TODOCOMPLEX
 	int iel;
 	//int numel = 0;
 	int nelem = fCompMesh->NElements();
-	TPZElementMatrix ek1(fCompMesh, TPZElementMatrix::EK) ,ef1(fCompMesh, TPZElementMatrix::EF),ef2(fCompMesh, TPZElementMatrix::EF);
+	TPZElementMatrixT<STATE> ek1(fCompMesh, TPZElementMatrix::EK) ,ef1(fCompMesh, TPZElementMatrix::EF),ef2(fCompMesh, TPZElementMatrix::EF);
 	
 	TPZAdmChunkVector<TPZCompEl *> &elementvec = fCompMesh->ElementVec();
 	TPZFNMatrix<64,STATE> diff(8,8);

--- a/Common/pzreal.h
+++ b/Common/pzreal.h
@@ -189,21 +189,17 @@ typedef TPZFlopCounter REAL;
 typedef float STATE;
 #endif // STATEfloat
 #ifdef STATEdouble
-typedef double STATE; //This is the default configuration
+//This is the default configuration
+typedef double STATE;
 #endif // STATEdouble
 #ifdef STATElongdouble
 typedef long double STATE;
 #endif // STATElongdouble
-#ifdef STATEcomplexf
-typedef std::complex<float> STATE;
-#endif // STATEcomplexf
-#ifdef STATEcomplexd
-typedef std::complex<double> STATE;
-#endif //STATEcomplexd
-#ifdef STATEcomplexld
-typedef std::complex<long double> STATE;
-#endif //STATEcomplexld
+typedef std::complex<STATE> CSTATE;
+// set(STATE_COMPLEX "STATE_COMPLEX")
+// set (BUILD_COMPLEX_PROJECTS ON)
 
+enum ESolType{ EReal=1,EComplex=2,EUndefined=3};
 #ifdef VC
 #include <io.h>
 #ifndef NOMINMAX

--- a/Material/TPZMaterial.cpp
+++ b/Material/TPZMaterial.cpp
@@ -330,6 +330,17 @@ TPZMaterial * TPZMaterial::NewMaterial() {
 	return 0;
 }
 
+void TPZMaterial::Contribute(TPZMaterialData &data, REAL weight, TPZFMatrix<CSTATE> &ek, TPZFMatrix<CSTATE> &ef){
+    TPZFMatrix<REAL>  &phi = data.phi;
+    const auto phr = phi.Rows();
+    for( auto in = 0; in < phr; in++ ) {
+        ef(in) = phi(in,0);
+        for( auto jn = 0; jn < phr; jn++ ) {
+            ek(in,jn) = phi(in,0) * phi(jn,0);
+        }
+    }
+}
+
 void TPZMaterial::Contribute(TPZVec<TPZMaterialData> &datavec, REAL weight, TPZFMatrix<STATE> &ek, TPZFMatrix<STATE> &ef) {
 	int nref=datavec.size();
     int ndif = 0;

--- a/Material/TPZMaterial.h
+++ b/Material/TPZMaterial.h
@@ -265,6 +265,8 @@ public:
      * @since April 16, 2007
      */
     virtual void Contribute(TPZMaterialData &data, REAL weight, TPZFMatrix<STATE> &ek, TPZFMatrix<STATE> &ef) = 0;
+
+    virtual void Contribute(TPZMaterialData &data, REAL weight, TPZFMatrix<CSTATE> &ek, TPZFMatrix<CSTATE> &ef);
     
     /**
      * @brief It computes a contribution to the residual vector at one integration point.
@@ -277,6 +279,12 @@ public:
       TPZFMatrix<STATE> fakeek(ef.Rows(), ef.Rows(), 0.);
       this->Contribute(data, weight, fakeek, ef);
     }
+
+        virtual void Contribute(TPZMaterialData &data, REAL weight, TPZFMatrix<CSTATE> &ef){
+      TPZFMatrix<CSTATE> fakeek(ef.Rows(), ef.Rows(), 0.);
+      this->Contribute(data, weight, fakeek, ef);
+    }
+    
     
 
     /**

--- a/Matrix/TPZSolutionMatrix.cpp
+++ b/Matrix/TPZSolutionMatrix.cpp
@@ -11,41 +11,42 @@ TPZSolutionMatrix::TPZSolutionMatrix(bool is_complex) {
     {
       fBaseMatrix = &fRealMatrix;
     }
-  else{DebugStop();}
-  // else{ fBaseMatrix = &fComplexMatrix;}
+  else{ fBaseMatrix = &fComplexMatrix;}
 }
 TPZSolutionMatrix::TPZSolutionMatrix(int nrows, int ncols,
-                                                  bool is_complex)
-    : fSolType(is_complex ? EComplex : EReal) {
-    if(fSolType == EReal) {
-    fBaseMatrix = &fRealMatrix;
-  }
-  else{DebugStop();}
-  // else{ fBaseMatrix = &fComplexMatrix;}
+                                     bool is_complex)
+  : fSolType(is_complex ? EComplex : EReal) {
+  if(fSolType == EReal)
+    {
+      fBaseMatrix = &fRealMatrix;
+    }
+    else{ fBaseMatrix = &fComplexMatrix;}
   fBaseMatrix->Resize(nrows, ncols);
 }
 
 TPZSolutionMatrix::TPZSolutionMatrix(const TPZFMatrix<STATE> &sol)
-    : fSolType(EReal), fRealMatrix(sol), fBaseMatrix(&fRealMatrix)
+    : fSolType(EReal), fRealMatrix(sol),
+      fBaseMatrix(&fRealMatrix)
 {
 
 }
 
-// TPZSolutionMatrix::TPZSolutionMatrix(const TPZFMatrix<CSTATE> &sol)
-//     : fSolType(EComplex), fComplexMatrix(sol), fBaseMatrix(&fComplexMatrix)
-// {
+TPZSolutionMatrix::TPZSolutionMatrix(const TPZFMatrix<CSTATE> &sol)
+    : fSolType(EComplex), fComplexMatrix(sol),
+      fBaseMatrix(&fComplexMatrix)
+{
 
-// }
+}
 
 TPZSolutionMatrix::TPZSolutionMatrix(const TPZSolutionMatrix &cp) :
     fSolType(cp.fSolType), fRealMatrix(cp.fRealMatrix)
-    // , fComplexMatrix(cp.fComplexMatrix)
+    , fComplexMatrix(cp.fComplexMatrix)
 {
-    if(fSolType == EReal) {
-    fBaseMatrix = &fRealMatrix;
-  }
-    else{DebugStop();}
-  // else{ fBaseMatrix = &fComplexMatrix;}
+  if(fSolType == EReal)
+    {
+      fBaseMatrix = &fRealMatrix;
+    }
+  else{ fBaseMatrix = &fComplexMatrix;}
 }
 
 TPZSolutionMatrix&
@@ -56,12 +57,11 @@ TPZSolutionMatrix::operator=(const TPZSolutionMatrix &cp)
     }
     if(fSolType == cp.fSolType){
         fRealMatrix = cp.fRealMatrix;
-        // fComplexMatrix = copy.fComplexMatrix;
+        fComplexMatrix = cp.fComplexMatrix;
         if(fSolType == EReal) {
           fBaseMatrix = &fRealMatrix;
         }
-        else{DebugStop();}
-        // else{ fBaseMatrix = &fComplexMatrix;}
+        else{ fBaseMatrix = &fComplexMatrix;}
         return *this;
   } else{DebugStop();}
     return *this;
@@ -71,28 +71,26 @@ template<class TVar>
 TPZSolutionMatrix&
 TPZSolutionMatrix::operator=(const TPZFMatrix<TVar> &mat)
 {
-    if constexpr (std::is_same<TVar,STATE>::value
-                  // ||std::is_same<TVar,CSTATE>::value
-                  ){
-        if constexpr(std::is_same<TVar,STATE>::value){
-            if(fSolType == EReal || fSolType == EUndefined){
-                fSolType = EReal;
-                fRealMatrix = mat;
-                fBaseMatrix = &fRealMatrix;
-                return *this;
-            }
-            // else if(fSolType == EComplex || fSolType == EUndefined){
-            //     fSolType = EComplex;
-            //     fRealMatrix = mat;
-            //     fBaseMatrix = &fComplexMatrix;
-            //     return *this;
-            // }
-        }
+  if constexpr(std::is_same<TVar,STATE>::value){
+    if(fSolType == EReal || fSolType == EUndefined){
+      fSolType = EReal;
+      fRealMatrix = mat;
+      fBaseMatrix = &fRealMatrix;
+      return *this;
     }
-    PZError<<__PRETTY_FUNCTION__;
-    PZError<<" called with incompatible type\n";
-    DebugStop();
-    return *this;
+  }
+  else if constexpr(std::is_same<TVar,CSTATE>::value){
+    if(fSolType == EComplex || fSolType == EUndefined){
+      fSolType = EComplex;
+      fComplexMatrix = mat;
+      fBaseMatrix = &fComplexMatrix;
+      return *this;
+    }
+  }
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<" called with incompatible type\n";
+  DebugStop();
+  return *this;
 }
 
 template <class TVar>
@@ -103,24 +101,23 @@ TPZSolutionMatrix &TPZSolutionMatrix::operator+=(const TPZFMatrix<TVar> &mat){
     PZError<<"Aborting...\n";
     DebugStop();
   }
-  if constexpr (std::is_same<TVar,STATE>::value
-                  // ||std::is_same<TVar,CSTATE>::value
-                  ){
-        if constexpr(std::is_same<TVar,STATE>::value){
-            if(fSolType == EReal){
-                fRealMatrix += mat;
-                return *this;
-            }
-            // else if(fSolType == EComplex){
-            //   fComplexMatrix += mat;              
-            //   return *this;
-            // }
-        }
+  if constexpr(std::is_same<TVar,STATE>::value){
+    if(fSolType == EReal){
+      fRealMatrix += mat;
+      return *this;
     }
-    PZError<<__PRETTY_FUNCTION__;
-    PZError<<" called with incompatible type\n";
-    DebugStop();
-    return *this;
+  }
+  else if constexpr(std::is_same<TVar,CSTATE>::value){
+    if(fSolType == EComplex){
+      fComplexMatrix += mat;              
+      return *this;
+    }
+  }
+    
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<" called with incompatible type\n";
+  DebugStop();
+  return *this;
 }
 
 TPZSolutionMatrix &TPZSolutionMatrix::operator+=(const TPZSolutionMatrix &sol){
@@ -128,10 +125,10 @@ TPZSolutionMatrix &TPZSolutionMatrix::operator+=(const TPZSolutionMatrix &sol){
     fRealMatrix += sol.fRealMatrix;
     return *this;
   }
-  // else if(fSolType == EComplex && sol.fSolType == EComplex){
-  //   fComplexMatrix += sol.fComplexMatrix;
-  //   return *this;
-  // }
+  else if(fSolType == EComplex && sol.fSolType == EComplex){
+    fComplexMatrix += sol.fComplexMatrix;
+    return *this;
+  }
   PZError << __PRETTY_FUNCTION__;
   PZError << " called with incompatible type\n";
   DebugStop();
@@ -166,14 +163,23 @@ TPZSolutionMatrix::operator const TPZFMatrix<STATE> &()const{
     return fRealMatrix;
 }
 
-// TPZSolutionMatrix::operator TPZFMatrix<CSTATE> &(){
-//     if(fSolType != EComplex){
-//         PZError<<__PRETTY_FUNCTION__;
-//         PZError << " called with incompatible type\n";
-//         DebugStop();
-//     }
-//     return fComplexMatrix;
-// }
+TPZSolutionMatrix::operator TPZFMatrix<CSTATE> &(){
+    if(fSolType != EComplex){
+        PZError<<__PRETTY_FUNCTION__;
+        PZError << " called with incompatible type\n";
+        DebugStop();
+    }
+    return fComplexMatrix;
+}
+
+TPZSolutionMatrix::operator const TPZFMatrix<CSTATE> &() const{
+    if(fSolType != EComplex){
+        PZError<<__PRETTY_FUNCTION__;
+        PZError << " called with incompatible type\n";
+        DebugStop();
+    }
+    return fComplexMatrix;
+}
 
 
 void TPZSolutionMatrix::ExpandAndSetSol(const TPZSolutionMatrix & sol, const int64_t nrows){
@@ -202,16 +208,16 @@ void TPZSolutionMatrix::ExpandAndSetSol(const TPZSolutionMatrix & sol, const int
         }
     }
   }
-  // else if(fSolType == EComplex){
-  //   const TPZFMatrix<CSTATE> &solst = sol;
-  //   for(auto j=0;j<solCols;j++)
-  //   {
-  //       for(auto i=0;i<solRows;i++)
-  //       {
-  //         fComplexMatrix.PutVal(i,j,solst.GetVal(i, j));
-  //       }
-  //   }
-  // }
+  else if(fSolType == EComplex){
+    const TPZFMatrix<CSTATE> &solst = sol;
+    for(auto j=0;j<solCols;j++)
+    {
+        for(auto i=0;i<solRows;i++)
+        {
+          fComplexMatrix.PutVal(i,j,solst.GetVal(i, j));
+        }
+    }
+  }
   else{
     PZError<<__PRETTY_FUNCTION__;
     PZError<<": solution does not have a defined type! Aborting...\n";
@@ -227,8 +233,7 @@ void TPZSolutionMatrix::Read(TPZStream &buf, void *context) {
   
   if (fSolType == EReal)
     return fRealMatrix.Read(buf, context);
-  else{DebugStop();}
-  // else return fComplexMatrix.Read(buf,context);
+  else return fComplexMatrix.Read(buf,context);
 }
 void TPZSolutionMatrix::Write(TPZStream &buf, int withclassid) const {
   if(fSolType == EUndefined){
@@ -240,11 +245,18 @@ void TPZSolutionMatrix::Write(TPZStream &buf, int withclassid) const {
   buf.Write(isComplex);
   if (!isComplex)
     return fRealMatrix.Write(buf, withclassid);
-  else{DebugStop();}
-  // else return fComplexMatrix.Write(buf,withclassid);
+  else return fComplexMatrix.Write(buf,withclassid);
 }
+
+
+
 
 template
 TPZSolutionMatrix &TPZSolutionMatrix::operator=<STATE>(const TPZFMatrix<STATE> &mat);
 template
 TPZSolutionMatrix &TPZSolutionMatrix::operator+=<STATE>(const TPZFMatrix<STATE> &mat);
+
+template
+TPZSolutionMatrix &TPZSolutionMatrix::operator=<CSTATE>(const TPZFMatrix<CSTATE> &mat);
+template
+TPZSolutionMatrix &TPZSolutionMatrix::operator+=<CSTATE>(const TPZFMatrix<CSTATE> &mat);

--- a/Matrix/TPZSolutionMatrix.h
+++ b/Matrix/TPZSolutionMatrix.h
@@ -18,10 +18,9 @@ class TPZSolutionMatrix : public TPZSavable{
 private:
 
   //! Enum for solution type
-  enum ESolType{ EReal=1,EComplex=2,EUndefined=3};
   ESolType fSolType;//!< Type of solution
   TPZFMatrix<STATE> fRealMatrix;//!< Static storage for real matrix
-  // TPZFMatrix<CSTATE> fComplexMatrix; //!< Static storage for complex matrix
+  TPZFMatrix<CSTATE> fComplexMatrix; //!< Static storage for complex matrix
   TPZBaseMatrix *fBaseMatrix;//!< Pointer for actual solution
 
 public:
@@ -38,8 +37,8 @@ public:
 
   //! Constructor taking a real matrix
   TPZSolutionMatrix(const TPZFMatrix<STATE> &sol);
-  // //! Constructor taking a complex matrix
-  // TPZSolutionMatrix(const TPZFMatrix<CSTATE> &sol);
+  //! Constructor taking a complex matrix
+  TPZSolutionMatrix(const TPZFMatrix<CSTATE> &sol);
   //! Copy constructor
   TPZSolutionMatrix(const TPZSolutionMatrix &);
   //! Move constructor (deleted)
@@ -58,6 +57,12 @@ public:
   //! Conversion function to TPZFMatrix<STATE>&. Throws error if incompatible
   operator TPZFMatrix<STATE>& ();
   operator const TPZFMatrix<STATE>& () const;
+  //@}
+
+  //@{
+  //! Conversion function to TPZFMatrix<CSTATE>&. Throws error if incompatible
+  operator TPZFMatrix<CSTATE>& ();
+  operator const TPZFMatrix<CSTATE>& () const;
   //@}
   
   //! Conversion function to TPZBaseMatrix&
@@ -78,12 +83,6 @@ public:
     with the dependent equations. This method provided a way for doing this operation
     with only one memory allocation.*/
   void ExpandAndSetSol(const TPZSolutionMatrix & sol, const int64_t nrows);
-  
-  // //@{
-  // //! Conversion function to TPZFMatrix<CSTATE>&. Throws error if incompatible
-  // operator TPZFMatrix<CSTATE>& ();
-  // operator const TPZFMatrix<CSTATE>& () const;
-  // //@}
   
   //! Number of Rows of the solution
   inline int64_t Rows() const {
@@ -135,11 +134,28 @@ public:
   void Read(TPZStream &buf, void *context) override;
   //! Write method (only the current matrix is written)
   void Write(TPZStream &buf, int withclassid) const override;
+  friend STATE Norm(const TPZSolutionMatrix &A);
 };
 
+inline STATE Norm(const TPZSolutionMatrix &A) {
+  if (A.fSolType == EReal)
+    return Norm(A.fRealMatrix);
+  else if (A.fSolType == EComplex){
+    return Norm(A.fComplexMatrix);
+  }
+  
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"Type is not set. Aborting...\n";
+  DebugStop();
+  return -1;
+}
 
 extern template
 TPZSolutionMatrix &TPZSolutionMatrix::operator=<STATE>(const TPZFMatrix<STATE> &mat);
 extern template
 TPZSolutionMatrix &TPZSolutionMatrix::operator+=<STATE>(const TPZFMatrix<STATE> &mat);
+extern template
+TPZSolutionMatrix &TPZSolutionMatrix::operator=<CSTATE>(const TPZFMatrix<CSTATE> &mat);
+extern template
+TPZSolutionMatrix &TPZSolutionMatrix::operator+=<CSTATE>(const TPZFMatrix<CSTATE> &mat);
 #endif

--- a/Mesh/CMakeLists.txt
+++ b/Mesh/CMakeLists.txt
@@ -47,6 +47,7 @@ set(headers
   tpzgeoelrefpattern.h.h
   pzcompelwithmem.h
   pzelmat.h
+  TPZElementMatrixT.h
   pzgnode.h
   pzreferredcompel.h
   TPZCompElLagrange.h
@@ -81,7 +82,8 @@ set(sources
   tpzcompmeshreferred.cpp
   TPZMultiphysicsCompMesh.cpp
   pzcompel.cpp
-  pzelmat.cpp  
+  pzelmat.cpp
+  TPZElementMatrixT.cpp
   TPZCompMeshTools.cpp
   TPZMultiphysicsInterfaceEl.cpp
   pzcompelwithmem.cpp  

--- a/Mesh/TPZAgglomerateEl.cpp
+++ b/Mesh/TPZAgglomerateEl.cpp
@@ -954,3 +954,5 @@ void TPZAgglomerateElement::Read(TPZStream &buf, void *context)
 
 template
 void TPZAgglomerateElement::ProjectSolution<STATE>(TPZFMatrix<STATE> &projectsol);
+template
+void TPZAgglomerateElement::ProjectSolution<CSTATE>(TPZFMatrix<CSTATE> &projectsol);

--- a/Mesh/TPZAgglomerateEl.cpp
+++ b/Mesh/TPZAgglomerateEl.cpp
@@ -172,15 +172,11 @@ REAL TPZAgglomerateElement::VolumeOfEl(){
 
 void TPZAgglomerateElement::CalcResidual(TPZFMatrix<REAL> &Rhs,TPZCompElDisc *el){
 	
-	PZError << "TPZAgglomerateElement::CalcResidual DEVE SER IMPLEMENTADO";
+	PZError << "TPZAgglomerateElement::CalcResidual must be implemented\n";
 }
 
-void TPZAgglomerateElement::CalcStiff(TPZElementMatrix &ekb, TPZElementMatrix &efb){
-	//TODOCOMPLEX
-	auto &ek =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
+template<class TVar>
+void TPZAgglomerateElement::CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef){	
 	if(Reference()) return TPZCompElDisc::CalcStiff(ek,ef);
 	
 	if(!Material()){

--- a/Mesh/TPZAgglomerateEl.cpp
+++ b/Mesh/TPZAgglomerateEl.cpp
@@ -14,7 +14,7 @@
 #include "pzmanvector.h"
 #include "pzadmchunk.h"
 #include "pzquad.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "pzgraphel.h"
 #include "pzgraphelq2dd.h"
 #include "pzgraphelq3dd.h"
@@ -175,8 +175,12 @@ void TPZAgglomerateElement::CalcResidual(TPZFMatrix<REAL> &Rhs,TPZCompElDisc *el
 	PZError << "TPZAgglomerateElement::CalcResidual DEVE SER IMPLEMENTADO";
 }
 
-void TPZAgglomerateElement::CalcStiff(TPZElementMatrix &ek, TPZElementMatrix &ef){
-	
+void TPZAgglomerateElement::CalcStiff(TPZElementMatrix &ekb, TPZElementMatrix &efb){
+	//TODOCOMPLEX
+	auto &ek =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
+	auto &ef =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
 	if(Reference()) return TPZCompElDisc::CalcStiff(ek,ef);
 	
 	if(!Material()){

--- a/Mesh/TPZAgglomerateEl.h
+++ b/Mesh/TPZAgglomerateEl.h
@@ -244,5 +244,7 @@ int ClassId() const override;
 
 extern template
 void TPZAgglomerateElement::ProjectSolution<STATE>(TPZFMatrix<STATE> &projectsol);
+extern template
+void TPZAgglomerateElement::ProjectSolution<CSTATE>(TPZFMatrix<CSTATE> &projectsol);
 
 #endif

--- a/Mesh/TPZAgglomerateEl.h
+++ b/Mesh/TPZAgglomerateEl.h
@@ -63,7 +63,9 @@ private:
 	
 	/** @brief Material id of the agglomerated element */
 	int fMaterialId;
-	
+
+	template<class TVar>
+    void CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef);
 public:
 	
 	/** @brief Constructor: If the element is possible to grouped returns a new index, else returns -1. */
@@ -138,14 +140,17 @@ public:
 	/** @brief Computes the residual of the solution to father element from clustered subelements. */
 	void CalcResidual(TPZFMatrix<REAL> &Rhs,TPZCompElDisc *el);
 	
-	void CalcResidual(TPZElementMatrix &ef) override
+	void CalcResidual(TPZElementMatrixT<STATE> &ef) override
 	{
 		std::cout << __PRETTY_FUNCTION__ << " is not implemented\n";
 		exit(-1);
 	}
 	
 	/** @brief Assembles the differential equation to model over the element defined by clustered subelements. */
-	void CalcStiff(TPZElementMatrix &ek, TPZElementMatrix &ef) override;
+	void CalcStiff(TPZElementMatrixT<STATE> &ek,
+				   TPZElementMatrixT<STATE> &ef) override{
+		CalcStiffInternal(ek,ef);
+	}
 	
 	/** @brief Returns the number of clustered subelements. */
 	int64_t NIndexes() const { return fIndexes.NElements(); }

--- a/Mesh/TPZCompElDisc.cpp
+++ b/Mesh/TPZCompElDisc.cpp
@@ -600,11 +600,12 @@ void TPZCompElDisc::Divide(int64_t index,TPZVec<int64_t> &subindex,int interpola
 	delete this;
 }
 
-void TPZCompElDisc::SolutionX(TPZVec<REAL> &x, TPZVec<STATE> &uh){
+template<class TVar>
+void TPZCompElDisc::SolutionXInternal(TPZVec<REAL> &x, TPZVec<TVar> &uh){
 	TPZCompMesh *finemesh = Mesh();
 	TPZBlock &fineblock = finemesh->Block();
 	int nstate = Material()->NStateVariables();
-	TPZFMatrix<STATE> &FineMeshSol = finemesh->Solution();
+	TPZFMatrix<TVar> &FineMeshSol = finemesh->Solution();
 	int matsize = NShapeF(),dim = Dimension();
 	TPZFMatrix<REAL> phix(matsize,1,0.);
 	TPZFMatrix<REAL> dphix(dim,matsize,0.);
@@ -616,7 +617,7 @@ void TPZCompElDisc::SolutionX(TPZVec<REAL> &x, TPZVec<STATE> &uh){
 	int iv = 0,d;
 	uh.Fill(0.);
 	for(d=0; d<dfvar; d++) {
-		uh[iv%nstate] += (STATE)phix(iv/nstate,0)*FineMeshSol(pos+d,0);
+		uh[iv%nstate] += (TVar)phix(iv/nstate,0)*FineMeshSol(pos+d,0);
 		iv++;
 	}
 }
@@ -1245,3 +1246,11 @@ int TPZCompElDisc::Degree() const {
     }
     return this->Connect(0).Order();
 }
+
+#define INSTANTIATE_METHODS(TVar) \
+template \
+ void TPZCompElDisc::SolutionXInternal<TVar>(TPZVec<REAL> &x, TPZVec<TVar> &uh);
+
+INSTANTIATE_METHODS(STATE)
+INSTANTIATE_METHODS(CSTATE)
+#undef INSTANTIATE_METHODS

--- a/Mesh/TPZCompElDisc.h
+++ b/Mesh/TPZCompElDisc.h
@@ -91,7 +91,9 @@ protected:
 	 * element and returns its index
 	 */
 	virtual int64_t CreateMidSideConnect();
-	
+
+    template<class TVar>
+    void SolutionXInternal(TPZVec<REAL> &x, TPZVec<TVar> &uh);
 public:
 	
 	/** @brief Define external shape functions which are stored in class attribute fExternalShape */
@@ -334,7 +336,13 @@ public:
 	 * Deprecated shape function method. It is kept because of TPZAgglomerateElement. \n
 	 * It does not include singular shape functions if they exist.
 	 */
-	void SolutionX(TPZVec<REAL> &x,TPZVec<STATE> &uh);
+    void SolutionX(TPZVec<REAL> &x, TPZVec<STATE> &uh){
+	SolutionXInternal(x,uh);
+    }
+
+    void SolutionX(TPZVec<REAL> &x, TPZVec<CSTATE> &uh){
+	SolutionXInternal(x,uh);
+    }
 	
     public:
 	/**
@@ -436,5 +444,14 @@ inline TPZCompEl *TPZCompElDisc::CreateDisc(TPZGeoEl *geo, TPZCompMesh &mesh, in
 }
 //Exemplo do quadrilatero:
 //acessar com -> TPZGeoElement<TPZShapeQuad,TPZGeoQuad,TPZRefQuad>::SetCreateFunction(TPZCompElDisc::CreateDisc);
+
+
+#define INSTANTIATE_METHODS(TVar) \
+extern template \
+ void TPZCompElDisc::SolutionXInternal<TVar>(TPZVec<REAL> &x, TPZVec<TVar> &uh);
+
+INSTANTIATE_METHODS(STATE)
+INSTANTIATE_METHODS(CSTATE)
+#undef INSTANTIATE_METHODS
 
 #endif

--- a/Mesh/TPZCompElLagrange.cpp
+++ b/Mesh/TPZCompElLagrange.cpp
@@ -8,7 +8,7 @@
 
 #include "TPZCompElLagrange.h"
 #include "TPZMaterial.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 
 TPZCompElLagrange::~TPZCompElLagrange()
 {
@@ -52,8 +52,13 @@ TPZCompEl *TPZCompElLagrange::ClonePatchEl(TPZCompMesh &mesh,
  * @param ek element stiffness matrix
  * @param ef element load vector
  */
-void TPZCompElLagrange::CalcStiff(TPZElementMatrix &ek,TPZElementMatrix &ef)
+void TPZCompElLagrange::CalcStiff(TPZElementMatrix &ekb,TPZElementMatrix &efb)
 {
+    //TODOCOMPLEX
+	auto &ek =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
+	auto &ef =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     InitializeElementMatrix(ek, ef);
 #ifdef PZDEBUG
     if (ef.fMat.Cols() != 1) {
@@ -107,8 +112,8 @@ void TPZCompElLagrange::InitializeElementMatrix(TPZElementMatrix &ek, TPZElement
     ef.fMesh = Mesh();
     ef.fType = TPZElementMatrix::EF;
     
-	ek.fBlock.SetNBlocks(ncon);
-	ef.fBlock.SetNBlocks(ncon);
+	ek.Block().SetNBlocks(ncon);
+	ef.Block().SetNBlocks(ncon);
 	int i;
     int numeq=0;
 	for(i=0; i<ncon; i++){
@@ -116,12 +121,12 @@ void TPZCompElLagrange::InitializeElementMatrix(TPZElementMatrix &ek, TPZElement
         int nshape = c.NShape();
         int nstate = c.NState();
         
-		ek.fBlock.Set(i,nshape*nstate);
-		ef.fBlock.Set(i,nshape*nstate);
+		ek.Block().Set(i,nshape*nstate);
+		ef.Block().Set(i,nshape*nstate);
         numeq += nshape*nstate;
 	}
-	ek.fMat.Redim(numeq,numeq);
-	ef.fMat.Redim(numeq,numloadcases);
+	ek.Matrix().Redim(numeq,numeq);
+	ef.Matrix().Redim(numeq,numloadcases);
 	ek.fConnect.Resize(ncon);
 	ef.fConnect.Resize(ncon);
 	for(i=0; i<ncon; i++){

--- a/Mesh/TPZCompElLagrange.cpp
+++ b/Mesh/TPZCompElLagrange.cpp
@@ -52,13 +52,9 @@ TPZCompEl *TPZCompElLagrange::ClonePatchEl(TPZCompMesh &mesh,
  * @param ek element stiffness matrix
  * @param ef element load vector
  */
-void TPZCompElLagrange::CalcStiff(TPZElementMatrix &ekb,TPZElementMatrix &efb)
+template<class TVar>
+void TPZCompElLagrange::CalcStiffInternal(TPZElementMatrixT<TVar> &ek,TPZElementMatrixT<TVar> &ef)
 {
-    //TODOCOMPLEX
-	auto &ek =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     InitializeElementMatrix(ek, ef);
 #ifdef PZDEBUG
     if (ef.fMat.Cols() != 1) {
@@ -78,10 +74,10 @@ void TPZCompElLagrange::CalcStiff(TPZElementMatrix &ekb,TPZElementMatrix &efb)
         ek.fMat(count+blsize0+fDef[l].fIdf[1],count+fDef[l].fIdf[0]) = -1.;
         ek.fMat(count+blsize0+fDef[l].fIdf[1],count+blsize0+fDef[l].fIdf[1]) = 1.;
         const TPZBlock &bl = Mesh()->Block();
-        TPZFMatrix<STATE> &sol = Mesh()->Solution();
+        TPZFMatrix<TVar> &sol = Mesh()->Solution();
         int64_t pos0 = bl.Index(c0.SequenceNumber(), fDef[l].fIdf[0]);
         int64_t pos1 = bl.Index(c1.SequenceNumber(), fDef[l].fIdf[1]);
-        STATE diff = sol(pos0,0)-sol(pos1,0);
+        TVar diff = sol(pos0,0)-sol(pos1,0);
         ef.fMat(count+fDef[l].fIdf[0],0) = -diff;
         ef.fMat(count+blsize0+fDef[l].fIdf[1],0) = diff;
         count += blsize0+blsize1;

--- a/Mesh/TPZCompElLagrange.h
+++ b/Mesh/TPZCompElLagrange.h
@@ -202,7 +202,9 @@ public:
 	 * @param ek element stiffness matrix
 	 * @param ef element load vector
 	 */
-	virtual void CalcStiff(TPZElementMatrix &ek,TPZElementMatrix &ef) override;
+	void CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef) override{
+        CalcStiffInternal(ek,ef);
+    }
 	
 	/**
 	 * @brief Computes the element right hand side
@@ -214,6 +216,9 @@ public:
     public:
 int ClassId() const override;
 
+protected:
+    template<class TVar>
+    void CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef);
 
 };
 

--- a/Mesh/TPZCompMeshTools.cpp
+++ b/Mesh/TPZCompMeshTools.cpp
@@ -8,6 +8,7 @@
 
 #include "TPZCompMeshTools.h"
 #include "pzelchdiv.h"
+#include "TPZElementMatrixT.h"
 #include "pzshapepiram.h"
 #include "TPZOneShapeRestraint.h"
 #include "pzshapetriang.h"
@@ -878,7 +879,7 @@ void TPZCompMeshTools::PrintSolutionByGeoElement(TPZCompMesh* cmesh, std::ostrea
 }
 
 void TPZCompMeshTools::PrintStiffnessMatrixByGeoElement(TPZCompMesh *cmesh, std::ostream &out, std::set<int> matIDs) {
-
+    //TODOCOMPLEX
     int64_t nel = cmesh->NElements();
     for (int64_t el = 0; el < nel; el++) {
         TPZCompEl *cel = cmesh->Element(el);
@@ -907,7 +908,7 @@ void TPZCompMeshTools::PrintStiffnessMatrixByGeoElement(TPZCompMesh *cmesh, std:
         }
         out << '\n';
 
-        TPZElementMatrix ekbc, efbc;
+        TPZElementMatrixT<STATE> ekbc, efbc;
         cel->CalcStiff(ekbc, efbc);
 
         ekbc.fMat.Print("StiffnessMatrix", out);

--- a/Mesh/TPZElementMatrixT.cpp
+++ b/Mesh/TPZElementMatrixT.cpp
@@ -1,0 +1,476 @@
+#include "TPZElementMatrixT.h"
+#include "pzcmesh.h"
+#include "pzlog.h"
+#ifdef PZ_LOG
+static TPZLogger logger("pz.mesh.tpzelmat");
+#endif
+
+
+template<class TVar>
+TPZElementMatrixT<TVar>::TPZElementMatrixT(const TPZElementMatrixT<TVar> &cp) :
+    TPZElementMatrix(cp), fMat(cp.fMat), fBlock(cp.fBlock),
+    fConstrMat(cp.fConstrMat),fConstrBlock(cp.fConstrBlock)
+{
+    fBlock.SetMatrix(&fMat);
+    fConstrBlock.SetMatrix(&fConstrMat);
+}
+
+
+template<class TVar>
+TPZElementMatrixT<TVar> &TPZElementMatrixT<TVar>::operator=(const TPZElementMatrixT<TVar> &cp)
+{
+    TPZElementMatrix::operator=(cp);
+    fMat = cp.fMat;
+    fBlock = cp.fBlock;
+    fConstrMat = cp.fConstrMat;
+    fConstrBlock = cp.fConstrBlock;
+    fBlock.SetMatrix(&fMat);
+    fConstrBlock.SetMatrix(&fConstrMat);
+    return *this;
+}
+
+template<class TVar>
+void TPZElementMatrixT<TVar>::Print(std::ostream &out){
+	if(fType == EK)
+	{
+        int ncon = fConnect.NElements();
+        int ic;
+        out << "Connect vector\n";
+        for(ic=0; ic<ncon; ic++) {
+            //	out << "Connect index " << fConnect[ic] << endl;
+            out << "ic = " << ic << " index " << fConnect[ic] << " ";
+            this->fMesh->ConnectVec()[fConnect[ic]].Print(*fMesh,out);
+        }
+        out << "Constrained connect vector\n";
+        //fConstrMat.Print("Constrained matrix",out);
+        ncon = fConstrConnect.NElements();
+        for(ic=0; ic<ncon; ic++) {
+            //	out << "Connect index " << fConstrConnect[ic] << endl;
+            out << "ic = " << ic << " index " << fConstrConnect[ic]  << ' ';
+            this->fMesh->ConnectVec()[fConstrConnect[ic]].Print(*fMesh,out);
+        }
+		ComputeDestinationIndices();
+		bool hasdepend = HasDependency();
+		int64_t size = fSourceIndex.NElements();
+		//TPZFMatrix<REAL> constrmatrix(size,size,0.);
+		TPZFNMatrix<400,STATE> constrmatrix(size,size,0.);
+		int64_t in,jn;
+		for(in=0; in<size; in++)
+		{
+			for (jn=0; jn<size; jn++) {
+				if(hasdepend)
+				{
+					constrmatrix(in,jn) = fConstrMat(fSourceIndex[in],fSourceIndex[jn]);
+				}
+				else {
+					constrmatrix(in,jn) = fMat(fSourceIndex[in],fSourceIndex[jn]);
+				}
+				
+			}
+		}
+        out << "SourceIndex = " << fSourceIndex << std::endl;
+        fConstrMat.Print("EKOrig=",out,EMathematicaInput);
+		std::stringstream sout;
+        sout << "EK = ";
+		//out << "Matrix size " << constrmatrix.Rows() << "\n";
+		//sout << "ConstrainedMatrix = ";
+		constrmatrix.Print(sout.str().c_str(), out, EMathematicaInput);
+	}
+    else if(fType == EF)
+	{
+		ComputeDestinationIndices();
+		bool hasdepend = HasDependency();
+		int64_t size = fSourceIndex.NElements();
+		//TPZFMatrix<REAL> constrmatrix(size,size,0.);
+		TPZFMatrix<STATE> constrmatrix(size,fMat.Cols(),0.);
+		int64_t in,jn;
+		for(in=0; in<size; in++)
+		{
+			for (jn=0; jn<fMat.Cols(); jn++) {
+				if(hasdepend)
+				{
+					constrmatrix(in,jn) = fConstrMat(fSourceIndex[in],jn);
+				}
+				else {
+					constrmatrix(in,jn) = fMat(fSourceIndex[in],jn);
+				}
+				
+			}
+		}
+		std::stringstream sout;
+        sout << "EF = ";
+		//out << "Matrix size " << constrmatrix.Rows() << "\n";
+		//sout << "ConstrainedMatrix = ";
+		constrmatrix.Print(sout.str().c_str(), out, EMathematicaInput);
+	}
+    else
+    {
+        DebugStop();
+    }
+}
+
+template<class TVar>
+void TPZElementMatrixT<TVar>::SetMatrixSize(short NumBli, short NumBlj,
+									 short BlSizei, short BlSizej) {
+	
+	
+	if(fMat.Rows() != NumBli*BlSizei || fMat.Cols() != NumBlj*BlSizej) {
+		fMat.Redim(NumBli*BlSizei,NumBlj*BlSizej);
+	}
+}
+template<class TVar>
+void TPZElementMatrixT<TVar>::SetMatrixMinSize(short NumBli, short NumBlj, 
+										short BlSizei, short BlSizej) {
+	
+	
+	if(fMat.Rows() < NumBli*BlSizei || fMat.Cols() < NumBlj*BlSizej) {
+		fMat.Redim(NumBli*BlSizei,NumBlj*BlSizej);
+	}
+}
+
+template<class TVar>
+void TPZElementMatrixT<TVar>::ApplyConstraints(){
+	
+	if (this->fMat.Rows() == 0){
+		LOGPZ_FATAL(logger, "this->fMat not initialized");
+	}
+	
+	int totalnodes= this->NConnects();
+	this->fConstrConnect.Resize(totalnodes);
+	if(totalnodes) this->fConstrConnect.Fill(0,0);
+	int in;
+    std::set<int64_t> origlist,connectlist;
+	for(in=0; in<totalnodes; in++) connectlist.insert(this->fConnect[in]);
+    for (std::list<TPZOneShapeRestraint>::iterator it = fOneRestraints.begin(); it != fOneRestraints.end(); it++) {
+        for (int c=0; c< it->fFaces.size(); c++) {
+            connectlist.insert(it->fFaces[c].first);
+        }
+    }
+    origlist = connectlist;
+	// total number of nodes of the constrained element
+	TPZConnect::BuildConnectList(connectlist, origlist, *this->fMesh);
+    this->fConstrConnect.resize(connectlist.size());
+    std::set<int64_t>::iterator it = connectlist.begin();
+    for (int64_t i=0; i<connectlist.size(); i++) {
+        fConstrConnect[i] = *it;
+        it++;
+    }
+	totalnodes = this->fConstrConnect.NElements();
+	
+	// compute the list of nodes and their proper order of processing
+	TPZVec<int> DependenceOrder;
+	// this->fConstrNod, totalnodes and DependenceOrder
+	// are initialized using codes documented above
+	BuildDependencyOrder(this->fConstrConnect,DependenceOrder,*this->fMesh);
+	
+	// compute the number of statevariables
+	// the number of state variables is the number of unknowns associated with
+	// each shapefunction
+	// numstate is best initialized during computation of the stiffness matrix
+	//   TPZMaterial * mat = Material();
+	//   int numstate = mat->NStateVariables();
+	
+	// initialize the block structure
+	this->fConstrBlock.SetNBlocks(totalnodes);
+	
+	// toteq contains the total number of equations of the constrained matrix
+	int64_t toteq = 0;
+	for(in=0; in<totalnodes; in++) {
+		int64_t dfnindex = this->fConstrConnect[in];
+		TPZConnect &dfn = fMesh->ConnectVec()[dfnindex];
+		int ndf = dfn.NDof(*fMesh);
+        int ndfcheck = dfn.NState()*dfn.NShape();
+        if(ndf != ndfcheck)
+        {
+            DebugStop();
+        }
+		this->fConstrBlock.Set(in,ndf);
+		toteq += ndf;
+	}
+	
+	this->fConstrBlock.Resequence();
+	this->fConstrBlock.SetMatrix(&this->fConstrMat);
+	    
+	int64_t nrhs = this->fMat.Cols();
+	if (this->fType == TPZElementMatrix::EK){
+		this->fConstrMat.Redim(toteq,toteq);
+	}
+	else{
+		this->fConstrMat.Redim(toteq,nrhs);
+	}
+	
+	// copy the original matrix to the constrained matrix
+	int numnod = this->fConnect.NElements();
+	for(in=0; in<numnod; in++) {
+		int irnode =0;
+		int64_t idfn = this->fConnect[in];
+		// find the index of the node in the destination (constrained) matrix
+		while(irnode < totalnodes && this->fConstrConnect[irnode] != idfn) irnode++;
+		
+		// first and last rows in the original matrix
+		int64_t ifirst = this->fBlock.Position(in);
+		int64_t ilast = ifirst+this->fBlock.Size(in);
+		
+		// first and last rows in the desination (reception) matrix
+		int64_t irfirst = this->fConstrBlock.Position(irnode);
+		//	   int irlast = irfirst+this->fConstrBlock->Size(irnode);
+		
+		int64_t i,ir,ieq;
+		if (this->fType == TPZElementMatrix::EF){
+			for(i=ifirst,ir=irfirst;i<ilast;i++,ir++) {
+				for(ieq=0; ieq<nrhs; ieq++) {
+					(this->fConstrMat)(ir,ieq) = (this->fMat)(i,ieq);
+				}
+			}
+		}
+		else{
+			int jn;
+			for(jn=0; jn<numnod; jn++) {
+				int jrnode = 0;
+				int64_t jdfn = this->fConnect[jn];
+				// find the index of the node in the destination (constrained) matrix
+				while(jrnode < totalnodes && this->fConstrConnect[jrnode] != jdfn) jrnode++;
+				if(jrnode == totalnodes) {
+					LOGPZ_WARN(logger, "node not found in node list");
+				}
+				// first and last columns in the original matrix
+				int64_t jfirst = this->fBlock.Position(jn);
+				int64_t jlast = jfirst+this->fBlock.Size(jn);
+				// first and last columns in the desination (reception) matrix
+				int64_t jrfirst = this->fConstrBlock.Position(jrnode);
+				//int jrlast = irfirst+this->fConstrBlock->Size(jrnode);
+				int64_t j,jr;
+				for(i=ifirst,ir=irfirst;i<ilast; i++,ir++) {
+					for(j=jfirst,jr=jrfirst;j<jlast; j++,jr++) {
+						(this->fConstrMat)(ir,jr) = (this->fMat)(i,j);
+					}
+				}
+			}
+		}//else
+	}
+	
+	int numnodes_processed = 0;
+	int current_order = 0;
+	while(numnodes_processed < totalnodes) {
+		int in;
+		for(in=0; in<totalnodes; in++) {
+			int64_t dfnindex = this->fConstrConnect[in];
+			TPZConnect *dfn = &(fMesh->ConnectVec()[dfnindex]);
+			if(DependenceOrder[in] != current_order) continue;
+			
+			// only nodes which have dependency order equal to the
+			// current order are processed
+			numnodes_processed++;
+			
+			int64_t inpos = this->fConstrBlock.Position(in);
+			int64_t insize = this->fConstrBlock.Size(in);
+			// inpos : position of the dependent equation
+			// insize : number of equations processed
+			
+			// loop over the nodes from which dfn depends
+			TPZConnect::TPZDepend *dep = dfn->FirstDepend();
+			while(dep) {
+				int64_t depnodeindex = dep->fDepConnectIndex;
+				// look for the index where depnode is found
+				int depindex=0;
+				while(depindex < totalnodes && this->fConstrConnect[depindex] != depnodeindex) depindex++;
+				if(depindex == totalnodes) {
+					LOGPZ_WARN(logger,"node not found in node list");
+				}
+				
+				int64_t deppos = this->fConstrBlock.Position(depindex);
+				int64_t depsize = this->fConstrBlock.Size(depindex);
+				// deppos : position of the receiving equation
+				// depsize : number of receiving equations
+				
+				// process the rows of the constrained matrix
+				int64_t send;
+				int64_t receive;
+				int ieq;
+				STATE coef;
+				int idf;
+				int numstate = dfn->NState();
+				for(send=inpos; send<inpos+insize; send += numstate) {
+					for(receive=deppos; receive<deppos+depsize; receive += numstate) {
+						coef = dep->fDepMatrix((send-inpos)/numstate,(receive-deppos)/numstate);
+						if (this->fType == TPZElementMatrix::EK){
+							for(ieq=0; ieq<toteq; ieq++) for(idf=0; idf<numstate; idf++)  {
+								(this->fConstrMat)(receive+idf,ieq) += coef*(this->fConstrMat)(send+idf,ieq);
+							}
+						}//EK
+						else{
+							for(ieq=0; ieq<nrhs; ieq++) for(idf=0; idf<numstate; idf++) {
+								(this->fConstrMat)(receive+idf,ieq) += coef*(this->fConstrMat)(send+idf,ieq);
+							}
+						}//EF
+					}
+				}
+				
+				if (this->fType == TPZElementMatrix::EK){
+					for(send=inpos; send<inpos+insize; send += numstate) {
+						for(receive=deppos; receive<deppos+depsize; receive += numstate) {
+							coef = dep->fDepMatrix((send-inpos)/numstate,(receive-deppos)/numstate);
+							for(ieq=0; ieq<toteq; ieq++) for(idf=0; idf<numstate; idf++) {
+								(this->fConstrMat)(ieq,receive+idf) += coef*(this->fConstrMat)(ieq,send+idf);
+							}
+						}
+					}
+				}//EK
+				
+				dep = dep->fNext;
+			} // end of while
+            
+            /// check whether the connect has a one shape restraint
+            if (fOneRestraints.size())
+            {
+                ApplyOneShapeConstraints(in);
+            }
+            
+            
+		} // end of loop over all nodes
+		current_order++;
+	} // end of while loop
+}//void
+
+template<class TVar>
+void TPZElementMatrixT<TVar>::ApplyOneShapeConstraints(int constraintindex)
+{
+    int64_t dfnindex = this->fConstrConnect[constraintindex];
+
+
+#ifdef PZ_LOG
+    int count = 0;
+    for (std::list<TPZOneShapeRestraint>::iterator it = fOneRestraints.begin(); it != fOneRestraints.end(); it++) {
+        if (it->fFaces[0].first != dfnindex) {
+            continue;
+        }
+        count++;
+    }
+    if (count && logger.isDebugEnabled()) {
+        std::stringstream sout;
+        sout << "Element matrix before ApplyOneShapeConstraint\n";
+        fConstrMat.Print("EKBefore = ",sout,EMathematicaInput);
+        LOGPZ_DEBUG(logger, sout.str())
+    }
+#endif
+    int64_t inpos = this->fConstrBlock.Position(constraintindex);
+    int64_t toteq = this->fConstrMat.Rows();
+    int64_t nrhs = this->fConstrMat.Cols();
+
+    for (std::list<TPZOneShapeRestraint>::iterator it = fOneRestraints.begin(); it != fOneRestraints.end(); it++) {
+        if (it->fFaces[0].first != dfnindex) {
+            continue;
+        }
+        int64_t send = inpos+it->fFaces[0].second;
+        for (int id=1; id<4; id++) {
+            int64_t depindex = it->fFaces[id].first;
+            int locdep = 0;
+            for (locdep = 0; locdep < fConstrConnect.size(); locdep++) {
+                if (fConstrConnect[locdep] == depindex) {
+                    break;
+                }
+            }
+            if (locdep == fConstrConnect.size()) {
+                DebugStop();
+            }
+            int64_t deppos = this->fConstrBlock.Position(locdep);
+            int64_t receive = deppos+it->fFaces[id].second;
+            REAL coef = -it->fOrient[id]/it->fOrient[0];
+            if (this->fType == TPZElementMatrix::EK){
+                for(int ieq=0; ieq<toteq; ieq++) {
+                    (this->fConstrMat)(receive,ieq) += coef*(this->fConstrMat)(send,ieq);
+                }
+            }//EK
+            else
+            {
+                
+                for(int ieq=0; ieq<nrhs; ieq++) {
+                    (this->fConstrMat)(receive,ieq) += coef*(this->fConstrMat)(send,ieq);
+                }
+            }//EF
+
+            if (this->fType == TPZElementMatrix::EK){
+                for(int ieq=0; ieq<toteq; ieq++)
+                {
+                    (this->fConstrMat)(ieq,receive) += coef*(this->fConstrMat)(ieq,send);
+                }
+            }//EK
+
+        }
+        if (this->fType == TPZElementMatrix::EK){
+            for(int ieq=0; ieq<toteq; ieq++)
+            {
+                (this->fConstrMat)(ieq,send) = 0.;
+                (this->fConstrMat)(send,ieq) = 0.;
+            }
+            (this->fConstrMat)(send,send) = 1.;
+        }//EK
+        else
+        {
+            for(int ieq=0; ieq<nrhs; ieq++) {
+                (this->fConstrMat)(send,ieq) = 0.;
+            }
+        }
+
+    }
+#ifdef PZ_LOG
+    if (count && logger.isDebugEnabled()) {
+        std::stringstream sout;
+        sout << "Element matrix after ApplyOneShapeConstraint\n";
+        fConstrMat.Print("EKAfter = ",sout,EMathematicaInput);
+        LOGPZ_DEBUG(logger, sout.str())
+    }
+#endif
+}
+
+
+template<class TVar>
+void TPZElementMatrixT<TVar>::PermuteGather(TPZVec<int64_t> &permute)
+{
+    if (permute.size() != fConnect.size()) {
+        DebugStop();
+    }
+    TPZElementMatrixT<TVar> cp(*this);
+    for (int64_t i=0; i<fConnect.size(); ++i) {
+        fConnect[i] = cp.fConnect[permute[i]];
+        fBlock.Set(i, cp.fBlock.Size(permute[i]));
+    }
+    fBlock.Resequence();
+#ifdef PZ_LOG2
+    if (logger.isDebugEnabled()) {
+        std::stringstream sout;
+        cp.fBlock.Print("cp.fBlock ",sout);
+        fBlock.Print("fBlock ",sout);
+        LOGPZ_DEBUG(logger, sout.str())
+    }
+#endif
+    if (fType == EK) {
+        int64_t ibl,jbl;
+        for (ibl=0; ibl<fBlock.NBlocks(); ++ibl) {
+            int64_t iblsize = fBlock.Size(ibl);
+            for (jbl=0; jbl<fBlock.NBlocks(); ++jbl) {
+                int64_t jblsize = fBlock.Size(jbl);
+                for (int64_t idf=0; idf<iblsize; ++idf) {
+                    for (int64_t jdf=0; jdf<jblsize; ++jdf) {
+                        fMat.at(fBlock.at(ibl,jbl,idf,jdf)) = cp.fMat.at(cp.fBlock.at(permute[ibl],permute[jbl],idf,jdf));
+                    }
+                }
+            }
+        }
+    }
+    else if (fType == EF)
+    {
+        int64_t ibl;
+        for (ibl=0; ibl<fBlock.NBlocks(); ++ibl) {
+            int64_t iblsize = fBlock.Size(ibl);
+            int64_t jblsize = fMat.Cols();
+            for (int64_t idf=0; idf<iblsize; ++idf) {
+                for (int64_t jdf=0; jdf<jblsize; ++jdf) {
+                    fMat.at(fBlock.at(ibl,0,idf,jdf)) = cp.fMat.at(cp.fBlock.at(permute[ibl],0,idf,jdf));
+                }
+            }
+        }
+    }
+}
+
+template class TPZElementMatrixT<STATE>;

--- a/Mesh/TPZElementMatrixT.cpp
+++ b/Mesh/TPZElementMatrixT.cpp
@@ -53,7 +53,7 @@ void TPZElementMatrixT<TVar>::Print(std::ostream &out){
 		bool hasdepend = HasDependency();
 		int64_t size = fSourceIndex.NElements();
 		//TPZFMatrix<REAL> constrmatrix(size,size,0.);
-		TPZFNMatrix<400,STATE> constrmatrix(size,size,0.);
+		TPZFNMatrix<400,TVar> constrmatrix(size,size,0.);
 		int64_t in,jn;
 		for(in=0; in<size; in++)
 		{
@@ -82,7 +82,7 @@ void TPZElementMatrixT<TVar>::Print(std::ostream &out){
 		bool hasdepend = HasDependency();
 		int64_t size = fSourceIndex.NElements();
 		//TPZFMatrix<REAL> constrmatrix(size,size,0.);
-		TPZFMatrix<STATE> constrmatrix(size,fMat.Cols(),0.);
+		TPZFMatrix<TVar> constrmatrix(size,fMat.Cols(),0.);
 		int64_t in,jn;
 		for(in=0; in<size; in++)
 		{

--- a/Mesh/TPZElementMatrixT.cpp
+++ b/Mesh/TPZElementMatrixT.cpp
@@ -474,3 +474,4 @@ void TPZElementMatrixT<TVar>::PermuteGather(TPZVec<int64_t> &permute)
 }
 
 template class TPZElementMatrixT<STATE>;
+template class TPZElementMatrixT<CSTATE>;

--- a/Mesh/TPZElementMatrixT.h
+++ b/Mesh/TPZElementMatrixT.h
@@ -89,4 +89,5 @@ struct TPZElementMatrixT : public TPZElementMatrix {
 };
 
 extern template class TPZElementMatrixT<STATE>;
+extern template class TPZElementMatrixT<CSTATE>;
 #endif

--- a/Mesh/TPZElementMatrixT.h
+++ b/Mesh/TPZElementMatrixT.h
@@ -1,0 +1,92 @@
+/**
+ * @file
+ * @brief Contains declaration of TPZElementMatrixT struct which associates an element matrix with the coeficients of its contribution in the global stiffness matrix.
+ */
+
+#ifndef TPZELEMENTMATRIXT_H
+#define TPZELEMENTMATRIXT_H
+
+#include "pzelmat.h"
+
+template<class TVar>
+struct TPZElementMatrixT : public TPZElementMatrix {
+	void Reset(TPZCompMesh *mesh = NULL, MType type=Unknown)
+	{
+      TPZElementMatrix::Reset(mesh,type);
+      fBlock.SetNBlocks(0);
+      fConstrBlock.SetNBlocks(0);
+      fMat.Resize(0,0);
+      fConstrMat.Resize(0,0);
+    }
+	
+	TPZElementMatrixT(TPZCompMesh *mesh, MType type) :
+        TPZElementMatrix(mesh,type),
+        fMat(0,0), fBlock(),
+        fConstrMat(0,0), fConstrBlock()
+    {
+        fBlock.SetMatrix(&fMat);
+        fConstrBlock.SetMatrix(&fConstrMat);
+    }
+
+    TPZElementMatrixT() :
+        TPZElementMatrix(), fMat(0,0), fConstrMat(0,0),
+        fBlock(&fMat), fConstrBlock(&fConstrMat)
+    {
+    }
+    
+    TPZElementMatrixT &operator=(const TPZElementMatrixT &copy);
+	
+    TPZElementMatrixT(const TPZElementMatrixT &copy);
+    
+	void Print(std::ostream &out) override;
+	
+	void SetMatrixSize(short NumBli, short NumBlj,
+                       short BlSizei, short BlSizej) override;
+	
+	void SetMatrixMinSize(short NumBli, short NumBlj,
+                          short BlMinSizei, short BlMinSizej) override;
+
+    /** @brief permute the order of the connects */
+    void PermuteGather(TPZVec<int64_t> &permute) override;
+	/** @brief Apply the constraints applied to the nodes by transforming the tangent matrix and right hand side */
+	void ApplyConstraints() override;
+    
+    /// Apply the constraint of the one shape restraints
+    void ApplyOneShapeConstraints(int constraintindex) override;
+
+    TVar &at(int64_t ibl, int64_t jbl, int idf, int jdf)
+    {
+        return fMat.at(fBlock.at(ibl,jbl,idf,jdf));
+    }
+    TVar &at(int64_t ibl, int idf)
+    {
+        return fMat(fBlock.Index(ibl,idf));
+    }
+
+    TPZFMatrix<TVar> & Matrix() override{
+        return fMat;
+    }
+
+    TPZFMatrix<TVar> & ConstrMatrix() override{
+        return fConstrMat;
+    }
+
+    TPZBlock & Block() override{
+        return fBlock;
+    }
+
+    TPZBlock & ConstrBlock() override{
+        return fConstrBlock;
+    }
+    /** @brief Pointer to a blocked matrix object*/
+	TPZFNMatrix<1000, TVar> fMat;
+    /** @brief Block structure associated with fMat*/
+	TPZBlock fBlock;
+	/** @brief Pointer to the constrained matrix object*/
+	TPZFNMatrix<1000, TVar> fConstrMat;
+    /** @brief Block structure associated with fConstrMat*/
+	TPZBlock fConstrBlock;
+};
+
+extern template class TPZElementMatrixT<STATE>;
+#endif

--- a/Mesh/TPZInterfaceEl.cpp
+++ b/Mesh/TPZInterfaceEl.cpp
@@ -3,7 +3,7 @@
  * @brief Contains the implementation of the TPZInterfaceElement methods.
  */
 
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "TPZInterfaceEl.h"
 #include "TPZCompElDisc.h"
 #include "pzgeoelside.h"
@@ -290,7 +290,10 @@ TPZCompEl * TPZInterfaceElement::CloneInterface(TPZCompMesh &aggmesh,int64_t &in
 	return  new TPZInterfaceElement(aggmesh, this->Reference(), index, left, right);
 }
 
-void TPZInterfaceElement::CalcResidual(TPZElementMatrix &ef){
+void TPZInterfaceElement::CalcResidual(TPZElementMatrix &efb){
+    //TODOCOMPLEX
+	auto &ef =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
 	TPZMaterial *mat = Material();
 	
 #ifdef PZDEBUG
@@ -877,8 +880,8 @@ void TPZInterfaceElement::InitializeElementMatrix(TPZElementMatrix &ef){
 	const int neqr = nshaper * nstater;
 	const int neq = neql + neqr;
     const int numloadcases = mat->NumLoadCases();
-	ef.fMat.Redim(neq,numloadcases);
-	ef.fBlock.SetNBlocks(ncon);
+	ef.Matrix().Redim(neq,numloadcases);
+	ef.Block().SetNBlocks(ncon);
 	ef.fConnect.Resize(ncon);
 	
 	int64_t ic = 0;
@@ -893,7 +896,7 @@ void TPZInterfaceElement::InitializeElementMatrix(TPZElementMatrix &ef){
             DebugStop();
         }
 #endif
-		ef.fBlock.Set(ic,con_neq);
+		ef.Block().Set(ic,con_neq);
 		(ef.fConnect)[ic] = ConnectIndexL[i];
 		ic++;
 	}
@@ -908,11 +911,11 @@ void TPZInterfaceElement::InitializeElementMatrix(TPZElementMatrix &ef){
         }
 #endif
         
-		ef.fBlock.Set(ic,con_neq);
+		ef.Block().Set(ic,con_neq);
 		(ef.fConnect)[ic] = ConnectIndexR[i];
 		ic++;
 	}
-	ef.fBlock.Resequence();
+	ef.Block().Resequence();
 	
 }
 
@@ -960,10 +963,10 @@ void TPZInterfaceElement::InitializeElementMatrix(TPZElementMatrix &ek, TPZEleme
 	const int neqr = nshaper * nstater;
 	const int neq = neql + neqr;
     const int numloadcases = mat->NumLoadCases();
-	ek.fMat.Redim(neq,neq);
-	ef.fMat.Redim(neq,numloadcases);
-	ek.fBlock.SetNBlocks(ncon);
-	ef.fBlock.SetNBlocks(ncon);
+	ek.Matrix().Redim(neq,neq);
+	ef.Matrix().Redim(neq,numloadcases);
+	ek.Block().SetNBlocks(ncon);
+	ef.Block().SetNBlocks(ncon);
 	ek.fConnect.Resize(ncon);
 	ef.fConnect.Resize(ncon);
 	
@@ -983,8 +986,8 @@ void TPZInterfaceElement::InitializeElementMatrix(TPZElementMatrix &ek, TPZEleme
             DebugStop();
         }
 #endif
-		ek.fBlock.Set(ic,con_neq );
-		ef.fBlock.Set(ic,con_neq);
+		ek.Block().Set(ic,con_neq );
+		ef.Block().Set(ic,con_neq);
 		(ef.fConnect)[ic] = ConnectIndexL[i];
 		(ek.fConnect)[ic] = ConnectIndexL[i];
 #ifdef PZDEBUG
@@ -1010,8 +1013,8 @@ void TPZInterfaceElement::InitializeElementMatrix(TPZElementMatrix &ek, TPZEleme
             DebugStop();
         }
 #endif
-		ek.fBlock.Set(ic,con_neq );
-		ef.fBlock.Set(ic,con_neq);
+		ek.Block().Set(ic,con_neq );
+		ef.Block().Set(ic,con_neq);
 		(ef.fConnect)[ic] = ConnectIndexR[i];
 		(ek.fConnect)[ic] = ConnectIndexR[i];
 #ifdef PZDEBUG
@@ -1038,12 +1041,17 @@ void TPZInterfaceElement::InitializeElementMatrix(TPZElementMatrix &ek, TPZEleme
 	}
 #endif
 #endif
-	ek.fBlock.Resequence();
-	ef.fBlock.Resequence();
+	ek.Block().Resequence();
+	ef.Block().Resequence();
 }
 
-void TPZInterfaceElement::CalcStiff(TPZElementMatrix &ek, TPZElementMatrix &ef){
-	
+void TPZInterfaceElement::CalcStiff(TPZElementMatrix &ekb, TPZElementMatrix &efb){
+    //TODOCOMPLEX
+    //TODOCOMPLEX
+	auto &ek =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
+	auto &ef =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
 #ifdef PZ_LOG
     if (logger.isDebugEnabled())
 	{

--- a/Mesh/TPZInterfaceEl.cpp
+++ b/Mesh/TPZInterfaceEl.cpp
@@ -290,10 +290,8 @@ TPZCompEl * TPZInterfaceElement::CloneInterface(TPZCompMesh &aggmesh,int64_t &in
 	return  new TPZInterfaceElement(aggmesh, this->Reference(), index, left, right);
 }
 
-void TPZInterfaceElement::CalcResidual(TPZElementMatrix &efb){
-    //TODOCOMPLEX
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
+template<class TVar>
+void TPZInterfaceElement::CalcResidualInternal(TPZElementMatrixT<TVar> &ef){
 	TPZMaterial *mat = Material();
 	
 #ifdef PZDEBUG
@@ -1045,13 +1043,8 @@ void TPZInterfaceElement::InitializeElementMatrix(TPZElementMatrix &ek, TPZEleme
 	ef.Block().Resequence();
 }
 
-void TPZInterfaceElement::CalcStiff(TPZElementMatrix &ekb, TPZElementMatrix &efb){
-    //TODOCOMPLEX
-    //TODOCOMPLEX
-	auto &ek =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
+template<class TVar>
+void TPZInterfaceElement::CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef){
 #ifdef PZ_LOG
     if (logger.isDebugEnabled())
 	{

--- a/Mesh/TPZInterfaceEl.h
+++ b/Mesh/TPZInterfaceEl.h
@@ -88,7 +88,6 @@ public:
 	 */
 	void NeighbourSolution(TPZCompElSide & Neighbor, TPZVec<REAL> & qsi, TPZSolVec &sol, TPZGradSolVec &dsol, TPZFMatrix<REAL> &NeighborAxes);
 	
-protected:
 	
 	/**
 	 * @brief Check consistency of mapped qsi performed by method TPZInterfaceElement::MapQsi by
@@ -110,6 +109,11 @@ protected:
 	/** @brief Computes normal for linear geometric elements. */
 	/** For linear geometry the normal vector is constant. */
 	void ComputeCenterNormal(TPZVec<REAL> &normal);
+
+	template<class TVar>
+    void CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef);
+    template<class TVar>
+    void CalcResidualInternal(TPZElementMatrixT<TVar> &ef);
 	
 public:
 	
@@ -257,13 +261,17 @@ public:
 	 * @param ek element matrix
 	 * @param ef element right hand side
 	 */
-	virtual void CalcStiff(TPZElementMatrix &ek, TPZElementMatrix &ef) override;
+	virtual void CalcStiff(TPZElementMatrixT<STATE> &ek, TPZElementMatrixT<STATE> &ef) override{
+		CalcStiffInternal<STATE>(ek,ef);
+	}
 	
 	/**
 	 * @brief CalcResidual only computes the element residual
 	 * @param ef element residual
 	 */
-	virtual void CalcResidual(TPZElementMatrix &ef) override;
+	virtual void CalcResidual(TPZElementMatrixT<STATE> &ef) override{
+		CalcResidualInternal<STATE>(ef);
+	}
 	
 	/**
 	 * @brief Computes solution and its derivatives in the local coordinate qsi.

--- a/Mesh/TPZMultiphysicsCompMesh.cpp
+++ b/Mesh/TPZMultiphysicsCompMesh.cpp
@@ -376,6 +376,20 @@ void TPZMultiphysicsCompMesh::AddConnects(){
 
 void TPZMultiphysicsCompMesh::LoadSolutionFromMeshes()
 {
+    if(fSolType == EReal){
+        return LoadSolutionFromMeshesInternal<STATE>();
+    }
+    if(fSolType == EComplex){
+        return LoadSolutionFromMeshesInternal<CSTATE>();
+    }
+    PZError<<__PRETTY_FUNCTION__<<'\n';
+    PZError<<"Invalid type! Aborting...\n";
+    DebugStop();
+}
+
+template<class TVar>
+void TPZMultiphysicsCompMesh::LoadSolutionFromMeshesInternal()
+{
     int n_approx_spaces = m_active_approx_spaces.size();
     TPZManVector<int64_t> FirstConnectIndex(n_approx_spaces+1,0);
     for (int i_as = 0; i_as < n_approx_spaces; i_as++) {
@@ -385,7 +399,7 @@ void TPZMultiphysicsCompMesh::LoadSolutionFromMeshes()
         FirstConnectIndex[i_as+1] = FirstConnectIndex[i_as]+m_mesh_vector[i_as]->NConnects();
     }
     TPZBlock &blockMF = Block();
-    TPZFMatrix<STATE> &solMF = Solution();
+    TPZFMatrix<TVar> &solMF = Solution();
     for (int i_as = 0; i_as < n_approx_spaces; i_as++) {
         
         if (m_active_approx_spaces[i_as] == 0) {
@@ -394,7 +408,7 @@ void TPZMultiphysicsCompMesh::LoadSolutionFromMeshes()
         
         int64_t ncon = m_mesh_vector[i_as]->NConnects();
         TPZBlock &block = m_mesh_vector[i_as]->Block();
-        TPZFMatrix<STATE> &sol = m_mesh_vector[i_as]->Solution();
+        TPZFMatrix<TVar> &sol = m_mesh_vector[i_as]->Solution();
         int64_t ic;
         for (ic=0; ic<ncon; ic++) {
             TPZConnect &con = m_mesh_vector[i_as]->ConnectVec()[ic];
@@ -413,6 +427,20 @@ void TPZMultiphysicsCompMesh::LoadSolutionFromMeshes()
 
 void TPZMultiphysicsCompMesh::LoadSolutionFromMultiPhysics()
 {
+    if(fSolType == EReal){
+        return LoadSolutionFromMultiPhysicsInternal<STATE>();
+    }
+    if(fSolType == EComplex){
+        return LoadSolutionFromMultiPhysicsInternal<CSTATE>();
+    }
+    PZError<<__PRETTY_FUNCTION__<<'\n';
+    PZError<<"Invalid type! Aborting...\n";
+    DebugStop();
+}
+
+template<class TVar>
+void TPZMultiphysicsCompMesh::LoadSolutionFromMultiPhysicsInternal()
+{
     int n_approx_spaces = m_active_approx_spaces.size();
     TPZManVector<int64_t> FirstConnectIndex(n_approx_spaces+1,0);
     for (int i_as = 0; i_as < n_approx_spaces; i_as++) {
@@ -422,7 +450,7 @@ void TPZMultiphysicsCompMesh::LoadSolutionFromMultiPhysics()
         FirstConnectIndex[i_as+1] = FirstConnectIndex[i_as]+m_mesh_vector[i_as]->NConnects();
     }
     TPZBlock &blockMF = Block();
-    TPZFMatrix<STATE> &solMF = Solution();
+    TPZFMatrix<TVar> &solMF = Solution();
     for (int i_as = 0; i_as < n_approx_spaces; i_as++) {
         
         if (m_active_approx_spaces[i_as] == 0) {
@@ -431,7 +459,7 @@ void TPZMultiphysicsCompMesh::LoadSolutionFromMultiPhysics()
         
         int64_t ncon = m_mesh_vector[i_as]->NConnects();
         TPZBlock &block = m_mesh_vector[i_as]->Block();
-        TPZFMatrix<STATE> &sol = m_mesh_vector[i_as]->Solution();
+        TPZFMatrix<TVar> &sol = m_mesh_vector[i_as]->Solution();
         int64_t ic;
         for (ic=0; ic<ncon; ic++) {
             TPZConnect &con = m_mesh_vector[i_as]->ConnectVec()[ic];

--- a/Mesh/TPZMultiphysicsCompMesh.h
+++ b/Mesh/TPZMultiphysicsCompMesh.h
@@ -77,6 +77,11 @@ private:
     
     /// delete the elements and connects
     void CleanElementsConnects();
+
+    template<class TVar>
+    void LoadSolutionFromMeshesInternal();
+    template<class TVar>
+    void LoadSolutionFromMultiPhysicsInternal();
 };
 
 #endif /* TPZMultiphysicsCompMesh_h */

--- a/Mesh/TPZMultiphysicsInterfaceEl.cpp
+++ b/Mesh/TPZMultiphysicsInterfaceEl.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "TPZMultiphysicsInterfaceEl.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "pzinterpolationspace.h"
 #include "TPZMaterial.h"
 #include "pzmultiphysicselement.h"
@@ -324,8 +324,13 @@ int64_t TPZMultiphysicsInterfaceElement::ConnectIndex(int i) const
 
 
 #include "pzmultiphysicscompel.h"
-void TPZMultiphysicsInterfaceElement::CalcStiff(TPZElementMatrix &ek, TPZElementMatrix &ef)
+void TPZMultiphysicsInterfaceElement::CalcStiff(TPZElementMatrix &ekb, TPZElementMatrix &efb)
 {
+    //TODOCOMPLEX
+    auto &ek =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
+	auto &ef =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
    TPZMaterial *material = this->Material();
 	
 	if(!material){
@@ -420,8 +425,11 @@ void TPZMultiphysicsInterfaceElement::CalcStiff(TPZElementMatrix &ek, TPZElement
 	
 }//CalcStiff
 
-void TPZMultiphysicsInterfaceElement::CalcStiff(TPZElementMatrix &ef)
+void TPZMultiphysicsInterfaceElement::CalcStiff(TPZElementMatrix &efb)
 {
+    //TODOCOMPLEX
+	auto &ef =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     TPZMaterial  * material = this->Material();
     if(!material){
         PZError << "Error at " << __PRETTY_FUNCTION__ << " this->Material() == NULL\n";
@@ -595,10 +603,10 @@ void TPZMultiphysicsInterfaceElement::InitializeElementMatrix(TPZElementMatrix &
     int nstate = mat->NStateVariables();
     numloadcases = mat->NumLoadCases();        
 	
-	ek.fMat.Redim(numeq,numeq);
-	ef.fMat.Redim(numeq,numloadcases);
-	ek.fBlock.SetNBlocks(ncon);
-	ef.fBlock.SetNBlocks(ncon);
+	ek.Matrix().Redim(numeq,numeq);
+	ef.Matrix().Redim(numeq,numloadcases);
+	ek.Block().SetNBlocks(ncon);
+	ef.Block().SetNBlocks(ncon);
 	
 	int i;
 	for(i=0; i<ncon; i++)
@@ -610,8 +618,8 @@ void TPZMultiphysicsInterfaceElement::InitializeElementMatrix(TPZElementMatrix &
             DebugStop();
         }
 #endif
-		ek.fBlock.Set(i,ndof);
-		ef.fBlock.Set(i,ndof);
+		ek.Block().Set(i,ndof);
+		ef.Block().Set(i,ndof);
 	}
 	ek.fConnect.Resize(ncon);
 	ef.fConnect.Resize(ncon);
@@ -652,8 +660,8 @@ void TPZMultiphysicsInterfaceElement::InitializeElementMatrix(TPZElementMatrix &
     int nstate = mat->NStateVariables();
     numloadcases = mat->NumLoadCases();
     
-    ef.fMat.Redim(numeq,numloadcases);
-    ef.fBlock.SetNBlocks(ncon);
+    ef.Matrix().Redim(numeq,numloadcases);
+    ef.Block().SetNBlocks(ncon);
     
     int i;
     for(i=0; i<ncon; i++)
@@ -665,7 +673,7 @@ void TPZMultiphysicsInterfaceElement::InitializeElementMatrix(TPZElementMatrix &
             DebugStop();
         }
 #endif
-        ef.fBlock.Set(i,ndof);
+        ef.Block().Set(i,ndof);
     }
     ef.fConnect.Resize(ncon);
     for(i=0; i<ncon; i++){

--- a/Mesh/TPZMultiphysicsInterfaceEl.cpp
+++ b/Mesh/TPZMultiphysicsInterfaceEl.cpp
@@ -324,13 +324,10 @@ int64_t TPZMultiphysicsInterfaceElement::ConnectIndex(int i) const
 
 
 #include "pzmultiphysicscompel.h"
-void TPZMultiphysicsInterfaceElement::CalcStiff(TPZElementMatrix &ekb, TPZElementMatrix &efb)
+template<class TVar>
+void TPZMultiphysicsInterfaceElement::CalcStiffInternal(TPZElementMatrixT<TVar> &ek,
+                                                        TPZElementMatrixT<TVar> &ef)
 {
-    //TODOCOMPLEX
-    auto &ek =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
    TPZMaterial *material = this->Material();
 	
 	if(!material){
@@ -425,11 +422,9 @@ void TPZMultiphysicsInterfaceElement::CalcStiff(TPZElementMatrix &ekb, TPZElemen
 	
 }//CalcStiff
 
-void TPZMultiphysicsInterfaceElement::CalcStiff(TPZElementMatrix &efb)
+template<class TVar>
+void TPZMultiphysicsInterfaceElement::CalcStiffInternal(TPZElementMatrixT<TVar> &ef)
 {
-    //TODOCOMPLEX
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     TPZMaterial  * material = this->Material();
     if(!material){
         PZError << "Error at " << __PRETTY_FUNCTION__ << " this->Material() == NULL\n";

--- a/Mesh/TPZMultiphysicsInterfaceEl.h
+++ b/Mesh/TPZMultiphysicsInterfaceEl.h
@@ -21,6 +21,10 @@
 class TPZMultiphysicsInterfaceElement : public TPZCompEl {
 
 protected:
+    template<class TVar>
+    void CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef);
+    template<class TVar>
+    void CalcStiffInternal(TPZElementMatrixT<TVar> &ef);
 
 	/** @brief Element vector the left of the normal a interface */
 	TPZCompElSide 	fLeftElSide;
@@ -153,12 +157,18 @@ public:
     /**
      * Compute the stiffness matrix and load vector of the interface element
      */
-    void CalcStiff(TPZElementMatrix &ek, TPZElementMatrix &ef) override;
+    void CalcStiff(TPZElementMatrixT<STATE> &ek,
+                   TPZElementMatrixT<STATE> &ef) override
+    {
+        CalcStiffInternal(ek,ef);
+    }
     
     /**
      * Compute the load vector of the interface element
      */
-    void CalcStiff(TPZElementMatrix &ef);
+    void CalcStiff(TPZElementMatrixT<STATE> &ef){
+        CalcStiffInternal(ef);
+    }
 
     /**
      * Return max integration rule of this interface element

--- a/Mesh/TPZSBFemElementGroup.cpp
+++ b/Mesh/TPZSBFemElementGroup.cpp
@@ -612,12 +612,8 @@ void TPZSBFemElementGroup::CalcStiffBlaze(TPZElementMatrix &ek,TPZElementMatrix 
 #endif
 }
 
-void TPZSBFemElementGroup::CalcStiff(TPZElementMatrix &ekb,TPZElementMatrix &efb)
+void TPZSBFemElementGroup::CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef)
 {
-    auto &ek =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
 
 #ifdef USING_BLAZE
     CalcStiffBlaze(ek,ef);

--- a/Mesh/TPZSBFemElementGroup.cpp
+++ b/Mesh/TPZSBFemElementGroup.cpp
@@ -66,16 +66,8 @@ int TPZSBFemElementGroup::gDefaultPolynomialOrder = 0;
  * @param ek element stiffness matrix
  * @param ef element load vector
  */
-void TPZSBFemElementGroup::ComputeMatrices(TPZElementMatrix &E0b, TPZElementMatrix &E1b, TPZElementMatrix &E2b, TPZElementMatrix &M0b)
+void TPZSBFemElementGroup::ComputeMatrices(TPZElementMatrixT<STATE> &E0, TPZElementMatrixT<STATE> &E1, TPZElementMatrixT<STATE> &E2, TPZElementMatrixT<STATE> &M0)
 {
-    auto &E0 =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(E0b);
-	auto &E1 =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(E1b);
-    auto &E2 =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(E2b);
-	auto &M0 =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(M0b);
     std::map<int64_t,int64_t> locindex;
     int64_t ncon = fConnectIndexes.size();
     for (int64_t ic=0; ic<ncon ; ic++) {
@@ -178,7 +170,7 @@ void TPZSBFemElementGroup::ComputeMatrices(TPZElementMatrix &E0b, TPZElementMatr
     }
 }
 
-void TPZSBFemElementGroup::CalcStiffBlaze(TPZElementMatrix &ek,TPZElementMatrix &ef)
+void TPZSBFemElementGroup::CalcStiffBlaze(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef)
 {
 #ifdef USING_BLAZE
     InitializeElementMatrix(ek, ef);
@@ -189,7 +181,7 @@ void TPZSBFemElementGroup::CalcStiffBlaze(TPZElementMatrix &ek,TPZElementMatrix 
         ef.fMat.Zero();
         return;
     }
-    TPZElementMatrix E0, E1, E2, M0;
+    TPZElementMatrixT<STATE> E0, E1, E2, M0;
     ComputeMatrices(E0, E1, E2, M0);
 
 #ifdef PZ_LOG
@@ -1165,10 +1157,8 @@ void TPZSBFemElementGroup::LoadSolution()
 }
 
 /// Compute the mass matrix based on the value of M0 and the eigenvectors
-void TPZSBFemElementGroup::ComputeMassMatrix(TPZElementMatrix &M0b)
+void TPZSBFemElementGroup::ComputeMassMatrix(TPZElementMatrixT<STATE> &M0)
 {
-    auto &M0 =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(M0b);
     //    M0.fMat.Print("Mass = ",std::cout,EMathematicaInput);
     TPZFMatrix<std::complex<double> > temp;
     REAL alpha = 1.;

--- a/Mesh/TPZSBFemElementGroup.cpp
+++ b/Mesh/TPZSBFemElementGroup.cpp
@@ -66,15 +66,23 @@ int TPZSBFemElementGroup::gDefaultPolynomialOrder = 0;
  * @param ek element stiffness matrix
  * @param ef element load vector
  */
-void TPZSBFemElementGroup::ComputeMatrices(TPZElementMatrix &E0, TPZElementMatrix &E1, TPZElementMatrix &E2, TPZElementMatrix &M0)
+void TPZSBFemElementGroup::ComputeMatrices(TPZElementMatrix &E0b, TPZElementMatrix &E1b, TPZElementMatrix &E2b, TPZElementMatrix &M0b)
 {
+    auto &E0 =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(E0b);
+	auto &E1 =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(E1b);
+    auto &E2 =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(E2b);
+	auto &M0 =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(M0b);
     std::map<int64_t,int64_t> locindex;
     int64_t ncon = fConnectIndexes.size();
     for (int64_t ic=0; ic<ncon ; ic++) {
         locindex[fConnectIndexes[ic]] = ic;
     }
 
-    TPZElementMatrix ef(Mesh(),TPZElementMatrix::EF);
+    TPZElementMatrixT<STATE> ef(Mesh(),TPZElementMatrix::EF);
     int64_t nel = fElGroup.size();
     InitializeElementMatrix(E0, ef);
     InitializeElementMatrix(E1, ef);
@@ -102,10 +110,10 @@ void TPZSBFemElementGroup::ComputeMatrices(TPZElementMatrix &E0, TPZElementMatri
             DebugStop();
         }
 #endif
-        TPZElementMatrix E0Loc(Mesh(),TPZElementMatrix::EK);
-        TPZElementMatrix E1Loc(Mesh(),TPZElementMatrix::EK);
-        TPZElementMatrix E2Loc(Mesh(),TPZElementMatrix::EK);
-        TPZElementMatrix M0Loc(Mesh(),TPZElementMatrix::EK);
+        TPZElementMatrixT<STATE>E0Loc(Mesh(),TPZElementMatrix::EK);
+        TPZElementMatrixT<STATE>E1Loc(Mesh(),TPZElementMatrix::EK);
+        TPZElementMatrixT<STATE>E2Loc(Mesh(),TPZElementMatrix::EK);
+        TPZElementMatrixT<STATE>M0Loc(Mesh(),TPZElementMatrix::EK);
         sbfem->ComputeKMatrices(E0Loc, E1Loc, E2Loc,M0Loc);
         
 #ifdef PZ_LOG
@@ -604,8 +612,12 @@ void TPZSBFemElementGroup::CalcStiffBlaze(TPZElementMatrix &ek,TPZElementMatrix 
 #endif
 }
 
-void TPZSBFemElementGroup::CalcStiff(TPZElementMatrix &ek,TPZElementMatrix &ef)
+void TPZSBFemElementGroup::CalcStiff(TPZElementMatrix &ekb,TPZElementMatrix &efb)
 {
+    auto &ek =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
+	auto &ef =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
 
 #ifdef USING_BLAZE
     CalcStiffBlaze(ek,ef);
@@ -620,7 +632,7 @@ void TPZSBFemElementGroup::CalcStiff(TPZElementMatrix &ek,TPZElementMatrix &ef)
         ef.fMat.Zero();
         return;
     }
-    TPZElementMatrix E0,E1,E2, M0;
+    TPZElementMatrixT<STATE> E0,E1,E2, M0;
     ComputeMatrices(E0, E1, E2, M0);
 
 #ifdef PZ_LOG
@@ -1157,8 +1169,10 @@ void TPZSBFemElementGroup::LoadSolution()
 }
 
 /// Compute the mass matrix based on the value of M0 and the eigenvectors
-void TPZSBFemElementGroup::ComputeMassMatrix(TPZElementMatrix &M0)
+void TPZSBFemElementGroup::ComputeMassMatrix(TPZElementMatrix &M0b)
 {
+    auto &M0 =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(M0b);
     //    M0.fMat.Print("Mass = ",std::cout,EMathematicaInput);
     TPZFMatrix<std::complex<double> > temp;
     REAL alpha = 1.;

--- a/Mesh/TPZSBFemElementGroup.h
+++ b/Mesh/TPZSBFemElementGroup.h
@@ -97,7 +97,7 @@ public:
      * @param ek element stiffness matrix
      * @param ef element load vector
      */
-    virtual void CalcStiff(TPZElementMatrix &ek,TPZElementMatrix &ef);
+    void CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef) override;
 
     void CalcStiffBlaze(TPZElementMatrix &ek,TPZElementMatrix &ef);
 
@@ -182,7 +182,7 @@ public:
      * @brief Computes the element right hand side
      * @param ef element load vector(s)
      */
-    virtual void CalcResidual(TPZElementMatrix &ef)
+    void CalcResidual(TPZElementMatrixT<STATE> &ef) override
     {
         TPZElementMatrixT<STATE> ek(Mesh(),TPZElementMatrix::EK);
         CalcStiff(ek,ef);

--- a/Mesh/TPZSBFemElementGroup.h
+++ b/Mesh/TPZSBFemElementGroup.h
@@ -10,7 +10,7 @@
 #define TPZSBFemElementGroup_hpp
 
 #include <stdio.h>
-
+#include "TPZElementMatrixT.h"
 #include "pzelementgroup.h"
 #include "TPZSBFemVolume.h"
 #include "pzcmesh.h"
@@ -184,7 +184,7 @@ public:
      */
     virtual void CalcResidual(TPZElementMatrix &ef)
     {
-        TPZElementMatrix ek(Mesh(),TPZElementMatrix::EK);
+        TPZElementMatrixT<STATE> ek(Mesh(),TPZElementMatrix::EK);
         CalcStiff(ek,ef);
     }
     

--- a/Mesh/TPZSBFemElementGroup.h
+++ b/Mesh/TPZSBFemElementGroup.h
@@ -58,7 +58,7 @@ private:
     REAL fDelt = 1.;
     
     /// Compute the mass matrix based on the value of M0 and the eigenvectors
-    void ComputeMassMatrix(TPZElementMatrix &M0);
+    void ComputeMassMatrix(TPZElementMatrixT<STATE>& M0);
 
     int fInternalPolynomialOrder = 0;
 
@@ -90,7 +90,7 @@ public:
 
     /// Compute the SBFem matrices
     /// method to assemble E0, E1, E2
-    void ComputeMatrices(TPZElementMatrix &E0, TPZElementMatrix &E1, TPZElementMatrix &E2, TPZElementMatrix &M0);
+    void ComputeMatrices(TPZElementMatrixT<STATE> &E0, TPZElementMatrixT<STATE> &E1, TPZElementMatrixT<STATE> &E2, TPZElementMatrixT<STATE> &M0);
     
     /**
      * @brief Computes the element stifness matrix and right hand side
@@ -99,7 +99,7 @@ public:
      */
     void CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef) override;
 
-    void CalcStiffBlaze(TPZElementMatrix &ek,TPZElementMatrix &ef);
+    void CalcStiffBlaze(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef);
 
     /// set the density or specific heat of the material
     void SetDensity(REAL density)

--- a/Mesh/TPZSBFemVolume.cpp
+++ b/Mesh/TPZSBFemVolume.cpp
@@ -34,10 +34,18 @@ TPZSBFemVolume::TPZSBFemVolume(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index)
 }
 
 /// Compute the K matrices
-void TPZSBFemVolume::ComputeKMatrices(TPZElementMatrix &E0, TPZElementMatrix &E1, TPZElementMatrix &E2, TPZElementMatrix &M0) {
+void TPZSBFemVolume::ComputeKMatrices(TPZElementMatrix &E0b, TPZElementMatrix &E1b, TPZElementMatrix &E2b, TPZElementMatrix &M0b) {
+    auto &E0 =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(E0b);
+	auto &E1 =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(E1b);
+    auto &E2 =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(E2b);
+	auto &M0 =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(M0b);
     // do all the computations here
 
-    TPZElementMatrix efmat(Mesh(), TPZElementMatrix::EF);
+    TPZElementMatrixT<STATE> efmat(Mesh(), TPZElementMatrix::EF);
 
     TPZGeoEl *Ref2D = Reference();
     TPZGeoMesh *gmesh = Ref2D->Mesh();

--- a/Mesh/TPZSBFemVolume.cpp
+++ b/Mesh/TPZSBFemVolume.cpp
@@ -34,15 +34,7 @@ TPZSBFemVolume::TPZSBFemVolume(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index)
 }
 
 /// Compute the K matrices
-void TPZSBFemVolume::ComputeKMatrices(TPZElementMatrix &E0b, TPZElementMatrix &E1b, TPZElementMatrix &E2b, TPZElementMatrix &M0b) {
-    auto &E0 =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(E0b);
-	auto &E1 =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(E1b);
-    auto &E2 =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(E2b);
-	auto &M0 =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(M0b);
+void TPZSBFemVolume::ComputeKMatrices(TPZElementMatrixT<STATE> &E0, TPZElementMatrixT<STATE> &E1, TPZElementMatrixT<STATE> &E2, TPZElementMatrixT<STATE> &M0) {
     // do all the computations here
 
     TPZElementMatrixT<STATE> efmat(Mesh(), TPZElementMatrix::EF);

--- a/Mesh/TPZSBFemVolume.h
+++ b/Mesh/TPZSBFemVolume.h
@@ -11,7 +11,7 @@
 
 #include <stdio.h>
 #include "pzcompel.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "pzinterpolationspace.h"
 
 class TPZSBFemVolume : public TPZInterpolationSpace
@@ -71,7 +71,7 @@ public:
     }
     
     /// Compute the E0, E1 and E2 matrices
-    void ComputeKMatrices(TPZElementMatrix &E0, TPZElementMatrix &E1, TPZElementMatrix &E2, TPZElementMatrix &M0);
+    void ComputeKMatrices(TPZElementMatrixT<STATE> &E0, TPZElementMatrixT<STATE> &E1, TPZElementMatrixT<STATE> &E2, TPZElementMatrixT<STATE> &M0);
     
     /// Data structure initialization
     void SetSkeleton(int64_t skeleton);

--- a/Mesh/pzcmesh.h
+++ b/Mesh/pzcmesh.h
@@ -47,6 +47,8 @@ class TPZCompMesh : public virtual TPZSavable {
 protected:
 	/** @brief Geometric grid to which this grid refers */
 	TPZGeoMesh	*fReference;
+    /** @brief Type of the solution (real/complex)*/
+    ESolType fSolType;
     
     /** @brief Autopointer to the geometric mesh used in case the user has passed an autopointer */
     TPZAutoPointer<TPZGeoMesh> fGMesh;
@@ -107,15 +109,19 @@ protected:
     void SetElementSolutionInternal(TPZFMatrix<TVar> &mysol, int64_t i, TPZVec<TVar> &sol);
     template<class TVar>
     void ConnectSolutionInternal(std::ostream &out, const TPZFMatrix<TVar>&sol) const;
+
+    friend TPZPersistenceManager;
+    friend TPZRestoreClass<TPZCompMesh>;
+    /* @brief Default constructor*/
+	TPZCompMesh();
 public:
-	
 	/**
 	 * @brief Constructor from geometrical mesh
 	 * @param gr pointer to geometrical reference mesh
 	 */
-	TPZCompMesh(TPZGeoMesh* gr=0);
+	TPZCompMesh(TPZGeoMesh* gr, bool isComplex=false);
     /** @brief Constructor based on an autopointer to a geometric mesh */
-    TPZCompMesh(TPZAutoPointer<TPZGeoMesh> &gmesh);
+    TPZCompMesh(TPZAutoPointer<TPZGeoMesh> &gmesh, bool isComplex = false);
 	/** @brief Copy constructor */
 	TPZCompMesh(const TPZCompMesh &copy);
     /** @brief copy the content of the mesh */
@@ -123,7 +129,9 @@ public:
 	
 	/** @brief Simple Destructor */
 	virtual ~TPZCompMesh();
-	
+
+    /** @brief Get type of solution (real/complex).*/
+    ESolType GetSolType() const { return fSolType;}
 	/**
 	 * @brief This method will initiate the comparison between the current computational
 	 * mesh and the mesh which is referenced by the geometric mesh

--- a/Mesh/pzcmesh.h
+++ b/Mesh/pzcmesh.h
@@ -287,7 +287,12 @@ public:
 	 * @{
 	 */
 	
-	/** @brief Set a ith element solution, expanding the element-solution matrix if necessary */
+	/**
+     * @brief Set a `i`th element solution, expanding the element-solution matrix if necessary.
+     * @tparam state variable type (`STATE`,`CSTATE`)
+     * @param i number of the element
+     * @param solution to be set
+     */
     template<class TVar>
 	void SetElementSolution(int64_t i, TPZVec<TVar> &sol);
 	
@@ -452,14 +457,19 @@ public:
 	virtual void Skyline(TPZVec<int64_t> &skyline);
 	
 	/**
-	 * @brief Builds the transfer matrix from the current grid to the coarse grid
+	 * @brief Builds the transfer matrix from the current grid to the coarse grid.
 	 * @param coarsemesh grid for where the matrix will be transfered
 	 * @param transfer transfer matrix between the current mesh and the coarse mesh
 	 */
 	void BuildTransferMatrix(TPZCompMesh &coarsemesh, TPZTransfer<STATE> &transfer);
 	
-	/** @brief To discontinuous elements */
+	/**
+	 * @brief Builds the transfer matrix from the current grid to the coarse grid for discontinuous meshes.
+	 * @param coarsemesh grid for where the matrix will be transfered
+	 * @param transfer transfer matrix between the current mesh and the coarse mesh
+	 */
 	void BuildTransferMatrixDesc(TPZCompMesh &transfermesh,TPZTransfer<STATE> &transfer);
+    
     template<class TVar>
 	void ProjectSolution(TPZFMatrix<TVar> &projectsol);
     
@@ -662,7 +672,8 @@ public:
 	 * @param dim Dimension of the working discontinuous elements
 	 * @param celJumps Vector to store the diference between the values from right and left elements connected on the interface
 	 */
-	void ConvertDiscontinuous2Continuous(REAL eps, int opt, int dim, TPZVec<STATE> &celJumps);
+    template<class TVar>
+	void ConvertDiscontinuous2Continuous(REAL eps, int opt, int dim, TPZVec<TVar> &celJumps);
 	
 	/**
 	 * @brief This method convert a discontinuous element with index disc_index in continuous element
@@ -762,20 +773,20 @@ inline void TPZCompMesh::SetReference(TPZAutoPointer<TPZGeoMesh> & gmesh){
 }
 
 //templates instantiation
+#define INSTANTIATE_METHODS(TVar) \
+extern template \
+void TPZCompMesh::UpdatePreviousState<TVar>(TVar); \
+extern template \
+void TPZCompMesh::SetElementSolution<TVar>(int64_t , TPZVec<TVar>&); \
+extern template \
+void TPZCompMesh::ConnectSolution<TVar>(int64_t , TPZCompMesh *, TPZFMatrix<TVar> &, TPZVec<TVar> &); \
+extern template \
+void TPZCompMesh::ProjectSolution<TVar>(TPZFMatrix<TVar> &); \
+extern template \
+void TPZCompMesh::ConvertDiscontinuous2Continuous<TVar>(REAL , int , int , TPZVec<TVar> &);
 
-extern template
-void TPZCompMesh::UpdatePreviousState<STATE>(STATE);
-extern template
-void TPZCompMesh::SetElementSolution<STATE>(int64_t , TPZVec<STATE>&);
-extern template
-void TPZCompMesh::ConnectSolution<STATE>(int64_t , TPZCompMesh *, TPZFMatrix<STATE> &, TPZVec<STATE> &);
-extern template
-void TPZCompMesh::ProjectSolution<STATE>(TPZFMatrix<STATE> &);
+INSTANTIATE_METHODS(STATE)
+INSTANTIATE_METHODS(CSTATE)
+#undef INSTANTIATE_METHODS
 
-// extern template
-// void TPZCompMesh::SetElementSolution<CSTATE>(int64_t , TPZVec<CSTATE>&);
-// extern template
-// void TPZCompMesh::ConnectSolution<CSTATE>(int64_t , TPZCompMesh *, TPZFMatrix<CSTATE> &, TPZVec<CSTATE> &);
-// extern template
-// void TPZCompMesh::ProjectSolution<CSTATE>(TPZFMatrix<CSTATE> &);
 #endif

--- a/Mesh/pzcompel.cpp
+++ b/Mesh/pzcompel.cpp
@@ -430,10 +430,12 @@ void TPZCompEl::EvaluateError(TPZVec<REAL> &/*errors*/, bool store_error) {
     DebugStop();
 }
 
-void TPZCompEl::Solution(TPZVec<REAL> &/*qsi*/,int var,TPZVec<STATE> &sol){
+
+template<class TVar>
+void TPZCompEl::SolutionInternal(TPZVec<REAL> &/*qsi*/,int var,TPZVec<TVar> &sol){
     if(var >= 100) {
         const int ind = Index();
-        TPZFMatrix<STATE> &elementSol = fMesh->ElementSolution();
+        TPZFMatrix<TVar> &elementSol = fMesh->ElementSolution();
         if(elementSol.Cols() > var-100) {
             sol[0] = elementSol(ind,var-100);
         } else {
@@ -1229,3 +1231,12 @@ void TPZCompEl::InitializeElementMatrix(TPZElementMatrix &ef){
     }
 }//void
 
+#define INSTANTIATE(TVar) \
+template \
+void TPZCompEl::SolutionInternal<TVar>(TPZVec<REAL> &qsi,int var,TPZVec<TVar> &sol); \
+template \
+void TPZCompEl::CalcBlockDiagonalInternal<TVar>(TPZStack<int64_t> &connectlist, TPZBlockDiagonal<TVar> & block);
+
+INSTANTIATE(STATE)
+INSTANTIATE(CSTATE)
+#undef INSTANTIATE

--- a/Mesh/pzcompel.cpp
+++ b/Mesh/pzcompel.cpp
@@ -48,9 +48,9 @@ static TPZLogger logger("pz.mesh.tpzcompel");
 static TPZLogger loggerSide("pz.mesh.tpzcompelside");
 #endif
 
-void TPZCompEl::CalcBlockDiagonal(TPZStack<int64_t> &connectlist, TPZBlockDiagonal<STATE> & blockdiag) {
-    //TODOCOMPLEX
-    TPZElementMatrixT<STATE> ek(this->Mesh(), TPZElementMatrix::EK),
+template<class TVar>
+void TPZCompEl::CalcBlockDiagonalInternal(TPZStack<int64_t> &connectlist, TPZBlockDiagonal<TVar> & blockdiag) {
+    TPZElementMatrixT<TVar> ek(this->Mesh(), TPZElementMatrix::EK),
         ef(this->Mesh(), TPZElementMatrix::EF);
     int b;
     CalcStiff(ek,ef);
@@ -71,11 +71,11 @@ void TPZCompEl::CalcBlockDiagonal(TPZStack<int64_t> &connectlist, TPZBlockDiagon
             TPZConnect &con = Mesh()->ConnectVec()[conind];
             if(con.HasDependency() || con.IsCondensed()) continue;
             //TPZFMatrix<REAL> ekbl(blsize,blsize);
-            TPZFMatrix<STATE> ekbl(blsize,blsize);
+            TPZFMatrix<TVar> ekbl(blsize,blsize);
             int r,c;
             //TPZBlock &mbl = ek.fConstrBlock;
             TPZBlock &mbl = ek.fConstrBlock;
-            TPZFMatrix<STATE> &msol = ek.fConstrMat;
+            TPZFMatrix<TVar> &msol = ek.fConstrMat;
             
             for(r=0; r<blsize; r++) {
                 for(c=0; c<blsize; c++) {
@@ -96,14 +96,14 @@ void TPZCompEl::CalcBlockDiagonal(TPZStack<int64_t> &connectlist, TPZBlockDiagon
         for(b=0; b<numblock; b++) {
             int blsize = blocksize[b];
             //TPZFMatrix<REAL> ekbl(blsize,blsize);
-            TPZFMatrix<STATE> ekbl(blsize,blsize);
+            TPZFMatrix<TVar> ekbl(blsize,blsize);
             int64_t conind = ek.fConnect[b];
             TPZConnect &con = Mesh()->ConnectVec()[conind];
             if(con.HasDependency() || con.IsCondensed()) continue;
             int r, c;
             //TPZBlock &mbl = ek.fBlock;
             TPZBlock &mbl = ek.fBlock;
-            TPZFMatrix<STATE> &sol = ek.fMat;
+            TPZFMatrix<TVar> &sol = ek.fMat;
             
             for(r=0; r<blsize; r++) {
                 for(c=0; c<blsize; c++) {

--- a/Mesh/pzcompel.cpp
+++ b/Mesh/pzcompel.cpp
@@ -620,8 +620,13 @@ void TPZCompEl::LoadElementReference()
 }
 
 void TPZCompEl::CalcResidual(TPZElementMatrixT<STATE> &ef){
-    //TODOCOMPLEX
     TPZElementMatrixT<STATE> ek(this->Mesh(), TPZElementMatrix::EK);
+    CalcStiff(ek,ef);
+}
+
+void TPZCompEl::CalcResidual(TPZElementMatrixT<CSTATE> &ef){
+    //TODOCOMPLEX
+    TPZElementMatrixT<CSTATE> ek(this->Mesh(), TPZElementMatrix::EK);
     CalcStiff(ek,ef);
 }
 

--- a/Mesh/pzcompel.cpp
+++ b/Mesh/pzcompel.cpp
@@ -619,7 +619,7 @@ void TPZCompEl::LoadElementReference()
     }
 }
 
-void TPZCompEl::CalcResidual(TPZElementMatrix &ef){
+void TPZCompEl::CalcResidual(TPZElementMatrixT<STATE> &ef){
     //TODOCOMPLEX
     TPZElementMatrixT<STATE> ek(this->Mesh(), TPZElementMatrix::EK);
     CalcStiff(ek,ef);

--- a/Mesh/pzcompel.cpp
+++ b/Mesh/pzcompel.cpp
@@ -9,7 +9,7 @@
 #include "TPZMaterial.h"
 #include "pzcmesh.h"
 #include "pzbndcond.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "pzconnect.h"
 #include "pzblockdiag.h"
 
@@ -49,7 +49,9 @@ static TPZLogger loggerSide("pz.mesh.tpzcompelside");
 #endif
 
 void TPZCompEl::CalcBlockDiagonal(TPZStack<int64_t> &connectlist, TPZBlockDiagonal<STATE> & blockdiag) {
-    TPZElementMatrix ek(this->Mesh(), TPZElementMatrix::EK),ef(this->Mesh(), TPZElementMatrix::EF);
+    //TODOCOMPLEX
+    TPZElementMatrixT<STATE> ek(this->Mesh(), TPZElementMatrix::EK),
+        ef(this->Mesh(), TPZElementMatrix::EF);
     int b;
     CalcStiff(ek,ef);
     if(HasDependency()) {
@@ -618,7 +620,8 @@ void TPZCompEl::LoadElementReference()
 }
 
 void TPZCompEl::CalcResidual(TPZElementMatrix &ef){
-    TPZElementMatrix ek(this->Mesh(), TPZElementMatrix::EK);
+    //TODOCOMPLEX
+    TPZElementMatrixT<STATE> ek(this->Mesh(), TPZElementMatrix::EK);
     CalcStiff(ek,ef);
 }
 
@@ -1160,8 +1163,8 @@ void TPZCompEl::InitializeElementMatrix(TPZElementMatrix &ek, TPZElementMatrix &
     ef.fMesh = Mesh();
     ef.fType = TPZElementMatrix::EF;
     
-    ek.fBlock.SetNBlocks(ncon);
-    ef.fBlock.SetNBlocks(ncon);
+    ek.Block().SetNBlocks(ncon);
+    ef.Block().SetNBlocks(ncon);
 
     int i;
     int numeq=0;
@@ -1178,12 +1181,12 @@ void TPZCompEl::InitializeElementMatrix(TPZElementMatrix &ek, TPZElementMatrix &
 #endif
         int nstate = c.NState();
         
-        ek.fBlock.Set(i,nshape*nstate);
-        ef.fBlock.Set(i,nshape*nstate);
+        ek.Block().Set(i,nshape*nstate);
+        ef.Block().Set(i,nshape*nstate);
         numeq += nshape*nstate;
     }
-    ek.fMat.Redim(numeq,numeq);
-    ef.fMat.Redim(numeq,numloadcases);
+    ek.Matrix().Redim(numeq,numeq);
+    ef.Matrix().Redim(numeq,numloadcases);
     ek.fConnect.Resize(ncon);
     ef.fConnect.Resize(ncon);
     for(i=0; i<ncon; i++){
@@ -1199,7 +1202,7 @@ void TPZCompEl::InitializeElementMatrix(TPZElementMatrix &ef){
     const int numloadcases = mat->NumLoadCases();
     ef.fMesh = Mesh();
     ef.fType = TPZElementMatrix::EF;
-    ef.fBlock.SetNBlocks(ncon);
+    ef.Block().SetNBlocks(ncon);
     ef.fOneRestraints = GetShapeRestraints();
     int numeq = 0;
     for(int i=0; i<ncon; i++){
@@ -1212,9 +1215,9 @@ void TPZCompEl::InitializeElementMatrix(TPZElementMatrix &ef){
             DebugStop();
         }
 #endif
-        ef.fBlock.Set(i,nshapec*numdof);
+        ef.Block().Set(i,nshapec*numdof);
     }
-    ef.fMat.Redim(numeq,numloadcases);
+    ef.Matrix().Redim(numeq,numloadcases);
     ef.fConnect.Resize(ncon);
     for(int i=0; i<ncon; i++){
         (ef.fConnect)[i] = ConnectIndex(i);

--- a/Mesh/pzcompel.h
+++ b/Mesh/pzcompel.h
@@ -464,7 +464,12 @@ public:
 	 * @param var variable name
 	 * @param sol vetor for the solution
 	 */
-	virtual void Solution(TPZVec<REAL> &qsi,int var,TPZVec<STATE> &sol);
+	virtual void Solution(TPZVec<REAL> &qsi,int var,TPZVec<STATE> &sol){
+        SolutionInternal(qsi,var,sol);
+    }
+    virtual void Solution(TPZVec<REAL> &qsi,int var,TPZVec<CSTATE> &sol){
+        SolutionInternal(qsi,var,sol);
+    }
     
     /**
      * @brief Compute the integral of a variable
@@ -603,6 +608,8 @@ public:
 	void Read(TPZStream &buf, void *context) override;
 	 
 private:
+    template<class TVar>
+    void SolutionInternal(TPZVec<REAL> &qsi,int var,TPZVec<TVar> &sol);
     template<class TVar>
     void CalcBlockDiagonalInternal(TPZStack<int64_t> &connectlist, TPZBlockDiagonal<TVar> & block);
 	/** @brief Default interpolation order */
@@ -857,5 +864,16 @@ inline int TPZCompEl::GetgOrder( )
 {
 	return gOrder;
 }
+
+
+#define INSTANTIATE(TVar) \
+extern template \
+void TPZCompEl::SolutionInternal<TVar>(TPZVec<REAL> &qsi,int var,TPZVec<TVar> &sol); \
+extern template \
+void TPZCompEl::CalcBlockDiagonalInternal<TVar>(TPZStack<int64_t> &connectlist, TPZBlockDiagonal<TVar> & block);
+
+INSTANTIATE(STATE)
+INSTANTIATE(CSTATE)
+#undef INSTANTIATE
 
 #endif

--- a/Mesh/pzcompel.h
+++ b/Mesh/pzcompel.h
@@ -580,7 +580,10 @@ public:
 	 * @param connectlist stack list to calculates the diagonal block
 	 * @param block object to receive the diagonal block
 	 */
-	virtual void CalcBlockDiagonal(TPZStack<int64_t> &connectlist, TPZBlockDiagonal<STATE> & block);
+	virtual void CalcBlockDiagonal(TPZStack<int64_t> &connectlist, TPZBlockDiagonal<STATE> & block){
+        CalcBlockDiagonalInternal(connectlist,block);
+    }
+    
 	
     /// Will return the maximum distance between the nodes of the reference element
 	REAL MaximumRadiusOfEl();
@@ -595,7 +598,8 @@ public:
 	void Read(TPZStream &buf, void *context) override;
 	 
 private:
-    
+    template<class TVar>
+    void CalcBlockDiagonalInternal(TPZStack<int64_t> &connectlist, TPZBlockDiagonal<TVar> & block);
 	/** @brief Default interpolation order */
     static int gOrder;
     

--- a/Mesh/pzcompel.h
+++ b/Mesh/pzcompel.h
@@ -24,6 +24,8 @@
 
 
 struct TPZElementMatrix;
+template<class TVar>
+struct TPZElementMatrixT;
 class TPZCompMesh;
 class TPZBndCond;
 class TPZInterpolatedElement;
@@ -324,7 +326,7 @@ public:
 	 * @param ek element stiffness matrix
 	 * @param ef element load vector
 	 */
-	virtual void CalcStiff(TPZElementMatrix &ek,TPZElementMatrix &ef);
+	virtual void CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef);
     
 	
 	/** @brief Verifies if the material associated with the element is contained in the set */
@@ -334,7 +336,7 @@ public:
 	 * @brief Computes the element right hand side
 	 * @param ef element load vector(s)
 	 */
-	virtual void CalcResidual(TPZElementMatrix &ef);
+	virtual void CalcResidual(TPZElementMatrixT<STATE> &ef);
 	
 	/**
 	 * @brief Implements of the orthogonal Chebyshev functions
@@ -804,8 +806,9 @@ inline void TPZCompEl::Assemble(){
     std::cout << "TPZCompEl::Assemble is called." << std::endl;
 }
 
-inline void TPZCompEl::CalcStiff(TPZElementMatrix &,TPZElementMatrix &){
-	std::cout << "TPZCompEl::CalcStiff(*,*) is called." << std::endl;
+inline void TPZCompEl::CalcStiff(TPZElementMatrixT<STATE> &,TPZElementMatrixT<STATE> &){
+	PZError << "TPZCompEl::CalcStiff(*,*) is called." << std::endl;
+    DebugStop();
 }
 
 inline bool TPZCompElSide::operator != (const TPZCompElSide &other)

--- a/Mesh/pzcompel.h
+++ b/Mesh/pzcompel.h
@@ -327,6 +327,7 @@ public:
 	 * @param ef element load vector
 	 */
 	virtual void CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef);
+    virtual void CalcStiff(TPZElementMatrixT<CSTATE> &ek,TPZElementMatrixT<CSTATE> &ef);
     
 	
 	/** @brief Verifies if the material associated with the element is contained in the set */
@@ -337,6 +338,7 @@ public:
 	 * @param ef element load vector(s)
 	 */
 	virtual void CalcResidual(TPZElementMatrixT<STATE> &ef);
+    virtual void CalcResidual(TPZElementMatrixT<CSTATE> &ef);
 	
 	/**
 	 * @brief Implements of the orthogonal Chebyshev functions
@@ -584,6 +586,9 @@ public:
         CalcBlockDiagonalInternal(connectlist,block);
     }
     
+    virtual void CalcBlockDiagonal(TPZStack<int64_t> &connectlist, TPZBlockDiagonal<CSTATE> & block){
+        CalcBlockDiagonalInternal(connectlist,block);
+    }
 	
     /// Will return the maximum distance between the nodes of the reference element
 	REAL MaximumRadiusOfEl();
@@ -811,6 +816,11 @@ inline void TPZCompEl::Assemble(){
 }
 
 inline void TPZCompEl::CalcStiff(TPZElementMatrixT<STATE> &,TPZElementMatrixT<STATE> &){
+	PZError << "TPZCompEl::CalcStiff(*,*) is called." << std::endl;
+    DebugStop();
+}
+
+inline void TPZCompEl::CalcStiff(TPZElementMatrixT<CSTATE> &,TPZElementMatrixT<CSTATE> &){
 	PZError << "TPZCompEl::CalcStiff(*,*) is called." << std::endl;
     DebugStop();
 }

--- a/Mesh/pzcondensedcompel.cpp
+++ b/Mesh/pzcondensedcompel.cpp
@@ -8,6 +8,7 @@
 #include "pzstepsolver.h"
 #include "pzelementgroup.h"
 #include "pzcmesh.h"
+#include "TPZElementMatrixT.h"
 
 #ifdef PZ_LOG
 static TPZLogger logger("pz.mesh.tpzcondensedcompel");
@@ -292,7 +293,8 @@ void TPZCondensedCompEl::Assemble()
     fCondensed.Redim(fNumTotalEqs, fNumInternalEqs);
 
     fCondensed.Zero();
-    TPZElementMatrix ek,ef;
+    //TODOCOMPLEX
+    TPZElementMatrixT<STATE> ek,ef;
     
     fReferenceCompEl->CalcStiff(ek,ef);
     ek.PermuteGather(fIndexes);
@@ -315,8 +317,12 @@ void TPZCondensedCompEl::Assemble()
  * @param ek element stiffness matrix
  * @param ef element load vector
  */
-void TPZCondensedCompEl::CalcStiff(TPZElementMatrix &ekglob,TPZElementMatrix &efglob)
+void TPZCondensedCompEl::CalcStiff(TPZElementMatrix &ekglobb,TPZElementMatrix &efglobb)
 {
+    auto &ekglob =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(ekglobb);
+	auto &efglob =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efglobb);
     if(fKeepMatrix == false)
     {
         fKeepMatrix = true;
@@ -325,7 +331,8 @@ void TPZCondensedCompEl::CalcStiff(TPZElementMatrix &ekglob,TPZElementMatrix &ef
         fKeepMatrix = false;
     }
     InitializeElementMatrix(ekglob, efglob);
-    TPZElementMatrix ek, ef;
+    //TODOCOMPLEX
+    TPZElementMatrixT<STATE> ek, ef;
     
     fReferenceCompEl->CalcStiff(ek,ef);
 #ifdef PZ_LOG
@@ -589,8 +596,11 @@ void TPZCondensedCompEl::CalcStiff(TPZElementMatrix &ekglob,TPZElementMatrix &ef
  * @brief Computes the element right hand side
  * @param ef element load vector(s)
  */
-void TPZCondensedCompEl::CalcResidual(TPZElementMatrix &ef)
+void TPZCondensedCompEl::CalcResidual(TPZElementMatrix &efb)
 {
+    //TODOCOMPLEX
+	auto &ef =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     // we need the stiffness matrix computed to compute the residual
     if (fKeepMatrix == false) {
         DebugStop();

--- a/Mesh/pzcondensedcompel.h
+++ b/Mesh/pzcondensedcompel.h
@@ -33,6 +33,10 @@ protected:
     bool fKeepMatrix = true;
     void Resequence();
 
+    template<class TVar>
+    void CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef);
+    template<class TVar>
+    void CalcResidualInternal(TPZElementMatrixT<TVar> &ef);
 public:
     
     TPZCondensedCompEl(TPZCompEl *ref, bool keepmatrix = true);
@@ -227,14 +231,18 @@ public:
 	 * @param ek element stiffness matrix
 	 * @param ef element load vector
 	 */
-	virtual void CalcStiff(TPZElementMatrix &ek,TPZElementMatrix &ef) override;
+	void CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef) override{
+        return CalcStiffInternal(ek,ef);
+    }
 	
 	
 	/**
 	 * @brief Computes the element right hand side
 	 * @param ef element load vector(s)
 	 */
-	virtual void CalcResidual(TPZElementMatrix &ef) override;
+	void CalcResidual(TPZElementMatrixT<STATE> &ef) override{
+        return CalcResidualInternal(ef);
+    }
     
     /** @brief Verifies if the material associated with the element is contained in the set */
     virtual bool HasMaterial(const std::set<int> &materialids) const override;

--- a/Mesh/pzelementgroup.cpp
+++ b/Mesh/pzelementgroup.cpp
@@ -208,13 +208,9 @@ void TPZElementGroup::InitializeElementMatrix(TPZElementMatrix &ef) const {
  * @param ek element stiffness matrix
  * @param ef element load vector
  */
-void TPZElementGroup::CalcStiff(TPZElementMatrix &ekb,TPZElementMatrix &efb)
+template<class TVar>
+void TPZElementGroup::CalcStiffInternal(TPZElementMatrixT<TVar> &ek,TPZElementMatrixT<TVar> &ef)
 {
-    //TODOCOMPLEX
-    auto &ek =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     std::map<int64_t,int64_t> locindex;
     int64_t ncon = fConnectIndexes.size();
     for (int64_t ic=0; ic<ncon ; ic++) {
@@ -230,7 +226,7 @@ void TPZElementGroup::CalcStiff(TPZElementMatrix &ekb,TPZElementMatrix &efb)
 #endif
     InitializeElementMatrix(ek, ef);
     int64_t nel = fElGroup.size();
-    TPZElementMatrixT<STATE> ekloc,efloc;
+    TPZElementMatrixT<TVar> ekloc,efloc;
     for (int64_t el = 0; el<nel; el++) {
         TPZCompEl *cel = fElGroup[el];
         
@@ -336,11 +332,9 @@ bool TPZElementGroup::HasMaterial(const std::set<int> &materialids) const {
  * @brief Computes the element right hand side
  * @param ef element load vector(s)
  */
-void TPZElementGroup::CalcResidual(TPZElementMatrix &efb)
+template<class TVar>
+void TPZElementGroup::CalcResidualInternal(TPZElementMatrixT<TVar> &ef)
 {
-    //TODOCOMPLEX
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     std::map<int64_t,int64_t> locindex;
     int64_t ncon = fConnectIndexes.size();
     for (int64_t ic=0; ic<ncon ; ic++) {
@@ -348,7 +342,7 @@ void TPZElementGroup::CalcResidual(TPZElementMatrix &efb)
     }
     InitializeElementMatrix(ef);
     int64_t nel = fElGroup.size();
-    TPZElementMatrixT<STATE> efloc;
+    TPZElementMatrixT<TVar> efloc;
     for (int64_t el = 0; el<nel; el++) {
         TPZCompEl *cel = fElGroup[el];
 #ifdef PZDEBUG

--- a/Mesh/pzelementgroup.h
+++ b/Mesh/pzelementgroup.h
@@ -261,7 +261,9 @@ public:
 	 * @param ek element stiffness matrix
 	 * @param ef element load vector
 	 */
-	virtual void CalcStiff(TPZElementMatrix &ek,TPZElementMatrix &ef) override;
+	virtual void CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef) override{
+        CalcStiffInternal<STATE>(ek,ef);
+    }
     /**
      * @brief Performs an error computation for the element
      * @param errors [out] the L2 norm of the error of the solution
@@ -276,7 +278,9 @@ public:
 	 * @brief Computes the element right hand side
 	 * @param ef element load vector(s)
 	 */
-	virtual void CalcResidual(TPZElementMatrix &ef) override;
+	virtual void CalcResidual(TPZElementMatrixT<STATE> &ef) override{
+        CalcResidualInternal<STATE>(ef);
+    }
 
     int ComputeIntegrationOrder() const override {
         std::cout << "This method should not be called. " << __PRETTY_FUNCTION__ << std::endl;
@@ -288,7 +292,10 @@ public:
 virtual int ClassId() const override;
 
 protected:
-    
+    template<class TVar>
+    void CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef);
+    template<class TVar>
+    void CalcResidualInternal(TPZElementMatrixT<TVar> &ef);
     /// Initialize the datastructure of ek and ef based on the connect information
     void InitializeElementMatrix(TPZElementMatrix &ek, TPZElementMatrix &ef) const;
 

--- a/Mesh/pzelmat.cpp
+++ b/Mesh/pzelmat.cpp
@@ -4,7 +4,7 @@
  */
 
 #include "pzelmat.h"
-#include "pzfmatrix.h"
+#include "pzbasematrix.h"
 #include "pzcmesh.h"
 
 #include "pzlog.h"
@@ -15,133 +15,30 @@ static TPZLogger logger("pz.mesh.tpzelmat");
 
 using namespace std;
 
-void TPZElementMatrix::SetMatrixSize(short NumBli, short NumBlj,
-									 short BlSizei, short BlSizej) {
-	
-	
-	if(fMat.Rows() != NumBli*BlSizei || fMat.Cols() != NumBlj*BlSizej) {
-		fMat.Redim(NumBli*BlSizei,NumBlj*BlSizej);
-	}
+TPZElementMatrix::TPZElementMatrix(const TPZElementMatrix &cp) : 
+    fType(cp.fType), fMesh(cp.fMesh), fConnect(cp.fConnect), 
+    fConstrConnect(cp.fConstrConnect),
+    fDestinationIndex(cp.fDestinationIndex), fSourceIndex(cp.fSourceIndex)
+{
+
 }
+
 TPZElementMatrix &TPZElementMatrix::operator=(const TPZElementMatrix &cp)
 {
     fType = cp.fType;
     fMesh = cp.fMesh;
-    fConnect = cp.fConnect;
-    fMat = cp.fMat;
-    fBlock = cp.fBlock;
+    fConnect = cp.fConnect;    
     fConstrConnect = cp.fConstrConnect;
-    fConstrMat = cp.fConstrMat;
-    fConstrBlock = cp.fConstrBlock;
     fDestinationIndex = cp.fDestinationIndex;
     fSourceIndex = cp.fSourceIndex;
-    fBlock.SetMatrix(&fMat);
-    fConstrBlock.SetMatrix(&fConstrMat);
     return *this;
-}
-
-void TPZElementMatrix::SetMatrixMinSize(short NumBli, short NumBlj, 
-										short BlSizei, short BlSizej) {
-	
-	
-	if(fMat.Rows() < NumBli*BlSizei || fMat.Cols() < NumBlj*BlSizej) {
-		fMat.Redim(NumBli*BlSizei,NumBlj*BlSizej);
-	}
-}
-
-TPZElementMatrix::TPZElementMatrix(const TPZElementMatrix &cp) : 
-    fType(cp.fType), fMesh(cp.fMesh), fConnect(cp.fConnect), fMat(cp.fMat),
-    fBlock(cp.fBlock), fConstrConnect(cp.fConstrConnect), fConstrMat(cp.fConstrMat),
-    fConstrBlock(cp.fConstrBlock), fDestinationIndex(cp.fDestinationIndex),
-    fSourceIndex(cp.fSourceIndex)
-{
-    fBlock.SetMatrix(&fMat);
-    fConstrBlock.SetMatrix(&fConstrMat);
-}
-
-void TPZElementMatrix::Print(std::ostream &out){
-	if(fType == EK)
-	{
-        int ncon = fConnect.NElements();
-        int ic;
-        out << "Connect vector\n";
-        for(ic=0; ic<ncon; ic++) {
-            //	out << "Connect index " << fConnect[ic] << endl;
-            out << "ic = " << ic << " index " << fConnect[ic] << " ";
-            this->fMesh->ConnectVec()[fConnect[ic]].Print(*fMesh,out);
-        }
-        out << "Constrained connect vector\n";
-        //fConstrMat.Print("Constrained matrix",out);
-        ncon = fConstrConnect.NElements();
-        for(ic=0; ic<ncon; ic++) {
-            //	out << "Connect index " << fConstrConnect[ic] << endl;
-            out << "ic = " << ic << " index " << fConstrConnect[ic]  << ' ';
-            this->fMesh->ConnectVec()[fConstrConnect[ic]].Print(*fMesh,out);
-        }
-		ComputeDestinationIndices();
-		bool hasdepend = HasDependency();
-		int64_t size = fSourceIndex.NElements();
-		//TPZFMatrix<REAL> constrmatrix(size,size,0.);
-		TPZFNMatrix<400,STATE> constrmatrix(size,size,0.);
-		int64_t in,jn;
-		for(in=0; in<size; in++)
-		{
-			for (jn=0; jn<size; jn++) {
-				if(hasdepend)
-				{
-					constrmatrix(in,jn) = fConstrMat(fSourceIndex[in],fSourceIndex[jn]);
-				}
-				else {
-					constrmatrix(in,jn) = fMat(fSourceIndex[in],fSourceIndex[jn]);
-				}
-				
-			}
-		}
-        out << "SourceIndex = " << fSourceIndex << std::endl;
-        fConstrMat.Print("EKOrig=",out,EMathematicaInput);
-		std::stringstream sout;
-        sout << "EK = ";
-		//out << "Matrix size " << constrmatrix.Rows() << "\n";
-		//sout << "ConstrainedMatrix = ";
-		constrmatrix.Print(sout.str().c_str(), out, EMathematicaInput);
-	}
-    else if(fType == EF)
-	{
-		ComputeDestinationIndices();
-		bool hasdepend = HasDependency();
-		int64_t size = fSourceIndex.NElements();
-		//TPZFMatrix<REAL> constrmatrix(size,size,0.);
-		TPZFMatrix<STATE> constrmatrix(size,fMat.Cols(),0.);
-		int64_t in,jn;
-		for(in=0; in<size; in++)
-		{
-			for (jn=0; jn<fMat.Cols(); jn++) {
-				if(hasdepend)
-				{
-					constrmatrix(in,jn) = fConstrMat(fSourceIndex[in],jn);
-				}
-				else {
-					constrmatrix(in,jn) = fMat(fSourceIndex[in],jn);
-				}
-				
-			}
-		}
-		std::stringstream sout;
-        sout << "EF = ";
-		//out << "Matrix size " << constrmatrix.Rows() << "\n";
-		//sout << "ConstrainedMatrix = ";
-		constrmatrix.Print(sout.str().c_str(), out, EMathematicaInput);
-	}
-    else
-    {
-        DebugStop();
-    }
 }
 
 void TPZElementMatrix::ComputeDestinationIndices(){
     if (!this->HasDependency()){
-		this->fSourceIndex.Resize(this->fMat.Rows());
-		this->fDestinationIndex.Resize(this->fMat.Rows());
+        TPZBaseMatrix &mat = Matrix();
+		this->fSourceIndex.Resize(mat.Rows());
+		this->fDestinationIndex.Resize(mat.Rows());
 		int64_t destindex = 0L;
         int64_t fullmatindex = 0L;
 		const int numnod = this->NConnects();
@@ -172,11 +69,11 @@ void TPZElementMatrix::ComputeDestinationIndices(){
 #endif
 	}//if
 	else{
-    
+        TPZBaseMatrix &constrMat = ConstrMatrix();
         int64_t destindex = 0L;
         int64_t fullmatindex = 0L;
-        this->fDestinationIndex.Resize(this->fConstrMat.Rows());
-        this->fSourceIndex.Resize(this->fConstrMat.Rows());
+        this->fDestinationIndex.Resize(constrMat.Rows());
+        this->fSourceIndex.Resize(constrMat.Rows());
         int numnod = this->fConstrConnect.NElements();
         for(int in = 0; in < numnod; in++){
             const int64_t npindex = this->fConstrConnect[in];
@@ -198,302 +95,6 @@ void TPZElementMatrix::ComputeDestinationIndices(){
     }
 }//void
 
-void TPZElementMatrix::ApplyConstraints(){
-	
-	if (this->fMat.Rows() == 0){
-		LOGPZ_FATAL(logger, "this->fMat not initialized");
-	}
-	
-	int totalnodes= this->NConnects();
-	this->fConstrConnect.Resize(totalnodes);
-	if(totalnodes) this->fConstrConnect.Fill(0,0);
-	int in;
-    std::set<int64_t> origlist,connectlist;
-	for(in=0; in<totalnodes; in++) connectlist.insert(this->fConnect[in]);
-    for (std::list<TPZOneShapeRestraint>::iterator it = fOneRestraints.begin(); it != fOneRestraints.end(); it++) {
-        for (int c=0; c< it->fFaces.size(); c++) {
-            connectlist.insert(it->fFaces[c].first);
-        }
-    }
-    origlist = connectlist;
-	// total number of nodes of the constrained element
-	TPZConnect::BuildConnectList(connectlist, origlist, *this->fMesh);
-    this->fConstrConnect.resize(connectlist.size());
-    std::set<int64_t>::iterator it = connectlist.begin();
-    for (int64_t i=0; i<connectlist.size(); i++) {
-        fConstrConnect[i] = *it;
-        it++;
-    }
-	totalnodes = this->fConstrConnect.NElements();
-	
-	// compute the list of nodes and their proper order of processing
-	TPZVec<int> DependenceOrder;
-	// this->fConstrNod, totalnodes and DependenceOrder
-	// are initialized using codes documented above
-	BuildDependencyOrder(this->fConstrConnect,DependenceOrder,*this->fMesh);
-	
-	// compute the number of statevariables
-	// the number of state variables is the number of unknowns associated with
-	// each shapefunction
-	// numstate is best initialized during computation of the stiffness matrix
-	//   TPZMaterial * mat = Material();
-	//   int numstate = mat->NStateVariables();
-	
-	// initialize the block structure
-	this->fConstrBlock.SetNBlocks(totalnodes);
-	
-	// toteq contains the total number of equations of the constrained matrix
-	int64_t toteq = 0;
-	for(in=0; in<totalnodes; in++) {
-		int64_t dfnindex = this->fConstrConnect[in];
-		TPZConnect &dfn = fMesh->ConnectVec()[dfnindex];
-		int ndf = dfn.NDof(*fMesh);
-        int ndfcheck = dfn.NState()*dfn.NShape();
-        if(ndf != ndfcheck)
-        {
-            DebugStop();
-        }
-		this->fConstrBlock.Set(in,ndf);
-		toteq += ndf;
-	}
-	
-	this->fConstrBlock.Resequence();
-	this->fConstrBlock.SetMatrix(&this->fConstrMat);
-	    
-	int64_t nrhs = this->fMat.Cols();
-	if (this->fType == TPZElementMatrix::EK){
-		this->fConstrMat.Redim(toteq,toteq);
-	}
-	else{
-		this->fConstrMat.Redim(toteq,nrhs);
-	}
-	
-	// copy the original matrix to the constrained matrix
-	int numnod = this->fConnect.NElements();
-	for(in=0; in<numnod; in++) {
-		int irnode =0;
-		int64_t idfn = this->fConnect[in];
-		// find the index of the node in the destination (constrained) matrix
-		while(irnode < totalnodes && this->fConstrConnect[irnode] != idfn) irnode++;
-		
-		// first and last rows in the original matrix
-		int64_t ifirst = this->fBlock.Position(in);
-		int64_t ilast = ifirst+this->fBlock.Size(in);
-		
-		// first and last rows in the desination (reception) matrix
-		int64_t irfirst = this->fConstrBlock.Position(irnode);
-		//	   int irlast = irfirst+this->fConstrBlock->Size(irnode);
-		
-		int64_t i,ir,ieq;
-		if (this->fType == TPZElementMatrix::EF){
-			for(i=ifirst,ir=irfirst;i<ilast;i++,ir++) {
-				for(ieq=0; ieq<nrhs; ieq++) {
-					(this->fConstrMat)(ir,ieq) = (this->fMat)(i,ieq);
-				}
-			}
-		}
-		else{
-			int jn;
-			for(jn=0; jn<numnod; jn++) {
-				int jrnode = 0;
-				int64_t jdfn = this->fConnect[jn];
-				// find the index of the node in the destination (constrained) matrix
-				while(jrnode < totalnodes && this->fConstrConnect[jrnode] != jdfn) jrnode++;
-				if(jrnode == totalnodes) {
-					LOGPZ_WARN(logger, "node not found in node list");
-				}
-				// first and last columns in the original matrix
-				int64_t jfirst = this->fBlock.Position(jn);
-				int64_t jlast = jfirst+this->fBlock.Size(jn);
-				// first and last columns in the desination (reception) matrix
-				int64_t jrfirst = this->fConstrBlock.Position(jrnode);
-				//int jrlast = irfirst+this->fConstrBlock->Size(jrnode);
-				int64_t j,jr;
-				for(i=ifirst,ir=irfirst;i<ilast; i++,ir++) {
-					for(j=jfirst,jr=jrfirst;j<jlast; j++,jr++) {
-						(this->fConstrMat)(ir,jr) = (this->fMat)(i,j);
-					}
-				}
-			}
-		}//else
-	}
-	
-	int numnodes_processed = 0;
-	int current_order = 0;
-	while(numnodes_processed < totalnodes) {
-		int in;
-		for(in=0; in<totalnodes; in++) {
-			int64_t dfnindex = this->fConstrConnect[in];
-			TPZConnect *dfn = &(fMesh->ConnectVec()[dfnindex]);
-			if(DependenceOrder[in] != current_order) continue;
-			
-			// only nodes which have dependency order equal to the
-			// current order are processed
-			numnodes_processed++;
-			
-			int64_t inpos = this->fConstrBlock.Position(in);
-			int64_t insize = this->fConstrBlock.Size(in);
-			// inpos : position of the dependent equation
-			// insize : number of equations processed
-			
-			// loop over the nodes from which dfn depends
-			TPZConnect::TPZDepend *dep = dfn->FirstDepend();
-			while(dep) {
-				int64_t depnodeindex = dep->fDepConnectIndex;
-				// look for the index where depnode is found
-				int depindex=0;
-				while(depindex < totalnodes && this->fConstrConnect[depindex] != depnodeindex) depindex++;
-				if(depindex == totalnodes) {
-					LOGPZ_WARN(logger,"node not found in node list");
-				}
-				
-				int64_t deppos = this->fConstrBlock.Position(depindex);
-				int64_t depsize = this->fConstrBlock.Size(depindex);
-				// deppos : position of the receiving equation
-				// depsize : number of receiving equations
-				
-				// process the rows of the constrained matrix
-				int64_t send;
-				int64_t receive;
-				int ieq;
-				STATE coef;
-				int idf;
-				int numstate = dfn->NState();
-				for(send=inpos; send<inpos+insize; send += numstate) {
-					for(receive=deppos; receive<deppos+depsize; receive += numstate) {
-						coef = dep->fDepMatrix((send-inpos)/numstate,(receive-deppos)/numstate);
-						if (this->fType == TPZElementMatrix::EK){
-							for(ieq=0; ieq<toteq; ieq++) for(idf=0; idf<numstate; idf++)  {
-								(this->fConstrMat)(receive+idf,ieq) += coef*(this->fConstrMat)(send+idf,ieq);
-							}
-						}//EK
-						else{
-							for(ieq=0; ieq<nrhs; ieq++) for(idf=0; idf<numstate; idf++) {
-								(this->fConstrMat)(receive+idf,ieq) += coef*(this->fConstrMat)(send+idf,ieq);
-							}
-						}//EF
-					}
-				}
-				
-				if (this->fType == TPZElementMatrix::EK){
-					for(send=inpos; send<inpos+insize; send += numstate) {
-						for(receive=deppos; receive<deppos+depsize; receive += numstate) {
-							coef = dep->fDepMatrix((send-inpos)/numstate,(receive-deppos)/numstate);
-							for(ieq=0; ieq<toteq; ieq++) for(idf=0; idf<numstate; idf++) {
-								(this->fConstrMat)(ieq,receive+idf) += coef*(this->fConstrMat)(ieq,send+idf);
-							}
-						}
-					}
-				}//EK
-				
-				dep = dep->fNext;
-			} // end of while
-            
-            /// check whether the connect has a one shape restraint
-            if (fOneRestraints.size())
-            {
-                ApplyOneShapeConstraints(in);
-            }
-            
-            
-		} // end of loop over all nodes
-		current_order++;
-	} // end of while loop
-}//void
-
-/// Apply the constraint of the one shape restraints
-void TPZElementMatrix::ApplyOneShapeConstraints(int constraintindex)
-{
-    int64_t dfnindex = this->fConstrConnect[constraintindex];
-
-
-#ifdef PZ_LOG
-    int count = 0;
-    for (std::list<TPZOneShapeRestraint>::iterator it = fOneRestraints.begin(); it != fOneRestraints.end(); it++) {
-        if (it->fFaces[0].first != dfnindex) {
-            continue;
-        }
-        count++;
-    }
-    if (count && logger.isDebugEnabled()) {
-        std::stringstream sout;
-        sout << "Element matrix before ApplyOneShapeConstraint\n";
-        fConstrMat.Print("EKBefore = ",sout,EMathematicaInput);
-        LOGPZ_DEBUG(logger, sout.str())
-    }
-#endif
-    int64_t inpos = this->fConstrBlock.Position(constraintindex);
-    int64_t toteq = this->fConstrMat.Rows();
-    int64_t nrhs = this->fConstrMat.Cols();
-
-    for (std::list<TPZOneShapeRestraint>::iterator it = fOneRestraints.begin(); it != fOneRestraints.end(); it++) {
-        if (it->fFaces[0].first != dfnindex) {
-            continue;
-        }
-        int64_t send = inpos+it->fFaces[0].second;
-        for (int id=1; id<4; id++) {
-            int64_t depindex = it->fFaces[id].first;
-            int locdep = 0;
-            for (locdep = 0; locdep < fConstrConnect.size(); locdep++) {
-                if (fConstrConnect[locdep] == depindex) {
-                    break;
-                }
-            }
-            if (locdep == fConstrConnect.size()) {
-                DebugStop();
-            }
-            int64_t deppos = this->fConstrBlock.Position(locdep);
-            int64_t receive = deppos+it->fFaces[id].second;
-            REAL coef = -it->fOrient[id]/it->fOrient[0];
-            if (this->fType == TPZElementMatrix::EK){
-                for(int ieq=0; ieq<toteq; ieq++) {
-                    (this->fConstrMat)(receive,ieq) += coef*(this->fConstrMat)(send,ieq);
-                }
-            }//EK
-            else
-            {
-                
-                for(int ieq=0; ieq<nrhs; ieq++) {
-                    (this->fConstrMat)(receive,ieq) += coef*(this->fConstrMat)(send,ieq);
-                }
-            }//EF
-
-            if (this->fType == TPZElementMatrix::EK){
-                for(int ieq=0; ieq<toteq; ieq++)
-                {
-                    (this->fConstrMat)(ieq,receive) += coef*(this->fConstrMat)(ieq,send);
-                }
-            }//EK
-
-        }
-        if (this->fType == TPZElementMatrix::EK){
-            for(int ieq=0; ieq<toteq; ieq++)
-            {
-                (this->fConstrMat)(ieq,send) = 0.;
-                (this->fConstrMat)(send,ieq) = 0.;
-            }
-            (this->fConstrMat)(send,send) = 1.;
-        }//EK
-        else
-        {
-            for(int ieq=0; ieq<nrhs; ieq++) {
-                (this->fConstrMat)(send,ieq) = 0.;
-            }
-        }
-
-    }
-#ifdef PZ_LOG
-    if (count && logger.isDebugEnabled()) {
-        std::stringstream sout;
-        sout << "Element matrix after ApplyOneShapeConstraint\n";
-        fConstrMat.Print("EKAfter = ",sout,EMathematicaInput);
-        LOGPZ_DEBUG(logger, sout.str())
-    }
-#endif
-}
-
-
-
 bool TPZElementMatrix::HasDependency()
 {
     if (fOneRestraints.size()) {
@@ -512,56 +113,6 @@ bool TPZElementMatrix::HasDependency()
 	}
 	return false;
 }
-
-/** @brief permute the order of the connects */
-void TPZElementMatrix::PermuteGather(TPZVec<int64_t> &permute)
-{
-    if (permute.size() != fConnect.size()) {
-        DebugStop();
-    }
-    TPZElementMatrix cp(*this);
-    for (int64_t i=0; i<fConnect.size(); ++i) {
-        fConnect[i] = cp.fConnect[permute[i]];
-        fBlock.Set(i, cp.fBlock.Size(permute[i]));
-    }
-    fBlock.Resequence();
-#ifdef PZ_LOG2
-    if (logger.isDebugEnabled()) {
-        std::stringstream sout;
-        cp.fBlock.Print("cp.fBlock ",sout);
-        fBlock.Print("fBlock ",sout);
-        LOGPZ_DEBUG(logger, sout.str())
-    }
-#endif
-    if (fType == EK) {
-        int64_t ibl,jbl;
-        for (ibl=0; ibl<fBlock.NBlocks(); ++ibl) {
-            int64_t iblsize = fBlock.Size(ibl);
-            for (jbl=0; jbl<fBlock.NBlocks(); ++jbl) {
-                int64_t jblsize = fBlock.Size(jbl);
-                for (int64_t idf=0; idf<iblsize; ++idf) {
-                    for (int64_t jdf=0; jdf<jblsize; ++jdf) {
-                        fMat.at(fBlock.at(ibl,jbl,idf,jdf)) = cp.fMat.at(cp.fBlock.at(permute[ibl],permute[jbl],idf,jdf));
-                    }
-                }
-            }
-        }
-    }
-    else if (fType == EF)
-    {
-        int64_t ibl;
-        for (ibl=0; ibl<fBlock.NBlocks(); ++ibl) {
-            int64_t iblsize = fBlock.Size(ibl);
-            int64_t jblsize = fMat.Cols();
-            for (int64_t idf=0; idf<iblsize; ++idf) {
-                for (int64_t jdf=0; jdf<jblsize; ++jdf) {
-                    fMat.at(fBlock.at(ibl,0,idf,jdf)) = cp.fMat.at(cp.fBlock.at(permute[ibl],0,idf,jdf));
-                }
-            }
-        }
-    }
-}
-
 
 void TPZElementMatrix::BuildDependencyOrder(TPZVec<int64_t> &connectlist, TPZVec<int> &DependenceOrder, TPZCompMesh &mesh) {
     // nodelist (input) : vector which contains pointers to all nodes which

--- a/Mesh/pzintel.cpp
+++ b/Mesh/pzintel.cpp
@@ -1695,10 +1695,8 @@ REAL TPZInterpolatedElement::MeanSolution(int var) {
 }
 
 /**Compute the contribution to stiffness matrix and load vector on the element*/
-void TPZInterpolatedElement::CalcIntegral(TPZElementMatrix &efb) {
-    //TODOCOMPLEX
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
+template<class TVar>
+void TPZInterpolatedElement::CalcIntegral(TPZElementMatrixT<TVar> &ef) {
     int i;
     TPZMaterial * material = Material();
     if (!material) {
@@ -1713,13 +1711,13 @@ void TPZInterpolatedElement::CalcIntegral(TPZElementMatrix &efb) {
     int dim = Dimension();
     int nshape = NShapeF();
     TPZBlock &block = Mesh()->Block();
-    TPZFMatrix<STATE> &solution = Mesh()->Solution();
+    TPZFMatrix<TVar> &solution = Mesh()->Solution();
     int numloadcases = solution.Cols();
 
     int numeq = nshape*numdof;
     ef.fMat.Redim(numeq, numloadcases);
     ef.fBlock.SetNBlocks(ncon);
-    TPZVec<STATE> sol(numdof, 0.);
+    TPZVec<TVar> sol(numdof, 0.);
     for (i = 0; i < ncon; i++) {
         TPZConnect &c = Connect(i);
         unsigned int nshape = c.NShape();
@@ -1758,7 +1756,7 @@ void TPZInterpolatedElement::CalcIntegral(TPZElementMatrix &efb) {
         Shape(intpoint, phi, dphi);
 
         int64_t l, iv = 0;
-        STATE coef;
+        TVar coef;
         for (int ist = 0; ist < numloadcases; ist++) {
             for (in = 0; in < numdof; in++) sol[in] = 0.;
             for (in = 0; in < ncon; in++) {
@@ -1768,13 +1766,13 @@ void TPZInterpolatedElement::CalcIntegral(TPZElementMatrix &efb) {
                 for (jn = 0; jn < dfvar; jn++) {
                     int64_t pos = block.Position(dfseq);
                     coef = solution(pos + jn, ist);
-                    sol[iv % numdof] += (STATE) phi(iv / numdof, 0) * coef;
+                    sol[iv % numdof] += (TVar) phi(iv / numdof, 0) * coef;
                     iv++;
                 }
             }
             for (in = 0; in < nshape; in++)
                 for (l = 0; l < numdof; l++)
-                    (ef.fMat)(in * numdof + l, 0) += (STATE) weight * (STATE) phi(in, 0) * sol[l];
+                    (ef.fMat)(in * numdof + l, 0) += (TVar) weight * (TVar) phi(in, 0) * sol[l];
         }
     }
 }
@@ -2011,3 +2009,8 @@ bool TPZInterpolatedElement::VerifyConstraintConsistency(int side, TPZCompElSide
 void TPZInterpolatedElement::SetCreateFunctions(TPZCompMesh* mesh) {
     mesh->SetAllCreateFunctionsContinuous();
 }
+
+
+template
+void TPZInterpolatedElement::
+CalcIntegral<STATE>(TPZElementMatrixT<STATE>&ef);

--- a/Mesh/pzintel.cpp
+++ b/Mesh/pzintel.cpp
@@ -13,7 +13,7 @@
 #include "pzsolve.h"
 #include "pzstepsolver.h"
 #include "pzquad.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "pzmat1dlin.h"
 #include "time.h"
 #include "pzmanvector.h"
@@ -1695,7 +1695,10 @@ REAL TPZInterpolatedElement::MeanSolution(int var) {
 }
 
 /**Compute the contribution to stiffness matrix and load vector on the element*/
-void TPZInterpolatedElement::CalcIntegral(TPZElementMatrix &ef) {
+void TPZInterpolatedElement::CalcIntegral(TPZElementMatrix &efb) {
+    //TODOCOMPLEX
+	auto &ef =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     int i;
     TPZMaterial * material = Material();
     if (!material) {

--- a/Mesh/pzintel.h
+++ b/Mesh/pzintel.h
@@ -441,8 +441,14 @@ public:
 	/** @brief Returns total mass contained into the element */
 	REAL MeanSolution(int var);
 	/** @brief Computes the integral over the finite element */
-	void CalcIntegral(TPZElementMatrix &ef);
+	template<class TVar>
+	void CalcIntegral(TPZElementMatrixT<TVar> &ef);
 	
 };
 
+
+
+extern template
+void TPZInterpolatedElement::
+CalcIntegral<STATE>(TPZElementMatrixT<STATE>&ef);
 #endif

--- a/Mesh/pzinterpolationspace.cpp
+++ b/Mesh/pzinterpolationspace.cpp
@@ -320,12 +320,8 @@ void TPZInterpolationSpace::VectorialProd(TPZVec<REAL> & ivec, TPZVec<REAL> & jv
 	}
 }
 
-void TPZInterpolationSpace::CalcStiff(TPZElementMatrix &ekb, TPZElementMatrix &efb){
-    //TODOCOMPLEX
-    auto &ek =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
+template<class TVar>
+void TPZInterpolationSpace::CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef){
     TPZMaterial * material = Material();
     if(!material){
         PZError << "Error at " << __PRETTY_FUNCTION__ << " this->Material() == NULL\n";
@@ -395,9 +391,8 @@ void TPZInterpolationSpace::CalcStiff(TPZElementMatrix &ekb, TPZElementMatrix &e
     
 }//CalcStiff
 
-void TPZInterpolationSpace::CalcResidual(TPZElementMatrix &efb){
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
+template<class TVar>
+void TPZInterpolationSpace::CalcResidualInternal(TPZElementMatrixT<TVar> &ef){
 	
 	TPZMaterial * material = Material();
 	if(!material){

--- a/Mesh/pzinterpolationspace.h
+++ b/Mesh/pzinterpolationspace.h
@@ -198,13 +198,18 @@ virtual int ClassId() const override;
 	 * @param ek element matrix
 	 * @param ef element right hand side
 	 */
-	virtual void CalcStiff(TPZElementMatrix &ek, TPZElementMatrix &ef) override;
+	virtual void CalcStiff(TPZElementMatrixT<STATE> &ek,
+                           TPZElementMatrixT<STATE> &ef) override{
+        CalcStiffInternal<STATE>(ek,ef);
+    }
 	
 	/**
 	 * @brief Only computes the element residual
 	 * @param ef element residual
 	 */
-	virtual void CalcResidual(TPZElementMatrix &ef) override;
+	virtual void CalcResidual(TPZElementMatrixT<STATE> &ef) override{
+        CalcResidualInternal<STATE>(ef);
+    }
 	
 	/** @brief Initialize element matrix in which is computed CalcStiff */
 	virtual void InitializeElementMatrix(TPZElementMatrix &ek, TPZElementMatrix &ef) override;
@@ -339,6 +344,10 @@ public:
 	void BuildTransferMatrix(TPZInterpolationSpace &coarsel, TPZTransform<> &t, TPZTransfer<STATE> &transfer);
 	
 protected:
+    template<class TVar>
+    void CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef);
+    template<class TVar>
+    void CalcResidualInternal(TPZElementMatrixT<TVar> &ef);
 	
 	/**
 	 * @brief Auxiliary method to expand a vector of shapefunctions and their derivatives to acount for constraints

--- a/Mesh/pzinterpolationspace.h
+++ b/Mesh/pzinterpolationspace.h
@@ -202,6 +202,10 @@ virtual int ClassId() const override;
                            TPZElementMatrixT<STATE> &ef) override{
         CalcStiffInternal<STATE>(ek,ef);
     }
+    virtual void CalcStiff(TPZElementMatrixT<CSTATE> &ek,
+                           TPZElementMatrixT<CSTATE> &ef) override{
+        CalcStiffInternal<CSTATE>(ek,ef);
+    }
 	
 	/**
 	 * @brief Only computes the element residual
@@ -209,6 +213,9 @@ virtual int ClassId() const override;
 	 */
 	virtual void CalcResidual(TPZElementMatrixT<STATE> &ef) override{
         CalcResidualInternal<STATE>(ef);
+    }
+    virtual void CalcResidual(TPZElementMatrixT<CSTATE> &ef) override{
+        CalcResidualInternal<CSTATE>(ef);
     }
 	
 	/** @brief Initialize element matrix in which is computed CalcStiff */

--- a/Mesh/pzmultiphysicscompel.cpp
+++ b/Mesh/pzmultiphysicscompel.cpp
@@ -789,14 +789,9 @@ void TPZMultiphysicsCompEl<TGeometry>::CleanupMaterialData(TPZVec<TPZMaterialDat
 }
 
 template <class TGeometry>
-void TPZMultiphysicsCompEl<TGeometry>::CalcStiff(TPZElementMatrix &ekb, TPZElementMatrix &efb)
+template<class TVar>
+void TPZMultiphysicsCompEl<TGeometry>::CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef)
 {
-
-    //TODOCOMPLEX
-    auto &ek =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     TPZMaterial * material = Material();
     if(!material){
         PZError << "Error at " << __PRETTY_FUNCTION__ << " this->Material() == NULL\n";
@@ -886,11 +881,9 @@ void TPZMultiphysicsCompEl<TGeometry>::CalcStiff(TPZElementMatrix &ekb, TPZEleme
 }//CalcStiff
 
 template <class TGeometry>
-void TPZMultiphysicsCompEl<TGeometry>::CalcResidual(TPZElementMatrix &efb)
+template<class TVar>
+void TPZMultiphysicsCompEl<TGeometry>::CalcResidualInternal(TPZElementMatrixT<TVar> &ef)
 {
-    //TODOCOMPLEX
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     TPZMaterial * material = Material();
     if(!material){
         PZError << "Error at " << __PRETTY_FUNCTION__ << " this->Material() == NULL\n";

--- a/Mesh/pzmultiphysicscompel.cpp
+++ b/Mesh/pzmultiphysicscompel.cpp
@@ -20,7 +20,7 @@
 #include "pzgeopyramid.h"
 #include "TPZMaterial.h"
 #include "TPZNullMaterial.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "pzconnect.h"
 #include "pzmaterialdata.h"
 #include "pzinterpolationspace.h"
@@ -572,10 +572,10 @@ void TPZMultiphysicsCompEl<TGeometry>::InitializeElementMatrix(TPZElementMatrix 
     }
     
     const int numstate = nstate;
-    ek.fMat.Redim(numeq,numeq);
-    ef.fMat.Redim(numeq,numloadcases);
-    ek.fBlock.SetNBlocks(ncon);
-    ef.fBlock.SetNBlocks(ncon);
+    ek.Matrix().Redim(numeq,numeq);
+    ef.Matrix().Redim(numeq,numloadcases);
+    ek.Block().SetNBlocks(ncon);
+    ef.Block().SetNBlocks(ncon);
     
     int i;
     for(i=0; i<ncon; i++){
@@ -586,8 +586,8 @@ void TPZMultiphysicsCompEl<TGeometry>::InitializeElementMatrix(TPZElementMatrix 
             DebugStop();
         }
 #endif
-        ek.fBlock.Set(i,ndof);
-        ef.fBlock.Set(i,ndof);
+        ek.Block().Set(i,ndof);
+        ef.Block().Set(i,ndof);
     }
     ek.fConnect.Resize(ncon);
     ef.fConnect.Resize(ncon);
@@ -631,8 +631,8 @@ void TPZMultiphysicsCompEl<TGeometry>::InitializeElementMatrix(TPZElementMatrix 
     }
     
     const int numstate = nstate;
-    ef.fMat.Redim(numeq,numloadcases);
-    ef.fBlock.SetNBlocks(ncon);
+    ef.Matrix().Redim(numeq,numloadcases);
+    ef.Block().SetNBlocks(ncon);
     
     int i;
     for(i=0; i<ncon; i++){
@@ -643,7 +643,7 @@ void TPZMultiphysicsCompEl<TGeometry>::InitializeElementMatrix(TPZElementMatrix 
             DebugStop();
         }
 #endif
-        ef.fBlock.Set(i,ndof);
+        ef.Block().Set(i,ndof);
     }
     ef.fConnect.Resize(ncon);
     for(i=0; i<ncon; i++){
@@ -789,8 +789,14 @@ void TPZMultiphysicsCompEl<TGeometry>::CleanupMaterialData(TPZVec<TPZMaterialDat
 }
 
 template <class TGeometry>
-void TPZMultiphysicsCompEl<TGeometry>::CalcStiff(TPZElementMatrix &ek, TPZElementMatrix &ef)
+void TPZMultiphysicsCompEl<TGeometry>::CalcStiff(TPZElementMatrix &ekb, TPZElementMatrix &efb)
 {
+
+    //TODOCOMPLEX
+    auto &ek =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
+	auto &ef =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     TPZMaterial * material = Material();
     if(!material){
         PZError << "Error at " << __PRETTY_FUNCTION__ << " this->Material() == NULL\n";
@@ -880,8 +886,11 @@ void TPZMultiphysicsCompEl<TGeometry>::CalcStiff(TPZElementMatrix &ek, TPZElemen
 }//CalcStiff
 
 template <class TGeometry>
-void TPZMultiphysicsCompEl<TGeometry>::CalcResidual(TPZElementMatrix &ef)
+void TPZMultiphysicsCompEl<TGeometry>::CalcResidual(TPZElementMatrix &efb)
 {
+    //TODOCOMPLEX
+	auto &ef =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     TPZMaterial * material = Material();
     if(!material){
         PZError << "Error at " << __PRETTY_FUNCTION__ << " this->Material() == NULL\n";

--- a/Mesh/pzmultiphysicscompel.h
+++ b/Mesh/pzmultiphysicscompel.h
@@ -32,7 +32,10 @@ protected:
     /// Integration rule associated with the element
     typename TGeometry::IntruleType fIntRule;
     
-    
+    template<class TVar>
+    void CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef);
+    template<class TVar>
+    void CalcResidualInternal(TPZElementMatrixT<TVar> &ef);
 	
 public:
 	/**
@@ -284,14 +287,18 @@ public:
 	 * @param ek element matrix
 	 * @param ef element right hand side
 	 */
-	virtual void CalcStiff(TPZElementMatrix &ek, TPZElementMatrix &ef) override;
+	virtual void CalcStiff(TPZElementMatrixT<STATE> &ek, TPZElementMatrixT<STATE> &ef) override{
+        CalcStiffInternal<STATE>(ek,ef);
+    }
 	
     /**
      * @brief Computes the element stiffness matrix and right hand side
      * @param ek element matrix
      * @param ef element right hand side
      */
-    virtual void CalcResidual(TPZElementMatrix &ef) override;
+    virtual void CalcResidual(TPZElementMatrixT<STATE> &ef) override{
+        CalcResidualInternal<STATE>(ef);
+    }
     
 	/** @brief Initialize element matrix in which is computed CalcStiff */
 	void InitializeElementMatrix(TPZElementMatrix &ek, TPZElementMatrix &ef) override;

--- a/Mesh/pzmultiphysicselement.cpp
+++ b/Mesh/pzmultiphysicselement.cpp
@@ -447,8 +447,20 @@ void TPZMultiphysicsElement::ComputeRequiredData(TPZVec<REAL> &intpointtemp, TPZ
 }//ComputeRequiredData
 
 
-
 void TPZMultiphysicsElement::TransferMultiphysicsElementSolution()
+{
+    if(fMesh->GetSolType() == EReal){
+        return TransferMultiphysicsElementSolutionInternal<STATE>();
+    }
+    if(fMesh->GetSolType() == EComplex){
+        return TransferMultiphysicsElementSolutionInternal<CSTATE>();
+    }
+    PZError<<__PRETTY_FUNCTION__<<'\n';
+    PZError<<"Invalid type! Aborting...\n";
+    DebugStop();
+}
+template<class TVar>
+void TPZMultiphysicsElement::TransferMultiphysicsElementSolutionInternal()
 {
     int nmeshes = this->NMeshes();
     int icon = 0;
@@ -477,9 +489,8 @@ void TPZMultiphysicsElement::TransferMultiphysicsElementSolution()
 #endif
             int pos = this->Mesh()->Block().Position(seq);
             int posloc = cel->Mesh()->Block().Position(seqloc);
-            //TODOCOMPLEX
-            TPZFMatrix<STATE> &celSol = cel->Mesh()->Solution();
-            TPZFMatrix<STATE> &meshSol = this->Mesh()->Solution();
+            TPZFMatrix<TVar> &celSol = cel->Mesh()->Solution();
+            TPZFMatrix<TVar> &meshSol = this->Mesh()->Solution();
             for (int ibl = 0; ibl < blsz; ibl++) {
                 for (int iload = 0; iload < nload; iload++) {
                     celSol(posloc+ibl,iload) = meshSol(pos+ibl,iload);

--- a/Mesh/pzmultiphysicselement.h
+++ b/Mesh/pzmultiphysicselement.h
@@ -98,7 +98,7 @@ public:
 	 */
     void EvaluateError(TPZVec<STATE> &errors, bool store_error) override;  
 
-	virtual void CalcStiff(TPZElementMatrix &ek,TPZElementMatrix &ef) override = 0 ;
+	virtual void CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef) override = 0 ;
 	
 	virtual void CreateGraphicalElement(TPZGraphMesh &grmesh, int dimension) override =0 ;
 	

--- a/Mesh/pzmultiphysicselement.h
+++ b/Mesh/pzmultiphysicselement.h
@@ -25,7 +25,9 @@ protected:
     
     /** @brief List of active approximation spaces */
     TPZManVector<int,5> fActiveApproxSpace;
-    
+
+    template<class TVar>
+    void TransferMultiphysicsElementSolutionInternal();
 public:
 	/** @brief Default constructor */
 	TPZMultiphysicsElement() : TPZCompEl()

--- a/Mesh/pzreducedspace.cpp
+++ b/Mesh/pzreducedspace.cpp
@@ -227,16 +227,18 @@ void TPZReducedSpace::InitializeElementMatrix(TPZElementMatrix &ek, TPZElementMa
 	const int nshape = this->NShapeF();
 	const int numeq = nshape*numdof;
     const int numloadcases = mat->NumLoadCases();
-	ek.fMat.Redim(numeq,numeq);
-	ef.fMat.Redim(numeq,numloadcases);
-	ek.fBlock.SetNBlocks(ncon);
-	ef.fBlock.SetNBlocks(ncon);
+	ek.Matrix().Redim(numeq,numeq);
+	ef.Matrix().Redim(numeq,numloadcases);
+    auto &ekBlock = ek.Block();
+    auto &efBlock = ef.Block();
+	ekBlock.SetNBlocks(ncon);
+	efBlock.SetNBlocks(ncon);
 
 	int i;
 	for(i=0; i<ncon; i++){
         unsigned int nshape = Connect(i).NShape();
-		ek.fBlock.Set(i,nshape*numdof);
-		ef.fBlock.Set(i,nshape*numdof);
+		ekBlock.Set(i,nshape*numdof);
+		efBlock.Set(i,nshape*numdof);
 	}
 	ek.fConnect.Resize(ncon);
 	ef.fConnect.Resize(ncon);
@@ -261,13 +263,13 @@ void TPZReducedSpace::InitializeElementMatrix(TPZElementMatrix &ef)
 	const int nshape = this->NShapeF();
 	const int numeq = nshape*numdof;
     const int numloadcases = mat->NumLoadCases();
-	ef.fMat.Redim(numeq,numloadcases);
-	ef.fBlock.SetNBlocks(ncon);
+	ef.Matrix().Redim(numeq,numloadcases);
+	ef.Block().SetNBlocks(ncon);
 
 	int i;
 	for(i=0; i<ncon; i++){
         unsigned int nshape = Connect(i).NShape();
-		ef.fBlock.Set(i,nshape*numdof);
+		ef.Block().Set(i,nshape*numdof);
 	}
 	ef.fConnect.Resize(ncon);
 	for(i=0; i<ncon; i++){

--- a/Mesh/pzsubcmesh.cpp
+++ b/Mesh/pzsubcmesh.cpp
@@ -1070,13 +1070,8 @@ void TPZSubCompMesh::InitializeEF(TPZElementMatrix &ef)
 }
 
 
-
-void TPZSubCompMesh::CalcStiff(TPZElementMatrix &ekb, TPZElementMatrix &efb){
-    //TODOCOMPLEX
-    auto &ek =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
+template<class TVar>
+void TPZSubCompMesh::CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef){
 	if(!fAnalysis)
 	{
         PZError<<__PRETTY_FUNCTION__;
@@ -1249,8 +1244,8 @@ void TPZSubCompMesh::CalcStiff(TPZElementMatrix &ekb, TPZElementMatrix &efb){
 		(ek.fConnect)[i] = ConnectIndex(i);
 	}
 	if (! fAnalysis){
-		TPZFStructMatrix<STATE> local(this);
-		TPZAutoPointer<TPZMatrix<STATE> > stiff = local.CreateAssemble(ef.fMat,NULL);
+		TPZFStructMatrix<TVar> local(this);
+		TPZAutoPointer<TPZMatrix<TVar> > stiff = local.CreateAssemble(ef.fMat,NULL);
 		ek.fMat = *(stiff.operator->());
 		//		TPZStructMatrix::Assemble(ek.fMat,ef.fMat,*this,-1,-1);
 	}
@@ -1266,7 +1261,7 @@ void TPZSubCompMesh::CalcStiff(TPZElementMatrix &ekb, TPZElementMatrix &efb){
 		TPZSubMeshFrontalAnalysis *sman = dynamic_cast<TPZSubMeshFrontalAnalysis *> (fAnalysis.operator->());
 		if(sman)
 		{
-			TPZAbstractFrontMatrix<STATE> *frontmat = dynamic_cast<TPZAbstractFrontMatrix<STATE> *> (fAnalysis->MatrixSolver<STATE>().Matrix().operator->());
+			TPZAbstractFrontMatrix<TVar> *frontmat = dynamic_cast<TPZAbstractFrontMatrix<TVar> *> (fAnalysis->MatrixSolver<TVar>().Matrix().operator->());
 			if(frontmat)
 			{
 				sman->SetFront(frontmat->GetFront());
@@ -1309,12 +1304,10 @@ void TPZSubCompMesh::CalcStiff(TPZElementMatrix &ekb, TPZElementMatrix &efb){
  * @brief Computes the element right hand side
  * @param ef element load vector(s)
  */
-void TPZSubCompMesh::CalcResidual(TPZElementMatrix &efb)
+template<class TVar>
+void TPZSubCompMesh::CalcResidualInternal(TPZElementMatrixT<TVar> &ef)
 {
-    //TODOCOMPLEX
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
-    TPZFMatrix<STATE> rhs;
+    TPZFMatrix<TVar> rhs;
     fAnalysis->AssembleResidual();
     TPZSubMeshAnalysis * castedAnal = dynamic_cast<TPZSubMeshAnalysis *>(fAnalysis.operator->());
 
@@ -1328,7 +1321,7 @@ void TPZSubCompMesh::CalcResidual(TPZElementMatrix &efb)
 //    ef.PermuteGather(fIndexes);
 //    fCondensed.SetF(ef.fMat);
 //    //const TPZFMatrix<REAL> &f1 = fCondensed.F1Red();
-//    TPZFNMatrix<100,STATE> f1(fCondensed.Dim1(),ef.fMat.Cols());
+//    TPZFNMatrix<100,TVar> f1(fCondensed.Dim1(),ef.fMat.Cols());
 //    fCondensed.F1Red(f1);
 //    int64_t dim1 = f1.Rows();
 //    int64_t dim = ef.fMat.Rows();

--- a/Mesh/pzsubcmesh.h
+++ b/Mesh/pzsubcmesh.h
@@ -35,6 +35,10 @@ public TPZCompMesh,
 public TPZCompEl
 {
 protected:
+    template<class TVar>
+    void CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef);
+    template<class TVar>
+    void CalcResidualInternal(TPZElementMatrixT<TVar> &ef);
 	/** @brief Pointer to submesh analysis object. Defines the resolution type. */
 	TPZAutoPointer<TPZAnalysis> fAnalysis;
 	
@@ -289,7 +293,9 @@ public:
     virtual void Assemble() override;
     
   	/** @brief Calculates the submesh stiffness matrix */
-	virtual void CalcStiff(TPZElementMatrix &ek,TPZElementMatrix &ef) override;
+	virtual void CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef) override{
+        CalcStiffInternal<STATE>(ef,ef);
+    }
 	
     /// Initialize the datastructure of ef
     void InitializeEF(TPZElementMatrix &ef);
@@ -298,7 +304,9 @@ public:
      * @brief Computes the element right hand side
      * @param ef element load vector(s)
      */
-    virtual void CalcResidual(TPZElementMatrix &ef) override;
+    virtual void CalcResidual(TPZElementMatrixT<STATE> &ef) override{
+        CalcResidualInternal<STATE>(ef);
+    }
     
     /**
      * Compute the residual norm of the internal equation

--- a/Post/pzcompelpostproc.h
+++ b/Post/pzcompelpostproc.h
@@ -13,7 +13,7 @@ class TPZMaterialData;
 #include "tpzautopointer.h"
 #include "TPZMaterial.h"
 #include "pzmaterialdata.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "pzstack.h"
 #include "pzcmesh.h"
 #include "pzquad.h"
@@ -248,8 +248,11 @@ inline void TPZCompElPostProc<TCOMPEL>::Read(TPZStream &buf, void *context)
 
 
 template <class TCOMPEL>
-inline void TPZCompElPostProc<TCOMPEL>::CalcResidual(TPZElementMatrix &ef)
+inline void TPZCompElPostProc<TCOMPEL>::CalcResidual(TPZElementMatrix &efb)
 {
+    //TODOCOMPLEX
+	auto &ef =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     ef.Reset();
     
     this->InitializeElementMatrix(ef);

--- a/Post/pzcompelpostproc.h
+++ b/Post/pzcompelpostproc.h
@@ -92,13 +92,15 @@ public:
      * The final ef vector shall be copied onto the solution vector, as it represents
      * the shape functions multipliers of the extrapolation functions.
      */
-    virtual void CalcResidual(TPZElementMatrix &ef) override;
+    virtual void CalcResidual(TPZElementMatrixT<STATE> &ef) override{
+        CalcResidualInternal(ef);
+    }
     
     /**
      * @brief Null implementation of the CalcStiff in order to ensure it wouldn't produce
      * any valid system of equations.
      */
-    virtual void CalcStiff(TPZElementMatrix &ek, TPZElementMatrix &ef) override;
+    void CalcStiff(TPZElementMatrixT<STATE> &ek, TPZElementMatrixT<STATE> &ef) override;
     
     /** @brief Compare some fields of 2 TPZMaterialData and return true if these do match. */
     bool dataequal(TPZMaterialData &d1,TPZMaterialData &d2);
@@ -146,15 +148,17 @@ public:
     virtual void ComputeShape(TPZVec<REAL> &intpoint, TPZVec<REAL> &X, TPZFMatrix<REAL> &jacobian, TPZFMatrix<REAL> &axes,
                               REAL &detjac, TPZFMatrix<REAL> &jacinv, TPZFMatrix<REAL> &phi, TPZFMatrix<REAL> &dphi, TPZFMatrix<REAL> &dphidx) override;
     
-    
-public:
-        int ClassId() const override;
+   
+    int ClassId() const override;
     
     /** @brief Save the element data to a stream */
     void Write(TPZStream &buf, int withclassid) const override;
     
     /** @brief Read the element data from a stream */
     void Read(TPZStream &buf, void *context) override;
+protected:
+    template<class TVar>
+    void CalcResidualInternal(TPZElementMatrixT<TVar> &ef);
     
 };
 
@@ -248,11 +252,9 @@ inline void TPZCompElPostProc<TCOMPEL>::Read(TPZStream &buf, void *context)
 
 
 template <class TCOMPEL>
-inline void TPZCompElPostProc<TCOMPEL>::CalcResidual(TPZElementMatrix &efb)
+template<class TVar>
+inline void TPZCompElPostProc<TCOMPEL>::CalcResidualInternal(TPZElementMatrixT<TVar> &ef)
 {
-    //TODOCOMPLEX
-	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     ef.Reset();
     
     this->InitializeElementMatrix(ef);
@@ -434,7 +436,7 @@ inline void TPZCompElPostProc<TCOMPEL>::CalcResidual(TPZElementMatrix &efb)
 }
 
 template <class TCOMPEL>
-inline void TPZCompElPostProc<TCOMPEL>::CalcStiff(TPZElementMatrix &ek, TPZElementMatrix &ef){
+inline void TPZCompElPostProc<TCOMPEL>::CalcStiff(TPZElementMatrixT<STATE> &ek, TPZElementMatrixT<STATE> &ef){
     PZError << "\nTPZCompElPostProc<TCOMPEL>::CalcStiff() Should never be called!!!\n";
     return;
 }

--- a/Post/pzgradientreconstruction.cpp
+++ b/Post/pzgradientreconstruction.cpp
@@ -7,7 +7,7 @@
 //
 #ifndef STATE_COMPLEX //AQUIFRAN
 #include "pzgradientreconstruction.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "pzgradient.h"
 #include "tpzintpoints.h"
 #include "pzmultiphysicselement.h"
@@ -99,8 +99,8 @@ void TPZGradientReconstruction::ProjectionL2GradientReconstructed(TPZCompMesh *c
         TPZCompEl *cel = cmesh->ElementVec()[i];
         if(!cel || cel->Dimension()!=dim) continue;
         
-        TPZElementMatrix ek(cel->Mesh(), TPZElementMatrix::EK);
-        TPZElementMatrix ef(cel->Mesh(), TPZElementMatrix::EF);
+        TPZElementMatrixT<STATE> ek(cel->Mesh(), TPZElementMatrix::EK);
+        TPZElementMatrixT<STATE> ef(cel->Mesh(), TPZElementMatrix::EF);
         
         fGradData->SetCel(cel, useweight, paramK);
 #ifdef PZ_LOG
@@ -170,8 +170,12 @@ void TPZGradientReconstruction::ChangeMaterialIdIntoCompElement(TPZCompEl *cel, 
 }
 
 
-void TPZGradientReconstruction::AssembleGlobalMatrix(TPZCompEl *el, TPZElementMatrix &ek, TPZElementMatrix &ef,TPZMatrix<STATE> & stiffmatrix, TPZFMatrix<STATE> &rhs){
-    
+void TPZGradientReconstruction::AssembleGlobalMatrix(TPZCompEl *el, TPZElementMatrix &ekb, TPZElementMatrix &efb,TPZMatrix<STATE> & stiffmatrix, TPZFMatrix<STATE> &rhs){
+    //TODOCOMPLEX
+    auto &ek =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
+	auto &ef =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
     if(!el->HasDependency()) {
         ek.ComputeDestinationIndices();
         

--- a/Projects/OilWaterSystem/OilWaterSystem.cpp
+++ b/Projects/OilWaterSystem/OilWaterSystem.cpp
@@ -17,7 +17,7 @@
 #include "pzl2projection.h"
 #include "pzelasmat.h"
 #include "TPZSkylineNSymStructMatrix.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "pzmultiphysicscompel.h"
 #include "pzbuildmultiphysicsmesh.h"
 #include "pzmultiphysicselement.h"
@@ -1467,7 +1467,7 @@ void CheckElConvergence(TPZFMatrix<STATE> &RUattn,TPZAnalysis *NonLinearAn, TPZV
     
     int NumberofEl = mphysics->ElementVec().NElements();      
     int64_t neq = mphysics->NEquations();
-    TPZElementMatrix elk(mphysics, TPZElementMatrix::EK),elf(mphysics, TPZElementMatrix::EF);      
+    TPZElementMatrixT<STATE> elk(mphysics, TPZElementMatrix::EK),elf(mphysics, TPZElementMatrix::EF);      
     
     int nsteps = 9;
     STATE du=0.0001;

--- a/Projects/artigoPira/Tools.cpp
+++ b/Projects/artigoPira/Tools.cpp
@@ -6,7 +6,7 @@
 //
 
 #include "Tools.h"
-
+#include "TPZElementMatrixT.h"
 #include "pzgmesh.h"
 #include "pzcmesh.h"
 #include "pzcompel.h"
@@ -1775,8 +1775,8 @@ void IntegrationRuleConvergence(bool intQuarterPoint){
         
         TPZInterpolationSpace *intel = dynamic_cast<TPZInterpolationSpace *>(cel);
         
-        TPZElementMatrix ek(cel->Mesh(), TPZElementMatrix::EK);
-        TPZElementMatrix ef(cel->Mesh(), TPZElementMatrix::EF);
+        TPZElementMatrixT<STATE> ek(cel->Mesh(), TPZElementMatrix::EK);
+        TPZElementMatrixT<STATE> ef(cel->Mesh(), TPZElementMatrix::EF);
         
         TPZFNMatrix<1000, STATE> RefMat1, RefMat2, RefMat;
         TPZFNMatrix<1000, STATE> DifMat;

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ make -j && sudo make install
 where some CMake options were given as an illustration. The following CMake options are available:
 
 - `REAL_TYPE`: which floating point type to use for real data types (geometry). It can be set as `float`, `double`, `long double`, `pzfpcounter` (last option is for internal usage). Default value: `double`.
-- `STATE_TYPE`: which floating point type to use for the Finite Element matrices. It can be set as `float`, `double`, `long double`, `complex<float>`, `complex<double>`, `complex<long double>`. Default value: `double`.
+- `STATE_TYPE`: which floating point type to use for the Finite Element matrices. It can be set as `float`, `double`, `long double`. Complex matrices will be created using `std::complex<STATE>`. Default value: `double`.
 - `CMAKE_INSTALL_PREFIX`: where to install the NeoPZ library. Defaulted to `/opt/neopz` on UNIX systems.
 - `USING_BLAZE`: Enable blaze library support
 - `USING_BOOST`: Enable Boost libraries (`Boost::date_time`, `Boost::graph` and `Boost::unit_test_framework`) support

--- a/StrMatrix/TPZBSpStructMatrix.cpp
+++ b/StrMatrix/TPZBSpStructMatrix.cpp
@@ -166,3 +166,7 @@ int TPZBSpStructMatrix<TVar,TPar>::ClassId() const{
 template class TPZBSpStructMatrix<STATE,TPZStructMatrixOR<STATE>>;
 template class TPZBSpStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZBSpStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
+
+template class TPZBSpStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
+template class TPZBSpStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
+template class TPZBSpStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;

--- a/StrMatrix/TPZFrontStructMatrix.cpp
+++ b/StrMatrix/TPZFrontStructMatrix.cpp
@@ -403,9 +403,9 @@ template<class TFront, class TVar, class TPar>
 void TPZFrontStructMatrix<TFront,TVar,TPar>::AssembleElement(TPZCompEl * el, TPZElementMatrix & ekb, TPZElementMatrix & efb, TPZMatrix<TVar> & stiffness, TPZFMatrix<TVar> & rhs){
 	//TODOCOMPLEX
     auto &ek =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
+		dynamic_cast<TPZElementMatrixT<TVar>&>(ekb);
 	auto &ef =
-		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
+		dynamic_cast<TPZElementMatrixT<TVar>&>(efb);
 	
 	if(!el->HasDependency()) {
 		//ek.fMat->Print("stiff has no constraint",test);

--- a/StrMatrix/TPZFrontStructMatrix.cpp
+++ b/StrMatrix/TPZFrontStructMatrix.cpp
@@ -540,3 +540,11 @@ template class TPZFrontStructMatrix<TPZFrontSym<STATE>,STATE,TPZStructMatrixOT<S
 template class TPZFrontStructMatrix<TPZFrontNonSym<STATE>,STATE,TPZStructMatrixOT<STATE>>;
 template class TPZFrontStructMatrix<TPZFrontSym<STATE>,STATE,TPZStructMatrixTBBFlow<STATE>>;
 template class TPZFrontStructMatrix<TPZFrontNonSym<STATE>,STATE,TPZStructMatrixTBBFlow<STATE>>;
+
+
+template class TPZFrontStructMatrix<TPZFrontSym<CSTATE>,CSTATE,TPZStructMatrixOR<CSTATE>>;
+template class TPZFrontStructMatrix<TPZFrontNonSym<CSTATE>,CSTATE,TPZStructMatrixOR<CSTATE>>;
+template class TPZFrontStructMatrix<TPZFrontSym<CSTATE>,CSTATE,TPZStructMatrixOT<CSTATE>>;
+template class TPZFrontStructMatrix<TPZFrontNonSym<CSTATE>,CSTATE,TPZStructMatrixOT<CSTATE>>;
+template class TPZFrontStructMatrix<TPZFrontSym<CSTATE>,CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;
+template class TPZFrontStructMatrix<TPZFrontNonSym<CSTATE>,CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;

--- a/StrMatrix/TPZFrontStructMatrix.cpp
+++ b/StrMatrix/TPZFrontStructMatrix.cpp
@@ -8,7 +8,7 @@
 // #include "TPZFrontSym.h"
 // #include "TPZFrontNonSym.h"
 #include "pzsubcmesh.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "TPZMaterial.h"
 #include "TPZStackEqnStorage.h"
 
@@ -250,7 +250,7 @@ void TPZFrontStructMatrix<TFront,TVar,TPar>::AssembleNew(TPZMatrix<TVar> & stiff
 	
 	int64_t iel;
 	int64_t numel = 0, nelem = this->fMesh->NElements();
-	TPZElementMatrix ek(this->fMesh,TPZElementMatrix::EK),ef(this->fMesh,TPZElementMatrix::EF);
+	TPZElementMatrixT<TVar> ek(this->fMesh,TPZElementMatrix::EK),ef(this->fMesh,TPZElementMatrix::EF);
 	TPZManVector<int64_t> destinationindex(0);
 	TPZManVector<int64_t> sourceindex(0);
 	
@@ -328,7 +328,7 @@ void TPZFrontStructMatrix<TFront,TVar,TPar>::Assemble(TPZBaseMatrix & stiff_base
     auto& rhs = dynamic_cast<TPZFMatrix<TVar>&>(rhs_base);
 	int64_t iel;
 	int64_t numel = 0, nelem = this->fMesh->NElements();
-	TPZElementMatrix ek(this->fMesh,TPZElementMatrix::EK),ef(this->fMesh,TPZElementMatrix::EF);
+	TPZElementMatrixT<TVar> ek(this->fMesh,TPZElementMatrix::EK),ef(this->fMesh,TPZElementMatrix::EF);
 	
 	TPZAdmChunkVector<TPZCompEl *> &elementvec = this->fMesh->ElementVec();
 	
@@ -400,8 +400,12 @@ void TPZFrontStructMatrix<TFront,TVar,TPar>::Assemble(TPZBaseMatrix & stiff_base
 
 //Verificar declaracao dos parametros !!!!!
 template<class TFront, class TVar, class TPar>
-void TPZFrontStructMatrix<TFront,TVar,TPar>::AssembleElement(TPZCompEl * el, TPZElementMatrix & ek, TPZElementMatrix & ef, TPZMatrix<TVar> & stiffness, TPZFMatrix<TVar> & rhs){
-	
+void TPZFrontStructMatrix<TFront,TVar,TPar>::AssembleElement(TPZCompEl * el, TPZElementMatrix & ekb, TPZElementMatrix & efb, TPZMatrix<TVar> & stiffness, TPZFMatrix<TVar> & rhs){
+	//TODOCOMPLEX
+    auto &ek =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(ekb);
+	auto &ef =
+		dynamic_cast<TPZElementMatrixT<STATE>&>(efb);
 	
 	if(!el->HasDependency()) {
 		//ek.fMat->Print("stiff has no constraint",test);

--- a/StrMatrix/TPZParFrontStructMatrix.cpp
+++ b/StrMatrix/TPZParFrontStructMatrix.cpp
@@ -552,4 +552,12 @@ template class TPZParFrontStructMatrix<TPZFrontNonSym<STATE>,STATE,TPZStructMatr
 template class TPZParFrontStructMatrix<TPZFrontSym<STATE>,STATE,TPZStructMatrixTBBFlow<STATE>>;
 template class TPZParFrontStructMatrix<TPZFrontNonSym<STATE>,STATE,TPZStructMatrixTBBFlow<STATE>>;
 
+template class TPZParFrontStructMatrix<TPZFrontSym<CSTATE>,CSTATE,TPZStructMatrixOR<CSTATE>>;
+template class TPZParFrontStructMatrix<TPZFrontNonSym<CSTATE>,CSTATE,TPZStructMatrixOR<CSTATE>>;
+template class TPZParFrontStructMatrix<TPZFrontSym<CSTATE>,CSTATE,TPZStructMatrixOT<CSTATE>>;
+template class TPZParFrontStructMatrix<TPZFrontNonSym<CSTATE>,CSTATE,TPZStructMatrixOT<CSTATE>>;
+template class TPZParFrontStructMatrix<TPZFrontSym<CSTATE>,CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;
+template class TPZParFrontStructMatrix<TPZFrontNonSym<CSTATE>,CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;
+
+
 

--- a/StrMatrix/TPZParFrontStructMatrix.cpp
+++ b/StrMatrix/TPZParFrontStructMatrix.cpp
@@ -11,7 +11,7 @@
 #include "TPZParFrontMatrix.h"
 #include "pzsubcmesh.h"
 #include "TPZMaterial.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "pzelementgroup.h"
 #include "pzcondensedcompel.h"
 #include "TPZFileEqnStorage.h"
@@ -131,8 +131,10 @@ void *TPZParFrontStructMatrix<TFront,TVar,TPar>::ElementAssemble(void *t){
 		//		int dim = el->NumNodes();
 		
 		//Builds elements stiffness matrix
-		TPZElementMatrix *ek = new TPZElementMatrix(parfront->fMesh,TPZElementMatrix::EK);
-		TPZElementMatrix *ef = new TPZElementMatrix(parfront->fMesh,TPZElementMatrix::EF);
+		auto *ek =
+            new TPZElementMatrixT<TVar>(parfront->fMesh,TPZElementMatrix::EK);
+		auto *ef =
+            new TPZElementMatrixT<TVar>(parfront->fMesh,TPZElementMatrix::EF);
 		
 		el->CalcStiff(*ek, *ef);
 		//Locks a mutex and adds element contribution to frontmatrix

--- a/StrMatrix/TPZSSpStructMatrix.cpp
+++ b/StrMatrix/TPZSSpStructMatrix.cpp
@@ -217,3 +217,7 @@ void TPZSSpStructMatrix<TVar,TPar>::Write(TPZStream& buf, int withclassid) const
 template class TPZSSpStructMatrix<STATE,TPZStructMatrixOR<STATE>>;
 template class TPZSSpStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZSSpStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
+
+template class TPZSSpStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
+template class TPZSSpStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
+template class TPZSSpStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;

--- a/StrMatrix/TPZSkylineNSymStructMatrix.cpp
+++ b/StrMatrix/TPZSkylineNSymStructMatrix.cpp
@@ -41,3 +41,6 @@ int TPZSkylineNSymStructMatrix<TVar,TPar>::ClassId() const{
 template class TPZSkylineNSymStructMatrix<STATE,TPZStructMatrixOR<STATE>>;
 template class TPZSkylineNSymStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZSkylineNSymStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
+template class TPZSkylineNSymStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
+template class TPZSkylineNSymStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
+template class TPZSkylineNSymStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;

--- a/StrMatrix/TPZSpStructMatrix.cpp
+++ b/StrMatrix/TPZSpStructMatrix.cpp
@@ -207,3 +207,7 @@ void TPZSpStructMatrix<TVar,TPar>::Write(TPZStream& buf, int withclassid) const{
 template class TPZSpStructMatrix<STATE,TPZStructMatrixOR<STATE>>;
 template class TPZSpStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZSpStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
+
+template class TPZSpStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
+template class TPZSpStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
+template class TPZSpStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;

--- a/StrMatrix/TPZStructMatrixTBBFlowUtils.cpp
+++ b/StrMatrix/TPZStructMatrixTBBFlowUtils.cpp
@@ -3,7 +3,7 @@
 #include "TPZStructMatrix.h"
 #include "pzcmesh.h"
 #include "TPZTimer.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "pzlog.h"
 
 #ifdef USING_TBB
@@ -224,8 +224,8 @@ void TPZFlowNode<TVar>::operator()(tbb::flow::continue_msg) const
     auto *mystruct = dynamic_cast<TPZStructMatrix*>(myGraph->fStruct);
     TPZCompMesh *cmesh = mystruct->Mesh();
     TPZAutoPointer<TPZGuiInterface> guiInterface = myGraph->fGuiInterface;
-    TPZElementMatrix ek(cmesh,TPZElementMatrix::EK);
-    TPZElementMatrix ef(cmesh,TPZElementMatrix::EF);
+    TPZElementMatrixT<TVar> ek(cmesh,TPZElementMatrix::EK);
+    TPZElementMatrixT<TVar> ef(cmesh,TPZElementMatrix::EF);
 #ifdef PZ_LOG
     if (logger.isDebugEnabled()) {
         std::stringstream sout;

--- a/StrMatrix/TPZStructMatrixTBBFlowUtils.cpp
+++ b/StrMatrix/TPZStructMatrixTBBFlowUtils.cpp
@@ -462,6 +462,8 @@ void TPZFlowGraph<TVar>::OrderElements()
     fElementOrder.Resize(seq);
 }
         
-        template class TPZFlowGraph<STATE>;
-        template class TPZFlowNode<STATE>;
+template class TPZFlowGraph<STATE>;
+template class TPZFlowNode<STATE>;
+template class TPZFlowGraph<CSTATE>;
+template class TPZFlowNode<CSTATE>;
 #endif

--- a/StrMatrix/TPZStructMatrixTBBFlowUtils.h
+++ b/StrMatrix/TPZStructMatrixTBBFlowUtils.h
@@ -46,9 +46,9 @@ public:
   /// gui interface object
   TPZAutoPointer<TPZGuiInterface> fGuiInterface;
   /// global matrix
-  TPZMatrix<STATE> *fGlobMatrix;
+  TPZMatrix<TVar> *fGlobMatrix;
   /// global rhs vector
-  TPZFMatrix<STATE> *fGlobRhs;
+  TPZFMatrix<TVar> *fGlobRhs;
 };
 
 template<class TVar = STATE>

--- a/StrMatrix/pzbdstrmatrix.cpp
+++ b/StrMatrix/pzbdstrmatrix.cpp
@@ -137,3 +137,6 @@ void TPZBlockDiagonalStructMatrix<TVar,TPar>::Write(TPZStream& buf, int withclas
 template class TPZBlockDiagonalStructMatrix<STATE,TPZStructMatrixOR<STATE>>;
 template class TPZBlockDiagonalStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZBlockDiagonalStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
+template class TPZBlockDiagonalStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
+template class TPZBlockDiagonalStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
+template class TPZBlockDiagonalStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;

--- a/StrMatrix/pzbstrmatrix.cpp
+++ b/StrMatrix/pzbstrmatrix.cpp
@@ -48,3 +48,7 @@ void TPZBandStructMatrix<TVar,TPar>::Write(TPZStream& buf, int withclassid) cons
 template class TPZBandStructMatrix<STATE,TPZStructMatrixOR<STATE>>;
 template class TPZBandStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZBandStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
+
+template class TPZBandStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
+template class TPZBandStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
+template class TPZBandStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;

--- a/StrMatrix/pzfstrmatrix.cpp
+++ b/StrMatrix/pzfstrmatrix.cpp
@@ -54,3 +54,7 @@ void TPZFStructMatrix<TVar,TPar>::Write(TPZStream& buf, int withclassid) const{
 template class TPZFStructMatrix<STATE,TPZStructMatrixOR<STATE>>;
 template class TPZFStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZFStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
+
+template class TPZFStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
+template class TPZFStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
+template class TPZFStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;

--- a/StrMatrix/pzsbstrmatrix.cpp
+++ b/StrMatrix/pzsbstrmatrix.cpp
@@ -50,3 +50,7 @@ void TPZSBandStructMatrix<TVar,TPar>::Write(TPZStream& buf, int withclassid) con
 template class TPZSBandStructMatrix<STATE,TPZStructMatrixOR<STATE>>;
 template class TPZSBandStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZSBandStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
+
+template class TPZSBandStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
+template class TPZSBandStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
+template class TPZSBandStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;

--- a/StrMatrix/pzsfstrmatrix.cpp
+++ b/StrMatrix/pzsfstrmatrix.cpp
@@ -54,3 +54,7 @@ void TPZSFStructMatrix<TVar,TPar>::Write(TPZStream& buf, int withclassid) const{
 template class TPZSFStructMatrix<STATE,TPZStructMatrixOR<STATE>>;
 template class TPZSFStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZSFStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
+
+template class TPZSFStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
+template class TPZSFStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
+template class TPZSFStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;

--- a/StrMatrix/pzskylstrmatrix.cpp
+++ b/StrMatrix/pzskylstrmatrix.cpp
@@ -54,3 +54,7 @@ void TPZSkylineStructMatrix<TVar,TPar>::Write(TPZStream& buf, int withclassid) c
 template class TPZSkylineStructMatrix<STATE,TPZStructMatrixOR<STATE>>;
 template class TPZSkylineStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZSkylineStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
+
+template class TPZSkylineStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
+template class TPZSkylineStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
+template class TPZSkylineStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;

--- a/StrMatrix/pzstrmatrixflowtbb.cpp
+++ b/StrMatrix/pzstrmatrixflowtbb.cpp
@@ -159,3 +159,5 @@ void TPZStructMatrixTBBFlow<TVar>::Write(TPZStream& buf, int withclassid) const 
 
 template class TPZStructMatrixTBBFlow<STATE>;
 template class TPZRestoreClass<TPZStructMatrixTBBFlow<STATE>>;
+template class TPZStructMatrixTBBFlow<CSTATE>;
+template class TPZRestoreClass<TPZStructMatrixTBBFlow<CSTATE>>;

--- a/StrMatrix/pzstrmatrixflowtbb.h
+++ b/StrMatrix/pzstrmatrixflowtbb.h
@@ -75,4 +75,5 @@ protected:
 };
 
 extern template class TPZStructMatrixTBBFlow<STATE>;
+extern template class TPZStructMatrixTBBFlow<CSTATE>;
 #endif

--- a/StrMatrix/pzstrmatrixor.cpp
+++ b/StrMatrix/pzstrmatrixor.cpp
@@ -852,3 +852,5 @@ TPZStructMatrixOR<TVar>::ThreadData::ShouldCompute(int matid) const{
 
 template class TPZStructMatrixOR<STATE>;
 template class TPZRestoreClass<TPZStructMatrixOR<STATE>>;
+template class TPZStructMatrixOR<CSTATE>;
+template class TPZRestoreClass<TPZStructMatrixOR<CSTATE>>;

--- a/StrMatrix/pzstrmatrixor.cpp
+++ b/StrMatrix/pzstrmatrixor.cpp
@@ -600,16 +600,12 @@ TPZStructMatrixOR<TVar>::ThreadData::ThreadWork(void *datavoid) {
         }
 
         TPZCompEl *el = cmesh->ElementVec()[iel];
-        TPZElementMatrix *ekp = ek.operator->();
-        TPZElementMatrix *efp = ef.operator->();
-        TPZElementMatrix &ekr = *ekp;
-        TPZElementMatrix &efr = *efp;
 
 #ifndef DRY_RUN
         if (data->fGlobMatrix) {
-            el->CalcStiff(ekr, efr);
+            el->CalcStiff(ek, ef);
         } else {
-            el->CalcResidual(efr);
+            el->CalcResidual(ef);
         }
 #else
         {

--- a/StrMatrix/pzstrmatrixor.cpp
+++ b/StrMatrix/pzstrmatrixor.cpp
@@ -76,7 +76,6 @@ TPZStructMatrixOR<TVar>::Assemble(TPZBaseMatrix & rhs, TPZAutoPointer<TPZGuiInte
         (dynamic_cast<TPZStructMatrix*>(this))->EquationFilter();
     ass_rhs.start();
     if (equationFilter.IsActive()) {
-        //TODOCOMPLEX
         auto rhsState = dynamic_cast<const TPZFMatrix<TVar> *>(&rhs);
             
         int64_t neqcondense = equationFilter.NActiveEquations();

--- a/StrMatrix/pzstrmatrixor.cpp
+++ b/StrMatrix/pzstrmatrixor.cpp
@@ -5,7 +5,7 @@
 #include "pzstrmatrixor.h"
 #include "TPZStructMatrix.h"
 #include "pzsubcmesh.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "TPZTimer.h"
 #include "run_stats_table.h"
 #include "fpo_exceptions.h"
@@ -143,7 +143,7 @@ TPZStructMatrixOR<TVar>::Serial_Assemble(TPZBaseMatrix & stiff_base, TPZBaseMatr
 
     int64_t iel;
     int64_t nelem = cmesh->NElements();
-    TPZElementMatrix ek(cmesh, TPZElementMatrix::EK), ef(cmesh, TPZElementMatrix::EF);
+    TPZElementMatrixT<TVar> ek(cmesh, TPZElementMatrix::EK), ef(cmesh, TPZElementMatrix::EF);
 #ifdef PZ_LOG
     bool globalresult = true;
     bool writereadresult = true;
@@ -408,7 +408,7 @@ TPZStructMatrixOR<TVar>::Serial_Assemble(TPZBaseMatrix & rhs_base, TPZAutoPointe
             }
         }
                 
-        TPZElementMatrix ef(cmesh, TPZElementMatrix::EF);
+        TPZElementMatrixT<TVar> ef(cmesh, TPZElementMatrix::EF);
 
         calcresidual.start();
 
@@ -590,10 +590,11 @@ TPZStructMatrixOR<TVar>::ThreadData::ThreadWork(void *datavoid) {
     int64_t nel = cmesh->NElements();
     while (iel < nel) {
 
-        TPZAutoPointer<TPZElementMatrix> ek;
-        TPZAutoPointer<TPZElementMatrix> ef = new TPZElementMatrix(cmesh, TPZElementMatrix::EF);
+        TPZAutoPointer<TPZElementMatrixT<TVar>> ek;
+        TPZAutoPointer<TPZElementMatrixT<TVar>> ef =
+            new TPZElementMatrixT<TVar>(cmesh, TPZElementMatrix::EF);
         if (data->fGlobMatrix) {
-            ek = new TPZElementMatrix(cmesh, TPZElementMatrix::EK);
+            ek = new TPZElementMatrixT<TVar>(cmesh, TPZElementMatrix::EK);
         } else {
             ek = ef;
         }
@@ -704,12 +705,10 @@ TPZStructMatrixOR<TVar>::ThreadData::ThreadAssembly(void *threaddata) {
         if (guiInterface) if (guiInterface->AmIKilled()) {
             break;//mutex will still be unlocked at the end of the function
             }
-        std::map<int, std::pair< TPZAutoPointer<TPZElementMatrix>, TPZAutoPointer<TPZElementMatrix> > >::iterator itavail;
-        std::set<int>::iterator itprocess;
         bool keeplooking = false;
         if (data->fSubmitted.size() && data->fProcessed.size()) {
-            itavail = data->fSubmitted.begin();
-            itprocess = data->fProcessed.begin();
+            auto itavail = data->fSubmitted.begin();
+            auto itprocess = data->fProcessed.begin();
             if (itavail->first == *itprocess) {
                 // make sure we come back to look for one more element
                 keeplooking = true;
@@ -718,8 +717,8 @@ TPZStructMatrixOR<TVar>::ThreadData::ThreadAssembly(void *threaddata) {
                 int iel = *itprocess;
 #endif
                 data->fProcessed.erase(itprocess);
-                TPZAutoPointer<TPZElementMatrix> ek = itavail->second.first;
-                TPZAutoPointer<TPZElementMatrix> ef = itavail->second.second;
+                TPZAutoPointer<TPZElementMatrixT<TVar>> ek = itavail->second.first;
+                TPZAutoPointer<TPZElementMatrixT<TVar>> ef = itavail->second.second;
                 data->fSubmitted.erase(itavail);
 #ifdef PZ_LOG
                 if (logger.isDebugEnabled()) {
@@ -843,9 +842,9 @@ TPZStructMatrixOR<TVar>::ThreadData::NextElement() {
 
 template<class TVar>
 void 
-TPZStructMatrixOR<TVar>::ThreadData::ComputedElementMatrix(int64_t iel, TPZAutoPointer<TPZElementMatrix> &ek, TPZAutoPointer<TPZElementMatrix> &ef) {
+TPZStructMatrixOR<TVar>::ThreadData::ComputedElementMatrix(int64_t iel, TPZAutoPointer<TPZElementMatrixT<TVar>> &ek, TPZAutoPointer<TPZElementMatrixT<TVar>> &ef) {
     std::scoped_lock lock(fMutexAccessElement);
-    std::pair< TPZAutoPointer<TPZElementMatrix>, TPZAutoPointer<TPZElementMatrix> > el(ek, ef);
+    std::pair< TPZAutoPointer<TPZElementMatrixT<TVar>>, TPZAutoPointer<TPZElementMatrixT<TVar>> > el(ek, ef);
     fSubmitted[iel] = el;
     fAssembly.Post();
 }

--- a/StrMatrix/pzstrmatrixor.h
+++ b/StrMatrix/pzstrmatrixor.h
@@ -14,6 +14,8 @@
 
 //forward declarations
 class TPZElementMatrix;
+template<class T>
+class TPZElementMatrixT;
 class TPZBaseMatrix;
 class TPZStructMatrix;
 
@@ -86,7 +88,7 @@ protected:
         /** @brief Look for an element index which needs to be computed and put it on the stack */
         int64_t NextElement();
         /** @brief Put the computed element matrices in the map */
-        void ComputedElementMatrix(int64_t iel, TPZAutoPointer<TPZElementMatrix> &ek, TPZAutoPointer<TPZElementMatrix> &ef);
+        void ComputedElementMatrix(int64_t iel, TPZAutoPointer<TPZElementMatrixT<TVar>> &ek, TPZAutoPointer<TPZElementMatrixT<TVar>> &ef);
         /** @brief The function which will compute the matrices */
         static void *ThreadWork(void *threaddata);
         /** @brief The function which will compute the assembly */
@@ -102,7 +104,7 @@ protected:
         /** @brief Global rhs vector */
         TPZBaseMatrix *fGlobRhs;
         /** @brief List of computed element matrices (autopointers?) */
-        std::map<int, std::pair< TPZAutoPointer<TPZElementMatrix>, TPZAutoPointer<TPZElementMatrix> > > fSubmitted;
+        std::map<int, std::pair< TPZAutoPointer<TPZElementMatrixT<TVar>>, TPZAutoPointer<TPZElementMatrixT<TVar>> > > fSubmitted;
         /** @brief Elements which are being processed */
         std::set<int> fProcessed;
         /** @brief  Current element */

--- a/StrMatrix/pzstrmatrixor.h
+++ b/StrMatrix/pzstrmatrixor.h
@@ -119,4 +119,5 @@ protected:
 
 
 extern template class TPZStructMatrixOR<STATE>;
+extern template class TPZStructMatrixOR<CSTATE>;
 #endif

--- a/StrMatrix/pzstrmatrixot.cpp
+++ b/StrMatrix/pzstrmatrixot.cpp
@@ -1264,3 +1264,5 @@ void TPZStructMatrixOT<TVar>::Write(TPZStream& buf, int withclassid) const {
 
 template class TPZStructMatrixOT<STATE>;
 template class TPZRestoreClass<TPZStructMatrixOT<STATE>>;
+template class TPZStructMatrixOT<CSTATE>;
+template class TPZRestoreClass<TPZStructMatrixOT<CSTATE>>;

--- a/StrMatrix/pzstrmatrixot.cpp
+++ b/StrMatrix/pzstrmatrixot.cpp
@@ -5,7 +5,7 @@
 
 #include "pzstrmatrixot.h"
 #include "pzsubcmesh.h"
-#include "pzelmat.h"
+#include "TPZElementMatrixT.h"
 #include "TPZStructMatrix.h"
 
 #include "TPZTimer.h"
@@ -236,7 +236,7 @@ void TPZStructMatrixOT<TVar>::Serial_Assemble(TPZBaseMatrix & stiff_base, TPZBas
     
     int64_t iel;
     int64_t nelem = cmesh->NElements();
-    TPZElementMatrix ek(cmesh, TPZElementMatrix::EK),ef(cmesh, TPZElementMatrix::EF);
+    TPZElementMatrixT<TVar> ek(cmesh, TPZElementMatrix::EK),ef(cmesh, TPZElementMatrix::EF);
 #ifdef PZ_LOG
     bool globalresult = true;
     bool writereadresult = true;
@@ -442,7 +442,7 @@ void TPZStructMatrixOT<TVar>::Serial_Assemble(TPZBaseMatrix & rhs_base, TPZAutoP
         int matid = mat->Id();
         if (myself->ShouldCompute(matid) == false) continue;
         
-        TPZElementMatrix ef(cmesh, TPZElementMatrix::EF);
+        TPZElementMatrixT<TVar> ef(cmesh, TPZElementMatrix::EF);
         
         calcresidual.start();
         
@@ -696,8 +696,8 @@ void *TPZStructMatrixOT<TVar>::ThreadData::ThreadWork(void *datavoid)
     
     TPZCompMesh *cmesh = data->fStruct->Mesh();
     TPZAutoPointer<TPZGuiInterface> guiInterface = data->fGuiInterface;
-    TPZElementMatrix ek(cmesh,TPZElementMatrix::EK);
-    TPZElementMatrix ef(cmesh,TPZElementMatrix::EF);
+    TPZElementMatrixT<TVar> ek(cmesh,TPZElementMatrix::EK);
+    TPZElementMatrixT<TVar> ef(cmesh,TPZElementMatrix::EF);
     int64_t numelements = data->fElSequenceColor->size();
     int64_t index = data->fCurrentIndex->fetch_add(1);
 #ifdef PZ_LOG

--- a/StrMatrix/pzstrmatrixot.h
+++ b/StrMatrix/pzstrmatrixot.h
@@ -142,4 +142,5 @@ protected:
 
 
 extern template class TPZStructMatrixOT<STATE>;
+extern template class TPZStructMatrixOT<CSTATE>;
 #endif

--- a/SubStruct/tpzpairstructmatrix.cpp
+++ b/SubStruct/tpzpairstructmatrix.cpp
@@ -606,15 +606,13 @@ void *TPZPairStructMatrix::ThreadData::ThreadWork(void *datavoid)
 	while(iel < nel)
 	{
 		
-		TPZAutoPointer<TPZElementMatrix> ek = new TPZElementMatrixT<STATE>(cmesh,TPZElementMatrix::EK);
-		TPZAutoPointer<TPZElementMatrix> ef = new TPZElementMatrixT<STATE>(cmesh,TPZElementMatrix::EF);
+      TPZAutoPointer<TPZElementMatrixT<STATE>> ek =
+        new TPZElementMatrixT<STATE>(cmesh,TPZElementMatrix::EK);
+      TPZAutoPointer<TPZElementMatrixT<STATE>> ef =
+        new TPZElementMatrixT<STATE>(cmesh,TPZElementMatrix::EF);
 		
 		TPZCompEl *el = cmesh->ElementVec()[iel];
-		TPZElementMatrix *ekp = ek.operator->();
-		TPZElementMatrix *efp = ef.operator->();
-		TPZElementMatrix &ekr = *ekp;
-		TPZElementMatrix &efr = *efp;
-		el->CalcStiff(ekr,efr);
+		el->CalcStiff(ek,ef);
 		
 		
 		if(!el->HasDependency()) {
@@ -864,10 +862,10 @@ int TPZPairStructMatrix::ThreadData::NextElement()
 }
 
 // put the computed element matrices in the map
-void TPZPairStructMatrix::ThreadData::ComputedElementMatrix(int iel, TPZAutoPointer<TPZElementMatrix> &ek, TPZAutoPointer<TPZElementMatrix> &ef)
+void TPZPairStructMatrix::ThreadData::ComputedElementMatrix(int iel, TPZAutoPointer<TPZElementMatrixT<STATE>> &ek, TPZAutoPointer<TPZElementMatrixT<STATE>> &ef)
 {
     unique_lock<std::mutex> lock(fAccessElement);
-	std::pair< TPZAutoPointer<TPZElementMatrix>, TPZAutoPointer<TPZElementMatrix> > el(ek,ef);
+	std::pair< TPZAutoPointer<TPZElementMatrixT<STATE>>, TPZAutoPointer<TPZElementMatrixT<STATE>> > el(ek,ef);
 	fSubmitted1[iel] = el;
 	fSubmitted2[iel] = ek;
 	fAssembly1.Post();

--- a/SubStruct/tpzpairstructmatrix.h
+++ b/SubStruct/tpzpairstructmatrix.h
@@ -94,7 +94,7 @@ public:
 		/** @brief Look for an element index which needs to be computed and put it on the stack */
 		int NextElement();
 		/** @brief Put the computed element matrices in the map */
-		void ComputedElementMatrix(int iel, TPZAutoPointer<TPZElementMatrix> &ek, TPZAutoPointer<TPZElementMatrix> &ef);
+		void ComputedElementMatrix(int iel, TPZAutoPointer<TPZElementMatrixT<STATE>> &ek, TPZAutoPointer<TPZElementMatrixT<STATE>> &ef);
 		/** @brief The function which will compute the matrices */
 		static void *ThreadWork(void *threaddata);
 		/** @brief The function which will compute the assembly */

--- a/cmake/StandardPZSettings.cmake
+++ b/cmake/StandardPZSettings.cmake
@@ -55,10 +55,7 @@ if (NOT STATE_TYPE)
         PROPERTY STRINGS
         "double"
         "float"
-        "long double"
-        "complex<float>"
-        "complex<double>"
-        "complex<long double>")
+        "long double")
 endif ()
 
 if (STATE_TYPE STREQUAL "double")
@@ -67,21 +64,9 @@ elseif (STATE_TYPE STREQUAL "float")
     set(STATE_TYPE_DEF "STATEfloat")
 elseif (STATE_TYPE STREQUAL "long double")
     set(STATE_TYPE_DEF "STATElongdouble")
-elseif (STATE_TYPE STREQUAL "complex<float>")
-    set(STATE_TYPE_DEF "STATEcomplexf")
-    set(STATE_COMPLEX "STATE_COMPLEX")
-    set (BUILD_COMPLEX_PROJECTS ON)
-elseif (STATE_TYPE STREQUAL "complex<double>")
-    set(STATE_TYPE_DEF "STATEcomplexd")
-    set(STATE_COMPLEX "STATE_COMPLEX")
-    set (BUILD_COMPLEX_PROJECTS ON)
-elseif (STATE_TYPE STREQUAL "complex<long double>")
-    set(STATE_TYPE_DEF "STATEcomplexld")
-    set(STATE_COMPLEX "STATE_COMPLEX")
-    set (BUILD_COMPLEX_PROJECTS ON)
 else()
     message(FATAL_ERROR "Please specify a valid type for STATE from the options: "
-            "'double', 'float', 'long double', 'complex<float>', 'complex<double>', 'complex<long double>'")
+            "'double', 'float', 'long double'")
 endif()
 
 message(STATUS "NeoPZ configuration:"


### PR DESCRIPTION
This PR aims to enable the computation of complex FEM matrices with no need for a separate configure-time option.

For this change to happen, apart from all the previous PRs ( #74 , #78, #81), the class `TPZElementMatrix` had to be divided into a base `TPZElementMatrix` class and a derived `TPZElementMatrix<TVar>`, where `TVar` stands for the state variable type (`STATE`, which now only assumes real values, and `CSTATE`, defined as `std::complex<STATE>`). A few methods therefore had a signature change, *e.g.*, `TPZCompEl::CalcStiff` now takes `TPZElementMatrixT<STATE>`.

Without the forthcoming `TPZMaterial` refactor (see #63 ), this PR is not exactly useful, since there is no way to create a `TPZMaterial` that actually computes anything relevant. And there are still a few other things to be done, once #63 is dealt with, a cleanup will happen.

This PR is *NOT* supposed to break anyone's external projects (except for the `TPZElementMatrixT<T>` possibility).

Please, let me know if this is not the case.