### PR TITLE
TPZEigenSolver

### DIFF
--- a/Common/pzreal.h
+++ b/Common/pzreal.h
@@ -41,6 +41,9 @@ typename std::underlying_type<Enumeration>::type as_integer(const Enumeration va
 }
 
 
+
+class TPZFlopCounter;
+
 //! Enables typename real_type<T>::type for the real type associated with T
 template <typename, typename = void>
 struct real_type;
@@ -61,10 +64,15 @@ template <typename T>
 struct real_type<Fad<T>, void>
 { using type = typename real_type<T>::type; };
 //! Enabling it for TFad<6,T>
-template <typename T>
-struct real_type<TFad<6,T>, void>
+template <int N,typename T>
+struct real_type<TFad<N,T>, void>
 { using type = typename real_type<T>::type; };
 
+
+//! Enabling it for TPZFlopCounter
+template<>
+struct real_type<TPZFlopCounter, void>
+{ using type = TPZFlopCounter; };
 
 //Convenience macros for real_type<T>::type
 #define RTVar typename real_type<TVar>::type
@@ -89,9 +97,14 @@ template <typename T>
 struct complex_type<Fad<T>, void>
 { using type = typename complex_type<T>::type; };
 //! Enabling it for TFad<6,T>
-template <typename T>
-struct complex_type<TFad<6,T>, void>
+template <int N,typename T>
+struct complex_type<TFad<N,T>, void>
 { using type = typename complex_type<T>::type; };
+
+//! Enabling it for TPZFlopCounter
+template<>
+struct complex_type<TPZFlopCounter, void>
+{ using type = TPZFlopCounter; };
 
 //Convenience macros for complex_type<T>::type
 #define CTVar typename complex_type<TVar>::type
