### PR TITLE
CMake quickfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # @file neopz/CMakeList.txt  -- First file to read for CMake
 
-cmake_minimum_required (VERSION 3.13.0)
+cmake_minimum_required (VERSION 3.14)
 
 #disable excessive warning messages by Microsoft VC compiler
 #set (CMAKE_USER_MAKE_RULES_OVERRIDE "${CMAKE_CURRENT_LIST_DIR}/cmake/CompilerOptionsMSVC.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,9 +331,6 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 # End of pz_config.h part
 
-# Set a debug suffix automatically when PZ is built in Debug mode
-set(CMAKE_DEBUG_POSTFIX "-debug")
-set_target_properties(pz PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
 install(TARGETS pz
         EXPORT NeoPZTargets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/UnitTest_PZ/CMakeLists.txt
+++ b/UnitTest_PZ/CMakeLists.txt
@@ -4,7 +4,7 @@ enable_testing()
 #in this file (and ONLY in this file) we will define CATCH_CONFIG_MAIN
 add_library(test_library STATIC test_main.cpp)
 target_compile_definitions(test_library PRIVATE CATCH_CONFIG_MAIN)
-target_link_libraries(test_library PUBLIC Catch2::Catch2)
+target_link_libraries(test_library PUBLIC pz Catch2::Catch2)
 
 add_subdirectory(TestAutoPointer)
 add_subdirectory(TestVecTypes)

--- a/cmake/add_unit_test.cmake
+++ b/cmake/add_unit_test.cmake
@@ -10,7 +10,7 @@ function(add_unit_test testName)
 
     add_test(${testName} ${testName})
     add_executable(${testName} ${ARGN})
-    target_link_libraries(${testName} PRIVATE pz test_library)
+    target_link_libraries(${testName} PRIVATE test_library)
     if(PZ_LOG)
       target_link_libraries(${testName} PRIVATE ${Log4cxx_LIBRARY})
     endif()


### PR DESCRIPTION
This branch fixes small problems with our CMake config, namely:

- The debug postfix was removed, since we can't ensure its robustness while semantic versioning is not implemented in the library.
- CMake minimum version is now `3.14`, which provides a function used to download Catch2.
- `pz` is now indirectly linked to the unit test through `test_library` target.