### PR TITLE
TPZPardisoSolver no longer has pointer to sym/nonsym systems

### DIFF
--- a/Matrix/pzsysmp.cpp
+++ b/Matrix/pzsysmp.cpp
@@ -368,11 +368,19 @@ int TPZSYsmpMatrix<TVar>::Decompose_LDLt()
     if (this->IsDecomposed() != ENoDecompose) {
         DebugStop();
     }
-    fPardisoControl.SetRawMatrix(this);
-    fPardisoControl.Decompose();
+    typename TPZPardisoSolver<TVar>::MStructure str =
+        TPZPardisoSolver<TVar>::MStructure::ESymmetric;
+    typename TPZPardisoSolver<TVar>::MSystemType sysType =
+		TPZPardisoSolver<TVar>::MSystemType::ESymmetric;
+	typename TPZPardisoSolver<TVar>::MProperty prop =
+		this->IsDefPositive() ?
+		TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:
+		TPZPardisoSolver<TVar>::MProperty::EIndefinite;
+    fPardisoControl.SetStructure(str);
+	fPardisoControl.SetMatrixType(sysType,prop);
+    fPardisoControl.Decompose(this);
     this->SetIsDecomposed(ELDLt);
     return 1;
-    
 }
 
 template<class TVar>
@@ -383,9 +391,18 @@ int TPZSYsmpMatrix<TVar>::Decompose_Cholesky()
         DebugStop();
     }
     this->fDefPositive = true;
-    fPardisoControl.SetRawMatrix(this);
-    fPardisoControl.Decompose();
-    this->SetIsDecomposed(ECholesky);
+    typename TPZPardisoSolver<TVar>::MStructure str =
+        TPZPardisoSolver<TVar>::MStructure::ESymmetric;
+    typename TPZPardisoSolver<TVar>::MSystemType sysType =
+		TPZPardisoSolver<TVar>::MSystemType::ESymmetric;
+	typename TPZPardisoSolver<TVar>::MProperty prop =
+		this->IsDefPositive() ?
+		TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:
+		TPZPardisoSolver<TVar>::MProperty::EIndefinite;
+    fPardisoControl.SetStructure(str);
+	fPardisoControl.SetMatrixType(sysType,prop);
+    fPardisoControl.Decompose(this);
+    this->SetIsDecomposed(ELDLt);
     return 1;
 }
 
@@ -400,7 +417,7 @@ template<class TVar>
 int TPZSYsmpMatrix<TVar>::Subst_LForward( TPZFMatrix<TVar>* b ) const
 {
     TPZFMatrix<TVar> x(*b);
-    fPardisoControl.ReallySolve(*b,x);
+    fPardisoControl.Solve(this,*b,x);
     *b = x;
     return 1;
 }
@@ -422,7 +439,7 @@ template<class TVar>
 int TPZSYsmpMatrix<TVar>::Subst_Forward( TPZFMatrix<TVar>* b ) const
 {
     TPZFMatrix<TVar> x(*b);
-    fPardisoControl.ReallySolve(*b,x);
+    fPardisoControl.Solve(this,*b,x);
     *b = x;
     return 1;
 }

--- a/Matrix/pzysmp.cpp
+++ b/Matrix/pzysmp.cpp
@@ -944,9 +944,21 @@ int TPZFYsmpMatrix<TVar>::Decompose_LU()
     if (this->IsDecomposed() != ENoDecompose) {
         DebugStop();
     }
-	//do NOT call SetMatrix.
-	fPardisoControl.SetRawMatrix(this);
-    fPardisoControl.Decompose();
+	typename TPZPardisoSolver<TVar>::MStructure str =
+        this->IsSimetric() ?
+		TPZPardisoSolver<TVar>::MStructure::ESymmetric:
+		TPZPardisoSolver<TVar>::MStructure::ENonSymmetric;
+	typename TPZPardisoSolver<TVar>::MSystemType sysType =
+		this->IsSimetric() ?
+		TPZPardisoSolver<TVar>::MSystemType::ESymmetric:
+		TPZPardisoSolver<TVar>::MSystemType::ENonSymmetric;
+	typename TPZPardisoSolver<TVar>::MProperty prop =
+		this->IsDefPositive() ?
+		TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:
+		TPZPardisoSolver<TVar>::MProperty::EIndefinite;
+	fPardisoControl.SetStructure(str);
+	fPardisoControl.SetMatrixType(sysType,prop);
+    fPardisoControl.Decompose(this);
     this->SetIsDecomposed(ELU);
     return 1;
 #endif
@@ -975,7 +987,7 @@ int TPZFYsmpMatrix<TVar>::Substitution( TPZFMatrix<TVar> *B ) const
     
 #ifdef USING_MKL
     TPZFMatrix<TVar> x(*B);
-    fPardisoControl.ReallySolve(*B,x);
+    fPardisoControl.Solve(this,*B,x);
     *B = x;
     return 1;
 #endif

--- a/Solvers/TPZPardisoSolver.h
+++ b/Solvers/TPZPardisoSolver.h
@@ -78,15 +78,17 @@ public:
     //! Clones the current object returning a pointer of type TPZSolver
 	TPZPardisoSolver<TVar> *Clone() const override;
 protected:
-    /// This method sets a matrix that is not controlled by a TPZAutoPointer(raw pointer)
-    void SetRawMatrix(TPZMatrix<TVar>* Refmat);
-    
     /// Compute the `mtype` parameter of the pardiso_64 call
     long long MatrixType();
-
+    /**@brief Decompose the matrix */
+    void Decompose(TPZMatrix<TVar> *mat);
     /** @brief Use the decomposed matrix to invert the system of equations
      This method assumes that the matrix has been decomposed.*/
-    void ReallySolve(const TPZFMatrix<TVar> &rhs, TPZFMatrix<TVar> &sol) const;
+    void Solve(const TPZMatrix<TVar> *mat, const TPZFMatrix<TVar> &rhs, TPZFMatrix<TVar> &sol) const;
+
+    void SetStructure(MStructure str){
+        fStructure = str;
+    }
     
     MSystemType fSystemType{MSystemType::ENonInitialized};
     
@@ -124,11 +126,6 @@ protected:
     // matrix type, computed based on the structural information and TVar
     long long fMatrixType{0};
 
-    /// pointer to the nonsymmetric system (where the data structures are stored
-    TPZFYsmpMatrix<TVar> *fNonSymmetricSystem{nullptr};
-    
-    /// pointer to the symmetric system (where the data structures are stored
-    TPZSYsmpMatrix<TVar> *fSymmetricSystem{nullptr};
     /// whether the matrix has been decomposed
     bool fDecomposed{false};
 };


### PR DESCRIPTION
In #92 there was a `TPZPardisoSolver<TVar>::SetRawMatrix` method, since
`TPZMatrixSolver<TVar>` (from which `TPZPardisoSolver` inherits) has a `TPZAutoPointer` for its solver.

This was needed since `TPZFYsmpMatrix` and `TPZSYsmpMatrix` use internally the `TPZPardisoSolver` and we did not want their memory to be managed by the `TPZAutoPointer`.


After working on #93 it became clear that a cleaner solution for this problem could be simply not storing the matrix in the `TPZPardisoSolver` when using it internally in matrix classes.