@@ -194,8 +207,6 @@ struct TPZCounter {
 
 /** @brief Re-implements << operator to show the counter (count) data */
 std::ostream &operator<<(std::ostream &out,const TPZCounter &count);
-
-class TPZFlopCounter;
 
 /** @brief This is the type of floating point number PZ will use. */
 #ifdef REALfloat

--- a/Matrix/pzfmatrix.h
+++ b/Matrix/pzfmatrix.h
@@ -48,16 +48,18 @@ template<class TVar>
 TVar Norm(const TPZFMatrix<TVar> &A);
 
 
+template<class TVar>
+class TPZLapackEigenSolver;
+
 /**
  * @brief Full matrix class. \ref matrix "Matrix"
  * @note The full matrix class is special in that the data is stored column wise
  * @author Misael Mandujano
  * @since 04/1996
  */
-
 template<class TVar=REAL>
 class TPZFMatrix: public TPZMatrix<TVar> {
-    
+    friend class TPZLapackEigenSolver<TVar>;
 public:
     
     /** @brief Simple constructor */
@@ -380,22 +382,26 @@ public:
     /** @brief Solves the Ax=w*x eigenvalue problem and calculates the eigenvectors. DEPENDS ON LAPACK.
      * @param w Stores the eigenvalues
      * @param Stores the correspondent eigenvectors
+     * @return Returns info param from LAPACK(0 if executed correctly)
      */
-    virtual int SolveEigenProblem(TPZVec < std::complex<double> > &w, TPZFMatrix < std::complex<double> > &eigenVectors);
+    virtual int SolveEigenProblem(TPZVec < CTVar > &w, TPZFMatrix < CTVar > &eigenVectors);
     /** @brief Solves the Ax=w*x eigenvalue problem and does NOT calculates the eigenvectors. DEPENDS ON LAPACK.
      * @param w Stores the eigenvalues
+     * @return Returns info param from LAPACK(0 if executed correctly)
      */
-    virtual int SolveEigenProblem(TPZVec < std::complex<double> > &w);
+    virtual int SolveEigenProblem(TPZVec < CTVar > &w);
 
     /** @brief Solves the generalised Ax=w*B*x eigenvalue problem and calculates the eigenvectors. DEPENDS ON LAPACK.
      * @param w Stores the eigenvalues
      * @param Stores the correspondent eigenvectors
+     * @return Returns info param from LAPACK(0 if executed correctly)
      */
-    virtual int SolveGeneralisedEigenProblem(TPZFMatrix< TVar > &B , TPZVec < std::complex<double> > &w, TPZFMatrix < std::complex<double> > &eigenVectors);
+    virtual int SolveGeneralisedEigenProblem(TPZFMatrix< TVar > &B , TPZVec < CTVar > &w, TPZFMatrix < CTVar > &eigenVectors);
     /** @brief Solves the generalised Ax=w*B*x eigenvalue problem and does NOT calculates the eigenvectors. DEPENDS ON LAPACK.
      * @param w Stores the eigenvalues
+     * @return Returns info param from LAPACK(0 if executed correctly)
      */
-    virtual int SolveGeneralisedEigenProblem(TPZFMatrix< TVar > &B , TPZVec < std::complex<double> > &w);    
+    virtual int SolveGeneralisedEigenProblem(TPZFMatrix< TVar > &B , TPZVec < CTVar > &w);    
 
     /**
      * @brief Uses LAPACK to compute the Singular Value Decomposition (SVD) of this rectangular (m by n) matrix A = U*Sigma*VT

--- a/Matrix/pzsbndmat.h
+++ b/Matrix/pzsbndmat.h
@@ -21,7 +21,8 @@ when configuring the library.
 #include "pzmatdefs.h"
 
 #endif
-
+template<class TVar>
+class TPZLapackEigenSolver;
 /**
  * @brief Implements symmetric band matrices. \ref matrix "Matrix"
  * @ingroup matrix
@@ -29,6 +30,7 @@ when configuring the library.
 template<class TVar>
 class TPZSBMatrix : public TPZMatrix<TVar>
 {
+    friend class TPZLapackEigenSolver<TVar>;
 public:
     TPZSBMatrix() : TPZRegisterClassId(&TPZSBMatrix::ClassId),
     TPZMatrix<TVar>() , fDiag() { fBand = 0; }
@@ -133,21 +135,25 @@ public:
     /** @brief Solves the Ax=w*x eigenvalue problem and calculates the eigenvectors. Depends on LAPACK.
      * @param w Stores the eigenvalues
      * @param Stores the correspondent eigenvectors
+     * @return Returns info param from LAPACK(0 if executed correctly)
      */
-    int SolveEigenProblem(TPZVec < std::complex<double> > &w, TPZFMatrix < std::complex<double> > &eigenVectors);
+    int SolveEigenProblem(TPZVec < CTVar > &w, TPZFMatrix < CTVar > &eigenVectors);
     /** @brief Solves the Ax=w*x eigenvalue problem and does NOT calculates the eigenvectors. Depends on LAPACK.
      * @param w Stores the eigenvalues
+     * @return Returns info param from LAPACK(0 if executed correctly)
      */
-    int SolveEigenProblem(TPZVec < std::complex<double> > &w);
+    int SolveEigenProblem(TPZVec < CTVar > &w);
     /** @brief Solves the generalised Ax=w*B*x eigenvalue problem and calculates the eigenvectors. Depends on LAPACK.
      * @param w Stores the eigenvalues
      * @param Stores the correspondent eigenvectors
+     * @return Returns info param from LAPACK(0 if executed correctly)
      */
-    int SolveGeneralisedEigenProblem(TPZSBMatrix< TVar > &B , TPZVec < std::complex<double> > &w, TPZFMatrix < std::complex<double> > &eigenVectors);
+    int SolveGeneralisedEigenProblem(TPZSBMatrix< TVar > &B , TPZVec < CTVar > &w, TPZFMatrix < CTVar > &eigenVectors);
     /** @brief Solves the generalised Ax=w*B*x eigenvalue problem and does NOT calculates the eigenvectors. Depends on LAPACK.
      * @param w Stores the eigenvalues
+     * @return Returns info param from LAPACK(0 if executed correctly)
      */
-    int SolveGeneralisedEigenProblem(TPZSBMatrix< TVar > &B , TPZVec < std::complex<double> > &w);
+    int SolveGeneralisedEigenProblem(TPZSBMatrix< TVar > &B , TPZVec < CTVar > &w);
     
     /** @} */
 

--- a/Solvers/CMakeLists.txt
+++ b/Solvers/CMakeLists.txt
@@ -7,6 +7,7 @@ target_include_directories(pz PUBLIC
 set(public_headers
     TPZSolver.h
     TPZMatrixSolver.h
+    TPZEigenSolver.h
     TPZPardisoSolver.h
     pzstepsolver.h
     pzseqsolver.h
@@ -19,6 +20,7 @@ set(headers
 set(sources
     TPZSolver.cpp
     TPZMatrixSolver.cpp
+    TPZEigenSolver.cpp
     TPZPardisoSolver.cpp
     pzstepsolver.cpp
     pzseqsolver.cpp

--- a/Solvers/CMakeLists.txt
+++ b/Solvers/CMakeLists.txt
@@ -35,7 +35,7 @@ foreach(header ${public_headers})
     list(APPEND PZ_PUBLIC_HEADERS " ${CMAKE_CURRENT_SOURCE_DIR}/${header}")
 endforeach()
 
-#black oil
 add_subdirectory(LinearSolvers)
+add_subdirectory(EigenSolvers)
 add_subdirectory(Multigrid)
 set(PZ_PUBLIC_HEADERS ${PZ_PUBLIC_HEADERS} PARENT_SCOPE)

--- a/Solvers/EigenSolvers/CMakeLists.txt
+++ b/Solvers/EigenSolvers/CMakeLists.txt
@@ -1,0 +1,26 @@
+# @file neopz/Solvers/EigenSolvers/CMakeLists.txt  -- CMake file for the EigenSolvers module
+
+target_include_directories(pz PUBLIC 
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/Solvers/EigenSolvers>
+    )
+
+set(public_headers
+    TPZLapackEigenSolver.h
+    )
+set(headers
+    ${public_headers}
+    )
+
+set(sources
+    TPZLapackEigenSolver.cpp
+    )
+
+install(FILES ${headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Solvers/EigenSolvers)
+
+target_sources(pz PRIVATE ${headers} ${sources})
+#for doxygen
+foreach(header ${headers})
+    list(APPEND PZ_PUBLIC_HEADERS " ${CMAKE_CURRENT_SOURCE_DIR}/${header}")
+endforeach()
+set(PZ_PUBLIC_HEADERS ${PZ_PUBLIC_HEADERS} PARENT_SCOPE)

--- a/Solvers/EigenSolvers/TPZLapackEigenSolver.cpp
+++ b/Solvers/EigenSolvers/TPZLapackEigenSolver.cpp
@@ -1,0 +1,534 @@
+#include "TPZLapackEigenSolver.h"
+#include "TPZLapack.h"
+#include "Hash/TPZHash.h"
+#include "pzsbndmat.h"
+
+using namespace std::complex_literals;
+
+template<class TVar>
+TPZLapackEigenSolver<TVar>::TPZLapackEigenSolver()
+{
+#ifndef USING_LAPACK
+  PZError<<"TPZLapackEigenSolver is only available if using LAPACK.\n";
+  PZError<<"Aborting...\n";
+  DebugStop();
+#endif
+}
+
+template<class TVar>
+int TPZLapackEigenSolver<TVar>::ClassId() const
+{
+  return Hash("TPZLapackEigenSolver") ^
+    TPZEigenSolver<TVar>::ClassId() << 1;
+}
+
+template<class TVar>
+TPZLapackEigenSolver<TVar>* TPZLapackEigenSolver<TVar>::Clone() const
+{
+  return new TPZLapackEigenSolver<TVar>(*this);
+}
+
+template<class TVar>
+int TPZLapackEigenSolver<TVar>::SolveEigenProblem(TPZVec<CTVar> &w,
+                                                  TPZFMatrix<CTVar> &eigenVectors)
+{
+  TPZFMatrix<TVar> *Afull =
+    dynamic_cast<TPZFMatrix<TVar>*>(this->fMatrixA.operator->());
+  TPZSBMatrix<TVar> *Absym =
+    dynamic_cast<TPZSBMatrix<TVar>*>(this->fMatrixA.operator->());
+  if(Afull){
+    return SolveEigenProblem(*Afull,w,eigenVectors);
+  }
+  else if (Absym){
+    return SolveEigenProblem(*Absym,w,eigenVectors);
+  }else{
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR:Unsupported type\nAborting...\n";
+    DebugStop();
+  }
+  return 0;
+}
+
+template<class TVar>
+int TPZLapackEigenSolver<TVar>::SolveEigenProblem(TPZVec <CTVar> &w)
+{
+  TPZFMatrix<TVar> *Afull =
+    dynamic_cast<TPZFMatrix<TVar>*>(this->fMatrixA.operator->());
+  TPZSBMatrix<TVar> *Absym =
+    dynamic_cast<TPZSBMatrix<TVar>*>(this->fMatrixA.operator->());
+  if(Afull){
+    return SolveEigenProblem(*Afull,w);
+  }
+  else if (Absym){
+    return SolveEigenProblem(*Absym,w);
+  }else{
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR:Unsupported type\nAborting...\n";
+    DebugStop();
+  }
+  return 0;
+}
+
+template<class TVar>
+int TPZLapackEigenSolver<TVar>::SolveGeneralisedEigenProblem(
+    TPZVec <CTVar> &w, TPZFMatrix <CTVar> &eigenVectors)
+{
+  TPZFMatrix<TVar> *Afull =
+    dynamic_cast<TPZFMatrix<TVar>*>(this->fMatrixA.operator->());
+  TPZFMatrix<TVar> *Bfull =
+    dynamic_cast<TPZFMatrix<TVar>*>(this->fMatrixB.operator->());
+  TPZSBMatrix<TVar> *Absym =
+    dynamic_cast<TPZSBMatrix<TVar>*>(this->fMatrixA.operator->());
+  TPZSBMatrix<TVar> *Bbsym =
+    dynamic_cast<TPZSBMatrix<TVar>*>(this->fMatrixB.operator->());
+  if(Afull && Bfull){
+    return SolveGeneralisedEigenProblem(*Afull,*Bfull,w,eigenVectors);
+  }
+  else if (Absym && Bbsym){
+    return SolveGeneralisedEigenProblem(*Absym,*Bbsym,w,eigenVectors);
+  }else{
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR:Unsupported type\nAborting...\n";
+    DebugStop();
+  }
+  return 0;
+}
+template<class TVar>
+int TPZLapackEigenSolver<TVar>::SolveGeneralisedEigenProblem(TPZVec <CTVar> &w){
+  TPZFMatrix<TVar> *Afull =
+    dynamic_cast<TPZFMatrix<TVar>*>(this->fMatrixA.operator->());
+  TPZFMatrix<TVar> *Bfull =
+    dynamic_cast<TPZFMatrix<TVar>*>(this->fMatrixB.operator->());
+  TPZSBMatrix<TVar> *Absym =
+    dynamic_cast<TPZSBMatrix<TVar>*>(this->fMatrixA.operator->());
+  TPZSBMatrix<TVar> *Bbsym =
+    dynamic_cast<TPZSBMatrix<TVar>*>(this->fMatrixB.operator->());
+  if(Afull && Bfull){
+    return SolveGeneralisedEigenProblem(*Afull,*Bfull,w);
+  }
+  else if (Absym && Bbsym){
+    return SolveGeneralisedEigenProblem(*Absym,*Bbsym,w);
+  }else{
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR:Unsupported type\nAborting...\n";
+    DebugStop();
+  }
+  return 1;
+}
+
+
+/*******************
+*    TPZFMATRIX    *
+*******************/
+template<class TVar>
+int TPZLapackEigenSolver<TVar>::SolveEigenProblem(TPZFMatrix<TVar> &A,
+                                                  TPZVec <CTVar> &eigenValues,
+                                                  TPZFMatrix <CTVar> &eigenVectors,
+                                                  bool calcVectors){
+  if (A.Rows() != A.Cols()) {
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR:Unsupported dimensions for matrix A\nAborting...\n";
+    DebugStop();
+  }
+  char jobvl[] = "N";
+  char jobvr[] = "V";
+  if(!calcVectors) jobvr[0]='N';
+  
+  TPZFMatrix<TVar> VL(A.Rows(),A.Cols()),VR(A.Rows(),A.Cols());
+  int dim = A.Rows();
+  TVar testwork;
+  int lwork = 10+20*dim;
+  int info;
+
+  TPZVec<TVar> work(lwork);
+
+  eigenValues.Resize(dim,0.);
+  if(calcVectors) eigenVectors.Redim(dim,dim);
+#ifdef USING_LAPACK
+  if constexpr(std::is_same_v<RTVar,TVar>){//real types
+    TPZVec<TVar> realeigen(dim,0.);
+    TPZVec<TVar> imageigen(dim,0.);
+    if constexpr (std::is_same_v<TVar,float>){
+      sgeev_(jobvl, jobvr, &dim, A.fElem, &dim, &realeigen[0],
+             &imageigen[0], VL.fElem, &dim,
+             VR.fElem, &dim, &work[0], &lwork, &info);
+    }else if constexpr (std::is_same_v<TVar,double>){
+      dgeev_(jobvl, jobvr, &dim, A.fElem, &dim, &realeigen[0],
+             &imageigen[0], VL.fElem, &dim,
+             VR.fElem, &dim, &work[0], &lwork, &info);
+    }else{
+      PZError<<__PRETTY_FUNCTION__;
+      PZError<<"\nERROR:Unsupported type\nAborting...\n";
+      DebugStop();
+    }
+    for(int i = 0 ; i < dim ; i ++){
+      eigenValues[i] = realeigen[i] + (CTVar)1i*imageigen[i];
+    }
+    if(calcVectors){
+      for(int i = 0 ; i < dim ; i ++){
+        if(imageigen[i] == 0){
+          for( int iV = 0 ; iV < dim ; iV++ ){
+            eigenVectors(iV,i) = VR(iV,i);
+          }
+        }
+        else{
+          for( int iV = 0 ; iV < dim ; iV++ ){
+            eigenVectors(iV,i) = VR(iV,i) + (CTVar)1i * VR(iV,i+1) ;
+            eigenVectors(iV,i + 1) = VR(iV,i) - (CTVar)1i * VR(iV,i+1) ;
+          }
+          i++;
+        }
+      }
+    }
+  }else{
+    TPZVec< RTVar > rwork( 2 * dim);
+    if constexpr (std::is_same_v<TVar,std::complex<float>>){
+      cgeev_(jobvl, jobvr, &dim, (varfloatcomplex*)A.fElem, &dim,
+             (varfloatcomplex*)&eigenValues[0],
+             (varfloatcomplex*)VL.fElem, &dim,
+             (varfloatcomplex*)eigenVectors.fElem, &dim,
+             (varfloatcomplex*)&work[0], &lwork, &rwork[0], &info);
+    }else if constexpr (std::is_same_v<TVar,std::complex<double>>){
+      zgeev_(jobvl, jobvr, &dim, (vardoublecomplex*)A.fElem, &dim,
+             (vardoublecomplex*)&eigenValues[0],
+             (vardoublecomplex*)VL.fElem, &dim,
+             (vardoublecomplex*)eigenVectors.fElem, &dim,
+             (vardoublecomplex*)&work[0], &lwork, &rwork[0], &info);
+    }else{
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR:Unsupported type\nAborting...\n";
+    DebugStop();
+    }
+  }
+#endif
+  if (info != 0) {
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR:LAPACK call returned with info: "<<info<<"\n";
+    PZError<<"Aborting...\n";
+    DebugStop();
+  }
+
+  return info;
+}
+
+template<class TVar>
+int TPZLapackEigenSolver<TVar>::SolveEigenProblem(TPZFMatrix<TVar> &A,
+                                                  TPZVec <CTVar> &eigenValues){
+  TPZFNMatrix<1,CTVar> dummy(1,1,0.);
+  constexpr bool calcVectors{false};
+  return SolveEigenProblem(A,eigenValues,dummy,calcVectors);
+}
+
+template<class TVar>
+int TPZLapackEigenSolver<TVar>::SolveGeneralisedEigenProblem(
+    TPZFMatrix<TVar> &A,
+    TPZFMatrix< TVar> &B ,
+    TPZVec <CTVar> &eigenValues,
+    TPZFMatrix <CTVar> &eigenVectors,
+    bool calcVectors)
+{
+  if (  A.Rows() != B.Rows() || A.Cols() != B.Cols() || A.Cols() != A.Cols() )
+  {
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"Incompatible dimensions\nAborting...\n";
+    DebugStop();
+  }
+
+  char jobvl[] = "N", jobvr[] = "V";
+  if(!calcVectors) jobvr[0] = 'N';
+  TPZFMatrix< TVar> VL(A.Rows(),A.Cols()),VR(A.Rows(),A.Cols());
+  int dim = A.Rows();
+  TVar testwork;
+  int lwork = 10+20*dim;
+  int info;
+
+  TPZVec<TVar> beta(dim);
+  TPZVec<TVar> work(lwork);
+
+#ifdef USING_LAPACK
+  
+  if(calcVectors) eigenVectors.Redim(dim,dim);
+  eigenValues.Resize(dim,0.);
+  
+  if constexpr(std::is_same_v<TVar,RTVar>){//real types
+    
+    TPZVec<TVar> realeigen(dim,0.);
+    TPZVec<TVar> imageigen(dim,0.);
+    if constexpr (std::is_same_v<TVar,float>){
+      sggev_(jobvl, jobvr, &dim, A.fElem, &dim , B.fElem, &dim , &realeigen[0], &imageigen[0], &beta[0]  , VL.fElem, &dim , VR.fElem, &dim, &work[0], &lwork, &info);
+    }else if constexpr (std::is_same_v<TVar,double>){
+      dggev_(jobvl, jobvr, &dim, A.fElem, &dim , B.fElem, &dim , &realeigen[0], &imageigen[0], &beta[0]  , VL.fElem, &dim , VR.fElem, &dim, &work[0], &lwork, &info);
+    }
+
+    for(int i = 0 ; i < dim ; i ++){
+      if( IsZero(beta[i])){
+        DebugStop(); //fran: i really dont know what to do with this result
+      }
+      else{
+        eigenValues[i] = (realeigen[i] + (CTVar)1i*imageigen[i]) / beta[i];
+      }
+    }
+    if(calcVectors){
+      for(int i = 0 ; i < dim ; i ++){
+        if(imageigen[i] == 0){
+          for( int iV = 0 ; iV < dim ; iV++ ){
+            eigenVectors(iV,i) = VR(iV,i);
+          }
+        }
+        else{
+          for( int iV = 0 ; iV < dim ; iV++ ){
+            eigenVectors(iV,i) = VR(iV,i) + (CTVar)1i * VR(iV,i+1) ;
+            eigenVectors(iV,i + 1) = VR(iV,i) - (CTVar)1i * VR(iV,i+1) ;
+          }
+          i++;
+        }
+      }
+    }
+  }else if constexpr (std::is_same_v<TVar,CTVar>){//complex types
+    TPZVec<TVar> eigen(dim,0.);
+    TPZVec<RTVar> rwork( 8 * dim );
+    if constexpr (std::is_same_v<TVar,std::complex<float>>){
+      cggev_(jobvl, jobvr, &dim,
+             (varfloatcomplex*)A.fElem, &dim,
+             (varfloatcomplex*)B.fElem, &dim,
+             (varfloatcomplex*)&eigen[0], (varfloatcomplex*)&beta[0],
+             (varfloatcomplex*)VL.fElem, &dim,
+             (varfloatcomplex*)eigenVectors.fElem, &dim,
+             (varfloatcomplex*)&work[0], &lwork, &rwork[0],&info);
+    }else if constexpr (std::is_same_v<TVar,std::complex<double>>){
+      zggev_(jobvl, jobvr, &dim,
+             (vardoublecomplex*)A.fElem, &dim,
+             (vardoublecomplex*)B.fElem, &dim,
+             (vardoublecomplex*)&eigen[0], (vardoublecomplex*)&beta[0],
+             (vardoublecomplex*)VL.fElem, &dim,
+             (vardoublecomplex*)eigenVectors.fElem, &dim,
+             (vardoublecomplex*)&work[0], &lwork, &rwork[0],&info);
+    }
+
+    for(int i = 0 ; i < dim ; i ++){
+        if( IsZero(beta[i])){
+            DebugStop(); //fran: i really dont know what to do with this result
+        }
+        else{
+            eigenValues[i] = eigen[i] / beta[i];
+        }
+    }
+  }else{
+      PZError<<__PRETTY_FUNCTION__;
+      PZError<<"\nERROR:Unsupported type\nAborting...\n";
+      DebugStop();
+    }
+#endif
+
+  if (info != 0) {
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR:LAPACK call returned with info: "<<info<<"\n";
+    PZError<<"Aborting...\n";
+    DebugStop();
+  }
+  return info;
+}
+
+template<class TVar>
+int TPZLapackEigenSolver<TVar>::SolveGeneralisedEigenProblem(
+    TPZFMatrix<TVar> &A,
+    TPZFMatrix<TVar> &B ,
+    TPZVec<CTVar> &eigenValues)
+{
+  TPZFNMatrix<1,CTVar> dummy(1,1,0.);
+  constexpr bool calcVectors{false};
+  return SolveGeneralisedEigenProblem(A,B,eigenValues,dummy,calcVectors);
+}
+
+/*******************
+*    TPZSBMATRIX    *
+*******************/
+template<class TVar>
+int TPZLapackEigenSolver<TVar>::SolveEigenProblem(TPZSBMatrix<TVar> &A,
+                                                  TPZVec <CTVar> &eigenValues,
+                                                  TPZFMatrix <CTVar> &eigenVectors,
+                                                  bool calcVectors){
+  if (A.Rows() != A.Cols())
+  {
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"Incompatible dimensions\nAborting...\n";
+    DebugStop();
+  }
+
+  char jobz = calcVectors ? 'V' : 'N'; //compute eigenvectors
+  char uplo = 'U';//assume upper triangular
+  int n = A.Dim();
+  int kd = A.fBand;
+  int ldab = A.fBand + 1;
+  int ldbb = A.fBand + 1;
+  TPZVec<RTVar> w(0,0.);
+  w.Resize(n);
+  int ldz = n;
+
+  int info = -666;
+#ifdef USING_LAPACK
+  eigenValues.Resize(n);
+  if(calcVectors) eigenVectors.Redim(n, n);
+  
+  if constexpr(std::is_same_v<TVar,RTVar>){
+    TPZVec<TVar> work(3*n);
+    TPZFMatrix<TVar> z(n,n);
+    if constexpr (std::is_same_v<TVar,float>){
+    
+      ssbev_(&jobz, &uplo, &n, &kd, A.fDiag.begin(), &ldab, w.begin(),
+             &z(0,0), &ldz, work.begin(), &info);
+    }else if constexpr (std::is_same_v<TVar,double>){
+      TPZVec<TVar> work(3*n);
+      dsbev_(&jobz, &uplo, &n, &kd, A.fDiag.begin(), &ldab, w.begin(),
+             &z(0,0), &ldz, work.begin(), &info);
+    }
+    if(calcVectors){
+      for (int iVec = 0 ; iVec < n; iVec++) {
+        for (int iCol = 0; iCol < n; iCol++) {
+          eigenVectors( iVec , iCol) = z(iVec,iCol);
+        }
+      }
+    }
+  }else if constexpr(std::is_same_v<TVar,CTVar>){
+    TPZVec<TVar> work(n);
+    TPZVec<RTVar> rwork(3*n);
+    if constexpr (std::is_same_v<TVar,std::complex<float>>){
+      chbev_(&jobz, &uplo, &n, &kd,
+             (varfloatcomplex*)A.fDiag.begin(), &ldab, w.begin(),
+             (varfloatcomplex*)&eigenVectors(0,0), &ldz,
+             (varfloatcomplex*)work.begin(), rwork.begin(), &info);
+    }else if constexpr (std::is_same_v<TVar,std::complex<double>>){
+      zhbev_(&jobz, &uplo, &n, &kd,
+             (vardoublecomplex*)A.fDiag.begin(), &ldab, w.begin(),
+             (vardoublecomplex*)&eigenVectors(0,0), &ldz,
+             (vardoublecomplex*)work.begin(), rwork.begin(), &info);
+    }
+  }else{
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR:Unsupported type\nAborting...\n";
+    DebugStop();
+  }
+#endif
+
+  if(info != 0){
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR:LAPACK call returned with info: "<<info<<"\n";
+    PZError<<"Aborting...\n";
+    DebugStop();
+  }
+
+  for(int i = 0 ; i < n ; i++){
+    eigenValues[i] = w[i];
+  }
+  return info;
+}
+  
+template<class TVar>
+int TPZLapackEigenSolver<TVar>::SolveEigenProblem(TPZSBMatrix<TVar> &A,
+                                                  TPZVec <CTVar> &eigenValues){
+  TPZFNMatrix<1,CTVar> dummy(1,1,0.);
+  constexpr bool calcVectors{false};
+  return SolveEigenProblem(A,eigenValues,dummy,calcVectors);
+}
+
+template<class TVar>
+int TPZLapackEigenSolver<TVar>::SolveGeneralisedEigenProblem(
+    TPZSBMatrix<TVar> &A, TPZSBMatrix< TVar> &B ,
+    TPZVec <CTVar> &eigenValues, TPZFMatrix <CTVar> &eigenVectors,
+    bool calcVectors)
+{  
+  if (  A.Rows() != B.Rows() && A.Cols() != B.Cols() )
+  {
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR:Unsupported dimensions for matrix A\nAborting...\n";
+    DebugStop();
+  }
+
+
+  char jobz = calcVectors? 'V' : 'N'; //Compute eigenvectors
+  char uplo = 'U';//assume upper triangular
+  int n = A.Dim();
+  int ka = A.fBand;
+  int kb = B.fBand;
+  int ldab = A.fBand + 1;
+  int ldbb = A.fBand + 1;
+  TPZVec<RTVar> w(0,0.);
+  w.Resize( n );
+  int ldz = n;
+  int info = -666;
+#ifdef USING_LAPACK
+  eigenValues.Resize(n);
+  if(calcVectors) eigenVectors.Redim(n, n);
+  
+  if constexpr(std::is_same_v<TVar,RTVar>){
+    TPZVec<TVar> work(3*n);
+    TPZFMatrix<TVar> z(n,n);
+    if constexpr (std::is_same_v<TVar,float>){
+    
+      ssbgv_(&jobz, &uplo, &n, &ka, &kb, A.fDiag.begin(),
+             &ldab, B.fDiag.begin(), &ldbb, w.begin(),
+             &z(0,0), &ldz, work.begin(), &info);
+    }else if constexpr (std::is_same_v<TVar,double>){
+      TPZVec<TVar> work(3*n);
+      dsbgv_(&jobz, &uplo, &n, &ka, &kb, A.fDiag.begin(),
+             &ldab, B.fDiag.begin(), &ldbb, w.begin(),
+             &z(0,0), &ldz, work.begin(), &info);
+    }
+    if(calcVectors){
+      for (int iVec = 0 ; iVec < n; iVec++) {
+        for (int iCol = 0; iCol < n; iCol++) {
+          eigenVectors( iVec , iCol) = z(iVec,iCol);
+        }
+      }
+    }
+  }else if constexpr(std::is_same_v<TVar,CTVar>){
+    TPZVec<TVar> work(n);
+    TPZVec<RTVar> rwork(3*n);
+    if constexpr (std::is_same_v<TVar,std::complex<float>>){
+      chbgv_(&jobz, &uplo, &n, &ka, &kb,
+             (varfloatcomplex *)A.fDiag.begin(), &ldab,
+             (varfloatcomplex *)B.fDiag.begin(), &ldbb, w.begin(),
+             (varfloatcomplex *)&eigenVectors(0,0), &ldz,
+             (varfloatcomplex *)work.begin(),rwork.begin(), &info);
+    }else if constexpr (std::is_same_v<TVar,std::complex<double>>){
+      zhbgv_(&jobz, &uplo, &n, &ka, &kb,
+             (vardoublecomplex *)A.fDiag.begin(), &ldab,
+             (vardoublecomplex *)B.fDiag.begin(), &ldbb, w.begin(),
+             (vardoublecomplex *)&eigenVectors(0,0), &ldz,
+             (vardoublecomplex *)work.begin(),rwork.begin(), &info);
+    }
+  }else{
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR:Unsupported type\nAborting...\n";
+    DebugStop();
+  }
+#endif
+  if(info != 0){
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR:LAPACK call returned with info: "<<info<<"\n";
+    PZError<<"Aborting...\n";
+    DebugStop();
+  }
+
+  for(int i = 0 ; i < n ; i++){
+    eigenValues[i] = w[i];
+  }
+  return info;
+}
+
+template<class TVar>
+int TPZLapackEigenSolver<TVar>::SolveGeneralisedEigenProblem(
+    TPZSBMatrix<TVar> &A,TPZSBMatrix< TVar> &B ,
+    TPZVec <CTVar> &eigenValues)
+{
+  TPZFNMatrix<1,CTVar> dummy(1,1,0.);
+  constexpr bool calcVectors{false};
+  return SolveGeneralisedEigenProblem(A,B,eigenValues,dummy,calcVectors);
+}
+
+
+template class TPZLapackEigenSolver<std::complex<float>>;
+template class TPZLapackEigenSolver<std::complex<double>>;
+
+template class TPZLapackEigenSolver<float>;
+template class TPZLapackEigenSolver<double>;

--- a/Solvers/EigenSolvers/TPZLapackEigenSolver.h
+++ b/Solvers/EigenSolvers/TPZLapackEigenSolver.h
@@ -1,0 +1,138 @@
+//
+// Created by Francisco Teixeira Orlandini on 18/05/2021
+//
+
+#ifndef TPZLAPACKEIGENSOLVER_H
+#define TPZLAPACKEIGENSOLVER_H
+
+#include "TPZEigenSolver.h"
+
+
+template<class T>
+class TPZSBMatrix;
+/**
+ * @ingroup solver
+ * @brief  Defines an interface for using LAPACK to solve eigenvalue problems.
+ * @note This class is only compatible with TPZFMatrix and TPZSBMatrix classes.
+ */
+template <typename TVar>
+class TPZLapackEigenSolver : public TPZEigenSolver<TVar> {
+  friend class TPZFMatrix<TVar>;
+  friend class TPZSBMatrix<TVar>;
+public:
+
+  //!Default constructor.  
+  TPZLapackEigenSolver();
+  //!Copy constructor
+  TPZLapackEigenSolver(const TPZLapackEigenSolver &copy) = default;
+  //!Move constructor
+  TPZLapackEigenSolver(TPZLapackEigenSolver &&rval) = default;
+  //!Copy-assignment operator
+  TPZLapackEigenSolver& operator=(const TPZLapackEigenSolver &copy) = default;
+  //!Move-assignment operator
+  TPZLapackEigenSolver& operator=(TPZLapackEigenSolver &&rval) = default;
+  //!Destructor
+  ~TPZLapackEigenSolver() = default;
+  
+  /** @name Eigen*/
+  /** @{*/
+  /**
+   * @brief Solves the Ax=w*x eigenvalue problem and calculates the eigenvectors
+   * @param[out] w Stores the eigenvalues
+   * @param[out] eigenVectors Stores the correspondent eigenvectors
+   * @return Returns info param from LAPACK(0 if executed correctly)
+   */
+  int SolveEigenProblem(TPZVec<CTVar> &w,TPZFMatrix<CTVar> &eigenVectors) override;
+
+  /**
+   * @brief Solves the Ax=w*x eigenvalue problem and does not calculate the eigenvectors
+   * @param[out] w Stores the eigenvalues
+   * @return Returns info param from LAPACK(0 if executed correctly)
+   */
+  int SolveEigenProblem(TPZVec<CTVar> &w) override;
+
+  /**
+   * @brief Solves the generalised Ax=w*B*x eigenvalue problem and calculates the eigenvectors
+   * @param[out] w Stores the eigenvalues
+   * @param[out] eigenVectors Stores the correspondent eigenvectors
+   * @return Returns info param from LAPACK(0 if executed correctly)
+   */
+  int SolveGeneralisedEigenProblem(TPZVec<CTVar> &w,TPZFMatrix<CTVar> &eigenVectors) override;
+
+  /**
+   * @brief Solves the generalised Ax=w*B*x eigenvalue problem and does not calculates the eigenvectors
+   * @param[out] w Stores the eigenvalues
+   * @return Returns info param from LAPACK(0 if executed correctly)
+   */
+  int SolveGeneralisedEigenProblem(TPZVec<CTVar> &w) override;
+  /** @}*/
+  //! Class identifier
+  int ClassId() const override;
+  //! Clone method
+  TPZLapackEigenSolver<TVar>* Clone() const override;
+protected:
+  /*******************
+   *    TPZFMATRIX    *
+   *******************/
+  /** @name EigenFMatrix */
+  /** @{ */
+  int SolveEigenProblem(TPZFMatrix<TVar> &A, TPZVec<CTVar> &w,
+                        TPZFMatrix<CTVar> &eigenVectors, bool calcVectors=true);
+
+  /** @brief Solves the Ax=w*x eigenvalue problem and does NOT calculates the eigenvectors
+   * @param w Stores the eigenvalues
+   */
+  int SolveEigenProblem(TPZFMatrix<TVar> &A, TPZVec<CTVar> &w);
+
+  /** @brief Solves the generalised Ax=w*B*x eigenvalue problem and calculates the eigenvectors
+   * @param w Stores the eigenvalues
+   * @param Stores the correspondent eigenvectors
+   */
+  int SolveGeneralisedEigenProblem(TPZFMatrix<TVar> &A, TPZFMatrix<TVar> &B,
+                                   TPZVec<CTVar> &w,
+                                   TPZFMatrix<CTVar> &eigenVectors,
+                                   bool calcVectors=true);
+  /** @brief Solves the generalised Ax=w*B*x eigenvalue problem and does NOT calculates the eigenvectors
+   * @param w Stores the eigenvalues
+   */
+  int SolveGeneralisedEigenProblem(TPZFMatrix<TVar> &A, TPZFMatrix<TVar> &B ,
+                                   TPZVec<CTVar> &w);
+
+  /** @} */
+  /*******************
+   *    TPSBMATRIX    *
+   *******************/
+  /** @name EigenSBMatrix */
+  /** @{ */
+  int SolveEigenProblem(TPZSBMatrix<TVar> &A, TPZVec<CTVar> &w,
+                        TPZFMatrix<CTVar> &eigenVectors, bool calcVectors = true);
+
+  /** @brief Solves the Ax=w*x eigenvalue problem and does NOT calculates the eigenvectors
+   * @param w Stores the eigenvalues
+   */
+  int SolveEigenProblem(TPZSBMatrix<TVar> &A, TPZVec<CTVar> &w);
+
+  /** @brief Solves the generalised Ax=w*B*x eigenvalue problem and calculates the eigenvectors
+   * @param w Stores the eigenvalues
+   * @param Stores the correspondent eigenvectors
+   */
+  int SolveGeneralisedEigenProblem(TPZSBMatrix<TVar> &A, TPZSBMatrix<TVar> &B ,
+                                   TPZVec<CTVar> &w,
+                                   TPZFMatrix<CTVar> &eigenVectors,
+                                   bool calcVectors=true);
+  /** @brief Solves the generalised Ax=w*B*x eigenvalue problem and does NOT calculates the eigenvectors
+   * @param w Stores the eigenvalues
+   */
+  int SolveGeneralisedEigenProblem(TPZSBMatrix<TVar> &A, TPZSBMatrix<TVar> &B ,
+                                   TPZVec<CTVar> &w);
+  /** @} */
+
+  
+};
+
+extern template class TPZLapackEigenSolver<std::complex<float>>;
+extern template class TPZLapackEigenSolver<std::complex<double>>;
+
+extern template class TPZLapackEigenSolver<float>;
+extern template class TPZLapackEigenSolver<double>;
+#endif //TPZEIGENSOLVER_H

--- a/Solvers/TPZEigenSolver.cpp
+++ b/Solvers/TPZEigenSolver.cpp
@@ -1,0 +1,32 @@
+#include "TPZEigenSolver.h"
+#include "Hash/TPZHash.h"
+
+template<class TVar>
+void TPZEigenSolver<TVar>::SetAsGeneralised(bool isGeneralised)
+{
+    fIsGeneralised = isGeneralised;
+}
+
+template<class TVar>
+int TPZEigenSolver<TVar>::ClassId() const
+{
+    return Hash("TPZEigenSolver") ^
+        ClassIdOrHash<TVar>() << 1 ^
+        TPZSolver::ClassId() << 2;
+}
+
+template<class TVar>
+void TPZEigenSolver<TVar>::ResetMatrix()
+{
+    TPZAutoPointer<TPZMatrix<TVar>> newA, newB;
+    fMatrixA = newA;
+    fMatrixB = newB;
+}
+
+template class TPZEigenSolver<float>;
+template class TPZEigenSolver<double>;
+template class TPZEigenSolver<long double>;
+
+template class TPZEigenSolver<std::complex<float>>;
+template class TPZEigenSolver<std::complex<double>>;
+template class TPZEigenSolver<std::complex<long double>>;

--- a/Solvers/TPZEigenSolver.h
+++ b/Solvers/TPZEigenSolver.h
@@ -1,0 +1,117 @@
+//
+// Created by Francisco Teixeira Orlandini on 18/05/2021
+//
+
+#ifndef TPZEIGENSOLVER_H
+#define TPZEIGENSOLVER_H
+
+#include "TPZSolver.h"
+
+#include "pzfmatrix.h"
+/**
+* @ingroup solver
+* @brief  Defines an interface for  eigenvalue problems solvers.
+*/
+template <typename TVar>
+class TPZEigenSolver : public TPZSolver {
+public:
+  //!Default constructor.  
+  TPZEigenSolver() = default;
+  //!Copy constructor
+  TPZEigenSolver(const TPZEigenSolver &copy) = default;
+  //!Move constructor
+  TPZEigenSolver(TPZEigenSolver &&rval) = default;
+  //!Copy-assignment operator
+  TPZEigenSolver& operator=(const TPZEigenSolver &copy) = default;
+  //!Move-assignment operator
+  TPZEigenSolver& operator=(TPZEigenSolver &&rval) = default;
+  //!Destructor
+  virtual ~TPZEigenSolver() = default;
+
+  /** @name Eigen*/
+  /** @{*/
+  /**
+   * @brief Solves the Ax=w*x eigenvalue problem and calculates the eigenvectors
+   * @param[out] w Stores the eigenvalues
+   * @param[out] eigenVectors Stores the correspondent eigenvectors
+   * @return Returns 1 if executed correctly
+   */
+  virtual int SolveEigenProblem(TPZVec<CTVar> &w,TPZFMatrix<CTVar> &eigenVectors) = 0;
+
+  /**
+   * @brief Solves the Ax=w*x eigenvalue problem and does not calculate the eigenvectors
+   * @param[out] w Stores the eigenvalues
+   * @return Returns 1 if executed correctly
+   */
+  virtual int SolveEigenProblem(TPZVec<CTVar> &w) = 0;
+
+  /**
+   * @brief Solves the generalised Ax=w*B*x eigenvalue problem and calculates the eigenvectors
+   * @param[out] w Stores the eigenvalues
+   * @param[out] eigenVectors Stores the correspondent eigenvectors
+   * @return Returns 1 if executed correctly
+   */
+  virtual int SolveGeneralisedEigenProblem(TPZVec<CTVar> &w,
+                                           TPZFMatrix<CTVar> &eigenVectors) = 0;
+
+  /**
+   * @brief Solves the generalised Ax=w*B*x eigenvalue problem and does not calculates the eigenvectors
+   * @param[out] w Stores the eigenvalues
+   * @return Returns 1 if executed correctly
+   */
+  virtual int SolveGeneralisedEigenProblem(TPZVec<CTVar> &w) = 0;
+  //!Gets the Matrix A
+  inline TPZAutoPointer<TPZMatrix<TVar>> MatrixA(){
+    return fMatrixA;
+  }
+  //!Gets the Matrix B(for generalised eigenvalue problems)
+  inline TPZAutoPointer<TPZMatrix<TVar>> MatrixB(){
+    return fMatrixB;
+  }
+  //!Sets the Matrix A
+  inline void SetMatrixA(TPZAutoPointer<TPZMatrix<TVar>> mat){
+    fMatrixA = mat;
+  }
+  //!Sets the Matrix B (for generalised eigenvalue problems)
+  inline void SetMatrixB(TPZAutoPointer<TPZMatrix<TVar>> mat){
+    fMatrixB = mat;
+  }
+  //!Whether the solver is set for a generalised eigenvalue problem
+  inline bool IsGeneralised() const{
+    return fIsGeneralised;
+  }
+  //!Configure the solver to solve a generalised eigenvalue problem
+  virtual void SetAsGeneralised(bool isGeneralised);
+  /** @}*/
+  //! Class identifier
+  int ClassId() const override;
+  //! Resets Matrices
+  void ResetMatrix() override;
+protected:
+  /** @brief Whether to solve the eigenvalue problem
+   *   is generalised (Ax=uBx) or not (Ax=ux)*/
+    bool fIsGeneralised{false};
+  /**
+   * @brief Stores the computed eigenvalues
+   */
+  TPZVec<CTVar> fEigenvalues;
+  /**
+   * @brief Stores the computed eigenvectors
+   */
+  TPZFMatrix<CTVar> fEigenvectors;
+
+  /** @brief Container classes */
+  TPZAutoPointer<TPZMatrix<TVar>> fMatrixA{nullptr};
+
+  /** @brief Container classes */
+  TPZAutoPointer<TPZMatrix<TVar>> fMatrixB{nullptr};
+};
+
+extern template class TPZEigenSolver<float>;
+extern template class TPZEigenSolver<double>;
+extern template class TPZEigenSolver<long double>;
+
+extern template class TPZEigenSolver<std::complex<float>>;
+extern template class TPZEigenSolver<std::complex<double>>;
+extern template class TPZEigenSolver<std::complex<long double>>;
+#endif //TPZEIGENSOLVER_H

--- a/UnitTest_PZ/TestMatrix/TestMatrix.cpp
+++ b/UnitTest_PZ/TestMatrix/TestMatrix.cpp
@@ -911,7 +911,7 @@ void TestingGeneralisedEigenValuesWithAutoFill(int dim, int symmetric) {
     bool check = true;
     matx cpmaOriginal(ma);
     matx cpma(ma), cpmb(mb);
-    TPZFMatrix<std::complex<double> > cpfma(dim, dim), cpfmb(dim, dim);
+    TPZFMatrix<CTVar > cpfma(dim, dim), cpfmb(dim, dim);
     for (int i = 0; i < dim; i++) {
         for (int j = 0; j < dim; j++) {
             cpfma(i, j) = ma(i, j);
@@ -919,8 +919,8 @@ void TestingGeneralisedEigenValuesWithAutoFill(int dim, int symmetric) {
         }
     }
 
-    TPZVec < std::complex<double> > w;
-    TPZFMatrix < std::complex<double> > eigenVectors;
+    TPZVec < CTVar > w;
+    TPZFMatrix < CTVar > eigenVectors;
     cpma.SolveGeneralisedEigenProblem(cpmb, w, eigenVectors);
     //    ma.Print("a",std::cout , EMathematicaInput);
     //    mb.Print("b",std::cout , EMathematicaInput);
@@ -932,8 +932,8 @@ void TestingGeneralisedEigenValuesWithAutoFill(int dim, int symmetric) {
         mult *= 10.;
     }
     for (int i = 0; i < dim; i++) {
-        TPZFMatrix< std::complex<double> > res(dim, dim, 0.);
-        TPZFMatrix< std::complex<double> > x(dim, 1, 0.);
+        TPZFMatrix< CTVar > res(dim, dim, 0.);
+        TPZFMatrix< CTVar > x(dim, 1, 0.);
         eigenVectors.GetSub(0, i, dim, 1, x);
 
         res = cpfma * x - w[i] * cpfmb * x;
@@ -966,15 +966,15 @@ matx ma;
     bool check = true;
     matx cpmaOriginal(ma);
     //    if(symmetric){
-    TPZFMatrix< std::complex<double> > cpma(dim, dim);
+    TPZFMatrix< CTVar > cpma(dim, dim);
     for (int i = 0; i < dim; i++) {
         for (int j = 0; j < dim; j++) {
             cpma(i, j) = ma.GetVal(i, j);
         }
     }
 
-    TPZVec < std::complex<double> > w;
-    TPZFMatrix < std::complex<double> > eigenVectors;
+    TPZVec < CTVar > w;
+    TPZFMatrix < CTVar > eigenVectors;
     ma.SolveEigenProblem(w, eigenVectors);
 
     //    cpma.Print("a = ",std::cout , EMathematicaInput);
@@ -985,8 +985,8 @@ matx ma;
         mult *= 10.;
     }
     for (int i = 0; i < dim; i++) {
-        TPZFMatrix< std::complex<double> > res(dim, 1, 0.);
-        TPZFMatrix< std::complex<double> > x(dim, 1, 0.);
+        TPZFMatrix< CTVar > res(dim, 1, 0.);
+        TPZFMatrix< CTVar > x(dim, 1, 0.);
         for (int j = 0; j < dim; j++) {
             x(j, 0) = eigenVectors(j, i);
         }

--- a/docs/solver/index.rst
+++ b/docs/solver/index.rst
@@ -16,13 +16,13 @@ The :cpp:expr:`TPZSolver` defines the hierarchy of solvers to be used.
 .. note::
    Since the availability of a given solver might depend on the chosen matrix storage format, the choice of solver is directly connected with the choice of :doc:`../structmatrix/structoptions`. Currently this only applies for the class :cpp:expr:`TPZPardisoSolver`, which is only compatible with sparse matrix storage.
 
-The NeoPZ solvers can be divided in two main groups: the :cpp:expr:`TPZMatrixSolver` hierarchy, for solving algebraic equation systems, and the (soon to be implemented) solvers for eigenvalue problems.
+The NeoPZ solvers can be divided in two main groups: the :cpp:expr:`TPZMatrixSolver` hierarchy, for solving algebraic equation systems, and the :cpp:expr:`TPZEigenSolver` hierarchy that implements solvers for eigenvalue problems.
 
 .. doxygenclass:: TPZSolver
    :members:
 
 TPZMatrixSolver
-^^^^^^^^^^^^^^^
+---------------
 
 The :cpp:expr:`TPZMatrixSolver` represents a solver for algebraic equation systems in which the matrix has entries with the type :cpp:type:`TVar`, where :cpp:expr:`TVar=STATE`, for real problems, and :cpp:expr:`TVar=CSTATE`, for complex problems.
 
@@ -32,8 +32,9 @@ The available solvers are
    :no-link:
 
 
-Further documentation
-"""""""""""""""""""""
+Further documentation on TPZMatrixSolver
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 .. doxygenclass:: TPZMatrixSolver
    :members:
 
@@ -57,3 +58,24 @@ The :cpp:expr:`TPZPardisoSolver` class acts as an wrapper for controlling the In
 
 .. doxygenclass:: TPZPardisoSolver
    :members:
+
+TPZEigenSolver
+--------------
+
+This class defines the interface for the NeoPZ solvers for eigenvalue problems. It will soon be complemented with an appropriated :cpp:expr:`TPZAnalysis` class.
+
+.. doxygenclass:: TPZEigenSolver
+   :members:
+   :membergroups: Eigen
+
+TPZLapackEigenSolver
+^^^^^^^^^^^^^^^^^^^^
+This class acts as a wrapper over LAPACK calls that can be used for solving eigenvalue problems. It supports :cpp:expr:`TPZFMatrix` and :cpp:expr:`TPZSBMatrix`, therefore it can only be used with the structural matrices :cpp:expr:`TPZFStructMatrix` and :cpp:expr:`TPZSBandStructMatrix`.
+
+.. note::
+   This class is also used internally by the :cpp:expr:`TPZFMatrix` and :cpp:expr:`TPZSBMatrix` classes, thus the specific (and protected) interfaces.
+
+.. doxygenclass:: TPZLapackEigenSolver
+   :members:
+   :protected-members:
+   :membergroups: Eigen EigenFMatrix EigenSBMatrix


### PR DESCRIPTION
This PR introduces the `TPZEigenSolver` class to be used for eigenvalue problems. It will be used in the `TPZEigenAnalysis` class that is soon to be implemented.

There was also a refactor on the eigenvalue-related LAPACK calls in `TPZFMatrix` and `TPZSBMatrix`. These now use the recently created `TPZLapackEigenSolver`, thus concentrating these calls in one place for ease of maintenance.