### PR TITLE
Adding new features to TPZMatrix hierarchy+fixes

### DIFF
--- a/External/tpznodesetcompute.cpp
+++ b/External/tpznodesetcompute.cpp
@@ -415,7 +415,7 @@ void TPZNodesetCompute::BuildElementGraph(TPZStack<int64_t> &blockgraph, TPZStac
 		  LOGPZ_DEBUG(logger,sout.str())
 	  }
 #endif
-    SubstractLowerNodes(in,nodeset);
+    SubtractLowerNodes(in,nodeset);
 #ifdef PZ_LOG
 		  {
 			  std::stringstream sout;
@@ -437,7 +437,7 @@ void TPZNodesetCompute::BuildElementGraph(TPZStack<int64_t> &blockgraph, TPZStac
   }
 }
 
-void TPZNodesetCompute::SubstractLowerNodes(int64_t node, std::set<int64_t> &nodeset)
+void TPZNodesetCompute::SubtractLowerNodes(int64_t node, std::set<int64_t> &nodeset)
 {
   std::set<int64_t> lownode,lownodeset,unionset;
   std::set<int64_t>::iterator it;

--- a/External/tpznodesetcompute.h
+++ b/External/tpznodesetcompute.h
@@ -121,7 +121,7 @@ private:
 	 * @param node node whose intersection need to be considered
 	 * @param nodeset the set of nodes which need to form elements
 	 */
-	void SubstractLowerNodes(int64_t node, std::set<int64_t> &nodeset);
+	void SubtractLowerNodes(int64_t node, std::set<int64_t> &nodeset);
 };
 
 #endif

--- a/Frontal/TPZFrontMatrix.cpp
+++ b/Frontal/TPZFrontMatrix.cpp
@@ -195,6 +195,33 @@ void TPZFrontMatrix<TVar,store, front>::Print(const char *name, std::ostream& ou
 	}
 }
 
+
+template<class TVar, class store, class front>
+int64_t TPZFrontMatrix<TVar,store,front>::Size() const
+{
+	PZError<<__PRETTY_FUNCTION__;
+  PZError<<"ERROR:Should not be called\n.Aborting...\n";
+  DebugStop();
+	return -1;
+}
+template<class TVar, class store, class front>
+TVar* &TPZFrontMatrix<TVar,store,front>::Elem()
+{
+	PZError<<__PRETTY_FUNCTION__;
+  PZError<<"ERROR:Should not be called\n.Aborting...\n";
+  DebugStop();
+	static TVar* t{nullptr};
+  return t;
+}
+template<class TVar, class store, class front>
+const TVar* TPZFrontMatrix<TVar,store,front>::Elem() const
+{
+	PZError<<__PRETTY_FUNCTION__;
+  PZError<<"ERROR:Should not be called\n.Aborting...\n";
+  DebugStop();
+	return nullptr;
+}
+
 template<class TVar, class store, class front>
 void TPZFrontMatrix<TVar,store, front>::main()
 {

--- a/Frontal/TPZFrontMatrix.h
+++ b/Frontal/TPZFrontMatrix.h
@@ -85,16 +85,16 @@ public:
 	static void main();
     /** @brief Prints a FrontMatrix object */
 	void Print(const char * name, std::ostream & out ,const MatrixOutputFormat form = EFormatted) const override;
-    /** @brief Simple Destructor */
-    ~TPZFrontMatrix();
-int ClassId() const override;
-    /** @brief Simple Constructor */
-    TPZFrontMatrix();
-    /** 
+  /** @brief Simple Destructor */
+  ~TPZFrontMatrix();
+  int ClassId() const override;
+  /** @brief Simple Constructor */
+  TPZFrontMatrix();
+  /** 
 	 * @brief Constructor with a globalsize parameter 
 	 * @param globalsize Indicates initial global size
 	 */
-    TPZFrontMatrix(int64_t globalsize);
+  TPZFrontMatrix(int64_t globalsize);
 	
 	TPZFrontMatrix(const TPZFrontMatrix &cp) : TPZRegisterClassId(&TPZFrontMatrix::ClassId),TPZAbstractFrontMatrix<TVar>(cp), fStorage(cp.fStorage),
 	fFront(cp.fFront),fNumEq(cp.fNumEq),fLastDecomposed(cp.fLastDecomposed), fNumElConnected(cp.fNumElConnected),fNumElConnectedBackup(cp.fNumElConnectedBackup)
@@ -168,6 +168,9 @@ int ClassId() const override;
     void SetFileName(char option, const char *name);
 	
 protected:
+  int64_t Size() const override;
+  TVar* &Elem() override;
+  const TVar* Elem() const override;
     /** @brief Indicates number of equations */
 	int64_t fNumEq;
     /** @brief Indicates last decomposed equation */

--- a/Frontal/TPZFrontMatrix.h
+++ b/Frontal/TPZFrontMatrix.h
@@ -166,7 +166,21 @@ public:
 	 * @param name Name of the file
 	 */
     void SetFileName(char option, const char *name);
-	
+
+  void CopyFrom(const TPZMatrix<TVar> *  mat) override        
+  {                                                           
+    auto *from = dynamic_cast<const TPZFrontMatrix<TVar,store,front> *>(mat);                
+    if (from) {                                               
+      *this = *from;                                          
+    }                                                         
+    else                                                      
+      {                                                       
+        PZError<<__PRETTY_FUNCTION__;                         
+        PZError<<"\nERROR: Called with incompatible type\n."; 
+        PZError<<"Aborting...\n";                             
+        DebugStop();                                          
+      }                                                       
+  }
 protected:
   int64_t Size() const override;
   TVar* &Elem() override;

--- a/Frontal/TPZFrontMatrix.h
+++ b/Frontal/TPZFrontMatrix.h
@@ -102,6 +102,7 @@ public:
     }
     
   //  CLONEDEF(TPZFrontMatrix)
+  inline TPZFrontMatrix*NewMatrix() const override {return new TPZFrontMatrix{};}
 	virtual TPZMatrix<TVar>*Clone() const  override { return new TPZFrontMatrix(*this); }
     /** 
 	 * @brief Sends a message to decompose equations from lower_eq to upper_eq, according to destination index

--- a/Matrix/CMakeLists.txt
+++ b/Matrix/CMakeLists.txt
@@ -1,15 +1,16 @@
 # @file neopz/Matrix/CMakeLists.txt  -- CMake file for the Matrix module
 
 target_include_directories(pz PUBLIC 
-                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-                           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/Matrix>
-                           )
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/Matrix>
+    )
 
 set(headers
     PZMatrixMarket.h
     doxmatrix.h
     pzbndmat.h
     pzfmatrix.h
+    TPZFMatrixRef.h
     pzmatrix.h
     pzbasematrix.h
     pzskylmat.h

--- a/Matrix/TPZFMatrixRef.h
+++ b/Matrix/TPZFMatrixRef.h
@@ -1,0 +1,27 @@
+#include "pzfmatrix.h"
+
+
+/** @brief TPZFMatrix wrapper for acessing storage of a given matrix*/
+template<class TVar>
+class TPZFMatrixRef : public TPZFMatrix<TVar>{
+public:
+  TPZFMatrixRef(const int64_t rows, TVar * &buf) :
+    TPZFMatrix<TVar>(rows,1,buf,rows), fOrigRef(buf) {}
+  TPZFMatrixRef(const TPZFMatrixRef<TVar> &ref) = default;
+  TPZFMatrixRef(TPZFMatrixRef<TVar> &&ref) = default;
+  TPZFMatrixRef &operator=(const TPZFMatrixRef<TVar> &ref) = delete;
+  TPZFMatrixRef &operator=(TPZFMatrixRef<TVar> &&rval) = delete;
+  TPZFMatrixRef &operator=(const TPZFMatrix<TVar> &ref) = delete;
+  TPZFMatrixRef &operator=(TPZFMatrix<TVar> &&rval)
+  {
+    TPZFMatrix<TVar>::operator=(rval);
+    return *this;
+  }
+  ~TPZFMatrixRef()
+  {
+    fOrigRef = this->Elem();
+    this->Elem() = nullptr;
+  }
+private:
+  TVar * &fOrigRef;
+};

--- a/Matrix/pzbasematrix.h
+++ b/Matrix/pzbasematrix.h
@@ -98,7 +98,7 @@ public:
   /** @} */
 
   /** @brief Checks if the current matrix is symmetric */
-  virtual int IsSimetric() const{ return 0;}
+  virtual int IsSymmetric() const{ return 0;}
   /** @brief Checks if current matrix is square */
   inline int IsSquare() const {
     return fRow == fCol; }

--- a/Matrix/pzblockdiag.h
+++ b/Matrix/pzblockdiag.h
@@ -134,6 +134,18 @@ public:
 int ClassId() const override;
 
 protected:
+	inline TVar *&Elem() override
+  {
+    return fStorage.begin();
+  }
+  inline const TVar *Elem() const override
+  {
+    return fStorage.begin();
+  }
+  inline int64_t Size() const override
+  {
+    return fStorage.size();
+  }
 	/** @brief Stores matrix data */
 	TPZVec<TVar> fStorage;
 	/** @brief Stores blocks data */

--- a/Matrix/pzblockdiag.h
+++ b/Matrix/pzblockdiag.h
@@ -37,7 +37,8 @@ public:
 	TPZBlockDiagonal (const TPZVec<int> &blocksizes);
 	/** @brief Copy constructor */
 	TPZBlockDiagonal (const TPZBlockDiagonal & );
-	
+
+  TPZBlockDiagonal* NewMatrix() const override{ return new TPZBlockDiagonal{};}
 	CLONEDEF(TPZBlockDiagonal)
 
 	/** @brief Creates a copy from another TPZBlockDiagonal*/

--- a/Matrix/pzblockdiag.h
+++ b/Matrix/pzblockdiag.h
@@ -39,6 +39,22 @@ public:
 	TPZBlockDiagonal (const TPZBlockDiagonal & );
 	
 	CLONEDEF(TPZBlockDiagonal)
+
+	/** @brief Creates a copy from another TPZBlockDiagonal*/
+  void CopyFrom(const TPZMatrix<TVar> *  mat) override
+  {                                                           
+    auto *from = dynamic_cast<const TPZBlockDiagonal<TVar> *>(mat);                
+    if (from) {                                               
+      *this = *from;                                          
+    }                                                         
+    else                                                      
+      {                                                       
+        PZError<<__PRETTY_FUNCTION__;                         
+        PZError<<"\nERROR: Called with incompatible type\n."; 
+        PZError<<"Aborting...\n";                             
+        DebugStop();                                          
+      }                                                       
+  }
 	/** @brief Simple destructor */
 	~TPZBlockDiagonal();
 	

--- a/Matrix/pzbndmat.cpp
+++ b/Matrix/pzbndmat.cpp
@@ -187,7 +187,6 @@ TPZFBMatrix<TVar>::operator-=(const TPZFBMatrix<TVar> & A )
 
 /******** Operacoes com MATRIZES GENERICAS ********/
 
-
 /*******************/
 /*** MultiplyAdd ***/
 //
@@ -265,7 +264,7 @@ TPZFBMatrix<TVar>::operator*(const TVar value ) const
 
     int64_t sz = fElem.size();
     for (int64_t i=0; i<sz; i++) {
-        fElem[i] *= value;
+        res.fElem[i] *= value;
     }
 	return( res );
 }

--- a/Matrix/pzbndmat.cpp
+++ b/Matrix/pzbndmat.cpp
@@ -45,14 +45,6 @@ TPZMatrix<TVar>( dim, dim ), fElem(dim*(3*band_width+1),0.), fBandLower(band_wid
 
 
 /*********************************/
-/*** Constructor( TPZFBMatrix& ) ***/
-
-template<class TVar>
-TPZFBMatrix<TVar>::TPZFBMatrix (const TPZFBMatrix<TVar> & A)
-: TPZRegisterClassId(&TPZFBMatrix::ClassId),
-TPZMatrix<TVar>( A.Dim(), A.Dim() ),fElem(A.fElem), fBandLower(A.fBandLower), fBandUpper(A.fBandUpper)
-{
-}
 
 
 
@@ -103,21 +95,6 @@ TPZFBMatrix<TVar>::Get(const int64_t row,const int64_t col ) const
 /******** Operacoes com matrizes FULL BAND  ********/
 
 /******************/
-/*** Operator = ***/
-
-
-template<class TVar>
-TPZFBMatrix<TVar>&
-TPZFBMatrix<TVar>::operator=(const TPZFBMatrix<TVar> & A )
-{
-	if(this == &A) return *this;
-
-    TPZMatrix<TVar>::operator=(A);
-    fBandLower = A.fBandLower;
-    fBandUpper = A.fBandUpper;
-    fElem = A.fElem;
-	return *this;
-}
 
 
 

--- a/Matrix/pzbndmat.cpp
+++ b/Matrix/pzbndmat.cpp
@@ -96,93 +96,66 @@ TPZFBMatrix<TVar>::Get(const int64_t row,const int64_t col ) const
 
 /******************/
 
-
-
-/*******************************/
-/*** Operator+( TPZFBMatrix & ) ***/
-// DEPENDS ON THE STORAGE FORMAT
-template<class TVar>
+ template<class TVar>
 TPZFBMatrix<TVar>
-TPZFBMatrix<TVar>::operator+(const TPZFBMatrix<TVar> & A ) const
+TPZFBMatrix<TVar>::operator+(const TPZFBMatrix<TVar> &A ) const
 {
-	if ( A.Dim() != Dim() || A.fBandLower != fBandLower || A.fBandUpper != fBandUpper )
-		this->Error(__PRETTY_FUNCTION__, "Operator+ <matrixs with different dimensions>" );
-	
-    TPZFBMatrix<TVar> res(*this);
-    int64_t sz = fElem.size();
-    for (int64_t i=0; i<sz; i++) {
-        res.fElem[i] += A.fElem[i];
-    }
-	return( res );
+    if ( this->Dim() != A.Dim() ||
+         fBandUpper != A.fBandUpper ||
+         fBandLower != A.fBandLower)
+       this->Error(__PRETTY_FUNCTION__,"operator+( TPZFBMatrix ) <incompatible dimensions>" );
+    auto res(*this);
+    const auto size = res.fElem.size();
+    for(auto i = 0; i < size; i++) res.fElem[i] += A.fElem[i];
+    return res;
 }
 
-
-
-/*******************************/
-/*** Operator-( TPZFBMatrix & ) ***/
-// DEPENDS ON THE STORAGE FORMAT
+/******************/
+/*** Operator - ***/
 
 template<class TVar>
-TPZFBMatrix<TVar>
-TPZFBMatrix<TVar>::operator-(const TPZFBMatrix<TVar> & A ) const
+TPZFBMatrix<TVar> 
+TPZFBMatrix<TVar>::operator-(const TPZFBMatrix<TVar> &A ) const
 {
-    if ( A.Dim() != Dim() || A.fBandLower != fBandLower || A.fBandUpper != fBandUpper )
-        this->Error(__PRETTY_FUNCTION__, "Operator- <matrixs with different dimensions>" );
-    
-    TPZFBMatrix<TVar> res(*this);
-    int64_t sz = fElem.size();
-    for (int64_t i=0; i<sz; i++) {
-        res.fElem[i] -= A.fElem[i];
-    }
-    return( res );
-
+    if ( this->Dim() != A.Dim() ||
+         fBandUpper != A.fBandUpper ||
+         fBandLower != A.fBandLower)
+       this->Error(__PRETTY_FUNCTION__,"operator+( TPZFBMatrix ) <incompatible dimensions>" );
+    auto res(*this);
+    const auto size = res.fElem.size();
+    for(auto i = 0; i < size; i++) res.fElem[i] -= A.fElem[i];
+    return res;
 }
 
-
-
-/*******************************/
-/*** Operator*( TPZFBMatrix & ) ***/
-
-
-
-/********************************/
-/*** Operator+=( TPZFBMatrix & ) ***/
-// DEPENDS ON THE STORAGE FORMAT
-
-template <class TVar>
-TPZFBMatrix<TVar> &
-TPZFBMatrix<TVar>::operator+=(const TPZFBMatrix<TVar> & A )
-{
-    if ( A.Dim() != Dim() || A.fBandLower != fBandLower || A.fBandUpper != fBandUpper )
-        this->Error(__PRETTY_FUNCTION__, "Operator+= <matrixs with different dimensions>" );
-    
-    int64_t sz = fElem.size();
-    for (int64_t i=0; i<sz; i++) {
-        fElem[i] += A.fElem[i];
-    }
-    return( *this );
-}
-
-
-
-/*******************************/
-/*** Operator-=( TPZFBMatrix & ) ***/
-// DEPENDS ON THE STORAGE FORMAT
+/*******************/
+/*** Operator += ***/
 
 template<class TVar>
 TPZFBMatrix<TVar> &
-TPZFBMatrix<TVar>::operator-=(const TPZFBMatrix<TVar> & A )
+TPZFBMatrix<TVar>::operator+=(const TPZFBMatrix<TVar> &A )
 {
-    if ( A.Dim() != Dim() || A.fBandLower != fBandLower || A.fBandUpper != fBandUpper )
-        this->Error(__PRETTY_FUNCTION__, "Operator-= <matrixs with different dimensions>" );
-    
-    int64_t sz = fElem.size();
-    for (int64_t i=0; i<sz; i++) {
-        fElem[i] -= A.fElem[i];
-    }
-	return( *this );
+    if ( this->Dim() != A.Dim() ||
+         fBandUpper != A.fBandUpper ||
+         fBandLower != A.fBandLower)
+       this->Error(__PRETTY_FUNCTION__,"operator+( TPZFBMatrix ) <incompatible dimensions>" );
+    *this = *this+A;
+    return *this;
 }
 
+/*******************/
+/*** Operator -= ***/
+
+template<class TVar>
+TPZFBMatrix<TVar> &
+TPZFBMatrix<TVar>::operator-=(const TPZFBMatrix<TVar> &A )
+{
+    if ( this->Dim() != A.Dim() ||
+         fBandUpper != A.fBandUpper ||
+         fBandLower != A.fBandLower)
+       this->Error(__PRETTY_FUNCTION__,"operator+( TPZFBMatrix ) <incompatible dimensions>" );
+    *this = *this-A;
+    return *this;
+}
 
 
 /******** Operacoes com MATRIZES GENERICAS ********/
@@ -260,53 +233,10 @@ template<class TVar>
 TPZFBMatrix<TVar>
 TPZFBMatrix<TVar>::operator*(const TVar value ) const
 {
-	TPZFBMatrix<TVar> res(*this);
-
-    int64_t sz = fElem.size();
-    for (int64_t i=0; i<sz; i++) {
-        res.fElem[i] *= value;
-    }
-	return( res );
+	auto res(*this);
+  for(auto &el : res.fElem) el *=value;
+	return res;
 }
-
-
-
-
-
-/***************************/
-/*** Operator*=( value ) ***/
-
-template<>
-TPZFBMatrix<std::complex<float> > &
-TPZFBMatrix<std::complex<float> >::operator*=(const std::complex<float> value )
-{
-	if ( value.real() != 1.0 || value.imag() != 0. )
-    {
-        int64_t sz = fElem.size();
-        for (int64_t i=0; i<sz; i++) {
-            fElem[i] *= value;
-        }
-    }
-	
-	return( *this );
-}
-
-template<>
-TPZFBMatrix<std::complex<double> > &
-TPZFBMatrix<std::complex<double> >::operator*=(const std::complex<double> value )
-{
-	if ( value.real() != 1.0 || value.imag() != 0. )
-    {
-        int64_t sz = fElem.size();
-        for (int64_t i=0; i<sz; i++) {
-            fElem[i] *= value;
-        }
-    }
-	
-	return( *this );
-}
-
-
 
 template<class TVar>
 TPZFBMatrix<TVar> &

--- a/Matrix/pzbndmat.h
+++ b/Matrix/pzbndmat.h
@@ -113,7 +113,7 @@ public:
 	TPZFBMatrix &operator-=(const TPZFBMatrix<TVar> & A );
 	
 	TPZFBMatrix operator*  (const TVar val ) const;
-	TPZFBMatrix &operator*=(const TVar val );
+	TPZFBMatrix &operator*=(const TVar val ) override;
 	
 	TPZFBMatrix operator-() const;
 	

--- a/Matrix/pzbndmat.h
+++ b/Matrix/pzbndmat.h
@@ -159,6 +159,20 @@ public:
 int ClassId() const override;
 
 protected:
+  inline void CheckTypeCompatibility(const TPZMatrix<TVar>*A,
+                                     const TPZMatrix<TVar>*B)const override
+  {
+    auto aPtr = dynamic_cast<const TPZFBMatrix<TVar>*>(A);
+    auto bPtr = dynamic_cast<const TPZFBMatrix<TVar>*>(B);
+    if(!aPtr || !bPtr ||
+       (aPtr->fBandUpper!=bPtr->fBandUpper)||
+       (aPtr->fBandLower!=bPtr->fBandLower)
+       ){
+      PZError<<__PRETTY_FUNCTION__;
+      PZError<<"\nERROR: incompatible matrices\n.Aborting...\n";
+      DebugStop();
+    }
+  }
   inline TVar *&Elem() override
   {
     return fElem.begin();

--- a/Matrix/pzbndmat.h
+++ b/Matrix/pzbndmat.h
@@ -44,6 +44,7 @@ public:
 	TPZFBMatrix (const TPZFBMatrix<TVar> & ) = default;
   /** @brief Move constructor */
 	TPZFBMatrix (TPZFBMatrix<TVar> && ) = default;
+  inline TPZFBMatrix<TVar>*NewMatrix() const override {return new TPZFBMatrix<TVar>{};}
 	CLONEDEF(TPZFBMatrix)
 	/** @brief Copy-assignment operator*/
   TPZFBMatrix &operator= (const TPZFBMatrix<TVar> & A ) = default;

--- a/Matrix/pzbndmat.h
+++ b/Matrix/pzbndmat.h
@@ -55,25 +55,39 @@ public:
   friend class TPZFBMatrix<float>;
   friend class TPZFBMatrix<double>;
     
-    /// copy the values from a matrix with a different precision
-    template<class TVar2>
-    void CopyFromDiffPrecision(TPZFBMatrix<TVar2> &orig)
-    {
-        TPZMatrix<TVar>::CopyFromDiffPrecision(orig);
-        fBandLower = orig.fBandLower;
-        fBandUpper = orig.fBandUpper;
-        fElem.resize(orig.fElem.size());
-        int64_t nel = fElem.size();
-        for (int64_t el=0; el<nel; el++) {
-            fElem[el] = orig.fElem[el];
-        }
-        fPivot = orig.fPivot;
-        
+  /// copy the values from a matrix with a different precision
+  template<class TVar2>
+  void CopyFromDiffPrecision(TPZFBMatrix<TVar2> &orig)
+  {
+    TPZMatrix<TVar>::CopyFromDiffPrecision(orig);
+    fBandLower = orig.fBandLower;
+    fBandUpper = orig.fBandUpper;
+    fElem.resize(orig.fElem.size());
+    int64_t nel = fElem.size();
+    for (int64_t el=0; el<nel; el++) {
+      fElem[el] = orig.fElem[el];
     }
+    fPivot = orig.fPivot;
+        
+  }
     
-
-    
-    void AutoFill(int64_t nrow, int64_t ncol, int symmetric) override;
+  /** @brief Creates a copy from another TPZFBMatrix*/
+  void CopyFrom(const TPZMatrix<TVar> *  mat) override
+  {                                                           
+    auto *from = dynamic_cast<const TPZFBMatrix<TVar> *>(mat);                
+    if (from) {                                               
+      *this = *from;                                          
+    }                                                         
+    else                                                      
+      {                                                       
+        PZError<<__PRETTY_FUNCTION__;                         
+        PZError<<"\nERROR: Called with incompatible type\n."; 
+        PZError<<"Aborting...\n";                             
+        DebugStop();                                          
+      }                                                       
+  }
+  
+  void AutoFill(int64_t nrow, int64_t ncol, int symmetric) override;
 
     
 	int    Put(const int64_t row,const int64_t col,const TVar& value ) override;

--- a/Matrix/pzbndmat.h
+++ b/Matrix/pzbndmat.h
@@ -57,9 +57,9 @@ public:
     
     /// copy the values from a matrix with a different precision
     template<class TVar2>
-    void CopyFrom(TPZFBMatrix<TVar2> &orig)
+    void CopyFromDiffPrecision(TPZFBMatrix<TVar2> &orig)
     {
-        TPZMatrix<TVar>::CopyFrom(orig);
+        TPZMatrix<TVar>::CopyFromDiffPrecision(orig);
         fBandLower = orig.fBandLower;
         fBandUpper = orig.fBandUpper;
         fElem.resize(orig.fElem.size());

--- a/Matrix/pzbndmat.h
+++ b/Matrix/pzbndmat.h
@@ -41,14 +41,19 @@ public:
 	 */
 	TPZFBMatrix (const int64_t dim,const int64_t band_width = 0 );
 	/** @brief Copy constructor */
-	TPZFBMatrix (const TPZFBMatrix<TVar> & );
-	
+	TPZFBMatrix (const TPZFBMatrix<TVar> & ) = default;
+  /** @brief Move constructor */
+	TPZFBMatrix (TPZFBMatrix<TVar> && ) = default;
 	CLONEDEF(TPZFBMatrix)
-	/** @brief Simple destructor */
+	/** @brief Copy-assignment operator*/
+  TPZFBMatrix &operator= (const TPZFBMatrix<TVar> & A ) = default;
+  /** @brief Move-assignment operator*/
+  TPZFBMatrix &operator= (TPZFBMatrix<TVar> && A ) = default;
+  /** @brief Simple destructor */
 	~TPZFBMatrix();
 
-    friend class TPZFBMatrix<float>;
-    friend class TPZFBMatrix<double>;
+  friend class TPZFBMatrix<float>;
+  friend class TPZFBMatrix<double>;
     
     /// copy the values from a matrix with a different precision
     template<class TVar2>
@@ -88,7 +93,6 @@ public:
 	// Peforms the product (*this)T x D x (*this).
 	//  TPZFBMatrix  InnerProd(TPZFBMatrix &D );
 	
-	TPZFBMatrix &operator= (const TPZFBMatrix<TVar> & A );
 	TPZFBMatrix operator+  (const TPZFBMatrix<TVar> & A ) const;
 	TPZFBMatrix operator-  (const TPZFBMatrix<TVar> & A ) const;
 	TPZFBMatrix &operator+=(const TPZFBMatrix<TVar> & A );

--- a/Matrix/pzbndmat.h
+++ b/Matrix/pzbndmat.h
@@ -144,7 +144,19 @@ public:
     public:
 int ClassId() const override;
 
-    
+protected:
+  inline TVar *&Elem() override
+  {
+    return fElem.begin();
+  }
+  inline const TVar *Elem() const override
+  {
+    return fElem.begin();
+  }
+  inline int64_t Size() const override
+  {
+    return fElem.size();
+  }
 private:
 	
     int64_t Index(int64_t i, int64_t j) const

--- a/Matrix/pzbndmat.h
+++ b/Matrix/pzbndmat.h
@@ -98,7 +98,7 @@ public:
 
 	inline int    PutVal(const int64_t row,const int64_t col,const TVar& value ) override;
 	inline const TVar GetVal(const int64_t row,const int64_t col ) const override;
-	
+  
 	void MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> &y, TPZFMatrix<TVar> &z,
 				 const TVar alpha=1,const TVar beta = 0,const int opt = 0) const override;
 	// Computes z = beta * y + alpha * opt(this)*x
@@ -182,7 +182,7 @@ private:
 	TPZVec<TVar> fElem;
 	int64_t  fBandLower, fBandUpper;
 
-    TPZManVector<int,5> fPivot;
+  TPZManVector<int,5> fPivot;
 
 };
 

--- a/Matrix/pzfmatrix.cpp
+++ b/Matrix/pzfmatrix.cpp
@@ -91,6 +91,17 @@ TPZMatrix<TVar>( A.fRow, A.fCol ), fElem(0), fGiven(0), fSize(0) {
     memcpy((void *)(p),(void *)(src),(size_t)size*sizeof(TVar));
 }
 
+template<class TVar>
+TPZFMatrix<TVar>::TPZFMatrix(TPZFMatrix<TVar> &&A)
+    : TPZMatrix<TVar>(A), fElem(A.fElem),
+      fGiven(A.fGiven),fSize(A.fSize),
+      fPivot(A.fPivot), fWork(A.fWork)
+{
+    A.fElem=nullptr;
+    A.fGiven=nullptr;
+    A.fSize=0;
+}
+
 /********************************/
 /*** Constructor( TPZVerySparseMatrix<TVar> & ) ***/
 
@@ -120,12 +131,6 @@ TPZMatrix<TVar>( A.Rows(), A.Cols() ), fElem(0), fGiven(0), fSize(0) {
     
 }
 
-
-
-/******** Operacoes com matrizes FULL  ********/
-
-/******************/
-/*** Operator = ***/
 template<class TVar>
 TPZFMatrix<TVar> &TPZFMatrix<TVar>::operator=(const TPZFMatrix<TVar> &A ) {
     if(this == &A) return *this;
@@ -153,6 +158,26 @@ TPZFMatrix<TVar> &TPZFMatrix<TVar>::operator=(const TPZFMatrix<TVar> &A ) {
     
     return *this;
 }
+
+template<class TVar>
+TPZFMatrix<TVar> &TPZFMatrix<TVar>::operator=(TPZFMatrix<TVar> &&A ) {
+    TPZMatrix<TVar>::operator=(A);
+    fElem=A.fElem;
+    fGiven=A.fGiven;
+    fSize=A.fSize;
+    fPivot = A.fPivot;
+    fWork = A.fWork;
+    
+    A.fElem = nullptr;
+    A.fGiven = nullptr;
+    A.fSize = 0;
+    return *this;
+}
+
+/******** Operacoes com matrizes FULL  ********/
+
+/******************/
+/*** Operator = ***/
 
 template< class TVar >
 TPZFMatrix<TVar>& TPZFMatrix<TVar>::operator= (const std::initializer_list<TVar>& list) {

--- a/Matrix/pzfmatrix.cpp
+++ b/Matrix/pzfmatrix.cpp
@@ -321,38 +321,37 @@ void TPZFMatrix<float>::AddFel(TPZFMatrix<float> &rhs,TPZVec<int64_t> &source, T
 /*** Operator+( TPZFMatrix>& ) ***/
 
 template <class TVar>
-TPZFMatrix<TVar> TPZFMatrix<TVar>::operator+(const TPZFMatrix<TVar> &A ) const {
+TPZFMatrix<TVar>
+TPZFMatrix<TVar>::operator+(const TPZFMatrix<TVar> &A ) const {
     if ( (A.Rows() != this->Rows())  ||  (A.Cols() != this->Cols()) )
         Error( "Operator+ <matrixs with different dimensions>" );
     
-    TPZFMatrix<TVar> res;
-    res.Redim( this->Rows(), this->Cols() );
-    int64_t size = ((int64_t)this->Rows()) * this->Cols();
-    TVar * pm = fElem, *plast = fElem+size;
+    auto res(*this);
     TVar * pa = A.fElem;
-    TVar * pr = res.fElem;
+    const auto size = this->Rows() * this->Cols();
+    TVar * pr = res.fElem, *plast = pr+size;
     
-    while(pm < plast) *pr++ = (*pm++) + (*pa++);
+    while(pr < plast) *pr++ +=  (*pa++);
     
-    return( res );
+    return res;
 }
 
 /*******************************/
 /*** Operator-( TPZFMatrix<>& ) ***/
 template <class TVar>
-TPZFMatrix<TVar> TPZFMatrix<TVar>::operator-(const TPZFMatrix<TVar> &A ) const {
+TPZFMatrix<TVar>
+TPZFMatrix<TVar>::operator-(const TPZFMatrix<TVar> &A ) const {
+
     if ( (A.Rows() != this->Rows())  ||  (A.Cols() != this->Cols()) )
         Error( "Operator- <matrixs with different dimensions>" );
     
-    TPZFMatrix<TVar> res;
-    res.Redim( this->Rows(), this->Cols() );
-    int64_t size = ((int64_t)this->Rows()) * this->Cols();
-    TVar * pm = fElem;
+    auto res (*this);
     TVar * pa = A.fElem;
+    const auto size = this->Rows()*this->Cols();
     TVar * pr = res.fElem, *prlast =pr+size;
     
-    while(pr < prlast) *pr++ = (*pm++) - (*pa++);
-    return( res );
+    while(pr < prlast) *pr++ -= (*pa++);
+    return res;
 }
 
 template <class TVar>
@@ -851,13 +850,17 @@ void TPZFMatrix<TVar>::MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> 
 /********************************/
 /*** Operator+=( TPZFMatrix<>& ) ***/
 template <class TVar>
-TPZFMatrix<TVar> & TPZFMatrix<TVar>::operator+=(const TPZFMatrix<TVar> &A ) {
-    if ( (A.Rows() != this->Rows())  ||  (A.Cols() != this->Cols()) )
-        Error( "Operator+= <matrixs with different dimensions>" );
+TPZFMatrix<TVar> & TPZFMatrix<TVar>::operator+=(const TPZMatrix<TVar> &aBase ) {
+    auto A = dynamic_cast<const TPZFMatrix<TVar>*>(&aBase);
+    if(!A){
+        Error(__PRETTY_FUNCTION__," incompatible argument");
+    }
+    if ( (A->Rows() != this->Rows())  ||  (A->Cols() != this->Cols()) )
+        Error( "Operator+= <matrices with different dimensions>" );
     
     int64_t size = ((int64_t)this->Rows()) * this->Cols();
     TVar * pm = fElem, *pmlast=pm+size;
-    TVar * pa = A.fElem;
+    TVar * pa = A->fElem;
     while(pm < pmlast) (*pm++) += (*pa++);
     return( *this );
 }
@@ -865,13 +868,17 @@ TPZFMatrix<TVar> & TPZFMatrix<TVar>::operator+=(const TPZFMatrix<TVar> &A ) {
 /*******************************/
 /*** Operator-=( TPZFMatrix<>& ) ***/
 template <class TVar>
-TPZFMatrix<TVar> &TPZFMatrix<TVar>::operator-=(const TPZFMatrix<TVar> &A ) {
-    if ( (A.Rows() != this->Rows())  ||  (A.Cols() != this->Cols()) )
+TPZFMatrix<TVar> &TPZFMatrix<TVar>::operator-=(const TPZMatrix<TVar> &aBase ) {
+    auto A = dynamic_cast<const TPZFMatrix<TVar>*>(&aBase);
+    if(!A){
+        Error(__PRETTY_FUNCTION__," incompatible argument");
+    }
+    if ( (A->Rows() != this->Rows())  ||  (A->Cols() != this->Cols()) )
         Error( "Operator-= <matrixs with different dimensions>" );
     
     int64_t size = ((int64_t)this->Rows()) * this->Cols();
     TVar * pm = fElem;
-    TVar * pa = A.fElem;
+    TVar * pa = A->fElem;
     
     for ( int64_t i = 0; i < size; i++ ) *pm++ -= *pa++;
     
@@ -1005,11 +1012,12 @@ TPZFMatrix<TVar> TPZFMatrix<TVar>::operator-  (const TVar val ) const {
 /*** Operator*( value ) ***/
 
 template <class TVar>
-TPZFMatrix<TVar> TPZFMatrix<TVar>::operator*(const TVar value ) const
+TPZFMatrix<TVar>
+TPZFMatrix<TVar>::operator*(const TVar value ) const
 {
-    TPZFMatrix<TVar> res( *this );
+    auto res(*this);
     res *= value;
-    return( res );
+    return res;
 }
 
 /***************************/

--- a/Matrix/pzfmatrix.cpp
+++ b/Matrix/pzfmatrix.cpp
@@ -192,6 +192,19 @@ TPZFMatrix<TVar>& TPZFMatrix<TVar>::operator= (const std::initializer_list<TVar>
 	return *this;
 }
 
+template<class TVar>
+void TPZFMatrix<TVar>::CopyFrom(const TPZMatrix<TVar> *mat)
+{
+    const auto r = mat->Rows();
+    const auto c = mat->Cols();
+    this->Resize(r,c);
+    for(auto i = 0 ;i < r;i++){
+        for(auto j = 0; j < c; j++){
+            this->PutVal(i,j,mat->GetVal(i,j));
+        }
+    }
+}
+
 template< class TVar >
 void TPZFMatrix<TVar>::InitializeEqualFromList (const std::initializer_list< std::initializer_list<TVar> >& list){
     size_t n_row = list.size();

--- a/Matrix/pzfmatrix.h
+++ b/Matrix/pzfmatrix.h
@@ -161,7 +161,8 @@ public:
             fElem[el] = orig.fElem[el];
         }
     }
-
+    /** @brief Creates a copy from another TPZMatrix*/
+    void CopyFrom(const TPZMatrix<TVar> *  mat) override;
     /** @brief Updates the values of the matrix based on the values of the matrix */
     virtual void UpdateFrom(TPZAutoPointer<TPZMatrix<TVar> >  mat) override
     {

--- a/Matrix/pzfmatrix.h
+++ b/Matrix/pzfmatrix.h
@@ -60,6 +60,7 @@ class TPZLapackEigenSolver;
 template<class TVar=REAL>
 class TPZFMatrix: public TPZMatrix<TVar> {
     friend class TPZLapackEigenSolver<TVar>;
+    friend class TPZMatrix<TVar>;
 public:
     
     /** @brief Simple constructor */
@@ -141,14 +142,10 @@ public:
     
     int64_t MemoryFootprint() const  override
     {
-        return (sizeof(TVar)*this->Rows()*this->Cols());
+        return (sizeof(TVar)*Size());
     }
     
-    TVar *Adress()
-    {
-        return fElem;
-    }
-    
+        
     friend class TPZFMatrix<float>;
     friend class TPZFMatrix<double>;
     friend class TPZHCurlAuxClass;//for using the GETVAL macro.
@@ -447,7 +444,22 @@ int ClassId() const override;
     operator const TVar*() const { return fElem; }
     
     static void PrintStatic(const TVar *ptr, int64_t rows, int64_t cols, const char *name, std::ostream& out,const MatrixOutputFormat form);
-    
+
+protected:
+    inline TVar *&
+    Elem() override
+    {
+        return fElem;
+    }
+    inline const TVar *Elem() const override
+    {
+        return fElem;
+    }
+
+    inline int64_t Size() const override
+    {
+        return this->Rows()*this->Cols();
+    }
 private:
     
     static int Error(const char *msg1,const char *msg2=0 );

--- a/Matrix/pzfmatrix.h
+++ b/Matrix/pzfmatrix.h
@@ -112,7 +112,7 @@ public:
     TPZFMatrix&operator= (const TPZFMatrix<TVar> &A );
     //!Move-assignment operator
     TPZFMatrix&operator= (TPZFMatrix<TVar> &&A );
-    
+    inline TPZFMatrix<TVar>*NewMatrix() const override {return new TPZFMatrix<TVar>{};}
     CLONEDEF(TPZFMatrix<TVar>)
     TPZFMatrix(const TPZMatrix<TVar> & refmat);
 

--- a/Matrix/pzfmatrix.h
+++ b/Matrix/pzfmatrix.h
@@ -152,10 +152,10 @@ public:
     /// copy the values from a matrix with a different precision
 
     template<class TVar2>
-    void CopyFrom(TPZFMatrix<TVar2> &orig)
+    void CopyFromDiffPrecision(TPZFMatrix<TVar2> &orig)
     {
         Resize(orig.Rows(), orig.Cols());
-        TPZMatrix<TVar>::CopyFrom(orig);
+        TPZMatrix<TVar>::CopyFromDiffPrecision(orig);
         int64_t nel = orig.Rows()*orig.Cols();
         for (int64_t el=0; el<nel; el++) {
             fElem[el] = orig.fElem[el];

--- a/Matrix/pzfmatrix.h
+++ b/Matrix/pzfmatrix.h
@@ -102,8 +102,15 @@ public:
      * @param refmat Used as a model for current object
      */
     TPZFMatrix(const TPZFMatrix<TVar> & refmat);
-    
-    
+    /**
+     * @brief Move constructor
+     * @param refmat Used as a model for current object
+     */
+    TPZFMatrix(TPZFMatrix<TVar> && refmat);
+    //!Copy-assignment operator
+    TPZFMatrix&operator= (const TPZFMatrix<TVar> &A );
+    //!Move-assignment operator
+    TPZFMatrix&operator= (TPZFMatrix<TVar> &&A );
     
     CLONEDEF(TPZFMatrix<TVar>)
     TPZFMatrix(const TPZMatrix<TVar> & refmat);
@@ -222,9 +229,6 @@ public:
      * @name Operations with FULL matrices
      * @{
      */
-    
-    /** @brief Generic operator with FULL matrices */
-    virtual TPZFMatrix&operator= (const TPZFMatrix<TVar> &A );
 
     virtual TPZFMatrix<TVar>& operator= (const std::initializer_list<TVar>& list);
     TPZFMatrix<TVar>& operator= (const std::initializer_list< std::initializer_list<TVar> >& list);
@@ -782,7 +786,7 @@ public:
         TPZFMatrix<TVar>::operator=(val);
     }
     
-    inline  TPZFMatrix<TVar> &operator=(const TPZFMatrix<TVar> &copy)  override {
+    inline  TPZFMatrix<TVar> &operator=(const TPZFMatrix<TVar> &copy) {
         return TPZFMatrix<TVar>::operator=(copy);
     }
     inline  TPZFNMatrix<N, TVar> &operator=(const TPZFNMatrix<N, TVar> &copy) {

--- a/Matrix/pzfmatrix.h
+++ b/Matrix/pzfmatrix.h
@@ -227,7 +227,7 @@ public:
     virtual TPZFMatrix&operator= (const TPZFMatrix<TVar> &A );
 
     virtual TPZFMatrix<TVar>& operator= (const std::initializer_list<TVar>& list);
-	TPZFMatrix<TVar>& operator= (const std::initializer_list< std::initializer_list<TVar> >& list);
+    TPZFMatrix<TVar>& operator= (const std::initializer_list< std::initializer_list<TVar> >& list);
     TPZFMatrix<TVar> operator+  (const TPZFMatrix<TVar> &A ) const;
     TPZFMatrix<TVar> operator-  (const TPZFMatrix<TVar> &A ) const;
     TPZFMatrix<TVar> operator*  ( TPZFMatrix<TVar> A ) const ;

--- a/Matrix/pzfmatrix.h
+++ b/Matrix/pzfmatrix.h
@@ -232,9 +232,9 @@ public:
     TPZFMatrix<TVar>& operator= (const std::initializer_list< std::initializer_list<TVar> >& list);
     TPZFMatrix<TVar> operator+  (const TPZFMatrix<TVar> &A ) const;
     TPZFMatrix<TVar> operator-  (const TPZFMatrix<TVar> &A ) const;
-    TPZFMatrix<TVar> operator*  ( TPZFMatrix<TVar> A ) const ;
-    TPZFMatrix<TVar> &operator+=(const TPZFMatrix<TVar> &A );
-    TPZFMatrix<TVar> &operator-=(const TPZFMatrix<TVar> &A );
+    TPZFMatrix<TVar> operator*  (const TPZFMatrix<TVar> &A ) const;
+    TPZFMatrix<TVar> &operator+=(const TPZMatrix<TVar> &A );
+    TPZFMatrix<TVar> &operator-=(const TPZMatrix<TVar> &A );
 
     /**
      * @brief Procedure to generate &operator= from list
@@ -274,7 +274,7 @@ public:
     TPZFMatrix<TVar> operator*  (const TVar val ) const;
     TPZFMatrix<TVar> &operator+=(const TVar val );
     TPZFMatrix<TVar> &operator-=(const TVar val )  { return operator+=( -val ); }
-    TPZFMatrix<TVar> &operator*=(const TVar val );
+    TPZFMatrix<TVar> &operator*=(const TVar val ) override;
     
     //	TPZFMatrix<TVar> operator-() const;// { return operator*( -1.0 ); }
     
@@ -586,7 +586,7 @@ inline TPZFMatrix<TVar> operator*(TVar val, const TPZFMatrix<TVar> &A)
 /*******************************/
 /*** Operator*( TPZMatrix<TVar> & ) ***/
 template<class TVar>
-inline TPZFMatrix<TVar> TPZFMatrix<TVar>::operator*( TPZFMatrix<TVar> A ) const {
+inline TPZFMatrix<TVar> TPZFMatrix<TVar>::operator*(const TPZFMatrix<TVar> &A) const {
     if ( this->Cols() != A.Rows() )
         Error( "Operator* <matrixs with incompatible dimensions>" );
     

--- a/Matrix/pzfmatrix.h
+++ b/Matrix/pzfmatrix.h
@@ -447,6 +447,18 @@ int ClassId() const override;
     static void PrintStatic(const TVar *ptr, int64_t rows, int64_t cols, const char *name, std::ostream& out,const MatrixOutputFormat form);
 
 protected:
+    /** @brief Checks compatibility of matrices before Add/Subtract operations*/
+    inline void CheckTypeCompatibility(const TPZMatrix<TVar>*A,
+                                       const TPZMatrix<TVar>*B)const override
+    {
+        auto aPtr = dynamic_cast<const TPZFMatrix<TVar>*>(A);
+        auto bPtr = dynamic_cast<const TPZFMatrix<TVar>*>(B);
+        if(!aPtr || !bPtr){
+            PZError<<__PRETTY_FUNCTION__;
+            PZError<<"\nERROR: incompatible matrices.Aborting...\n";
+            DebugStop();
+        }
+    }
     inline TVar *&
     Elem() override
     {

--- a/Matrix/pzmatred.cpp
+++ b/Matrix/pzmatred.cpp
@@ -122,6 +122,32 @@ TVar& TPZMatRed<TVar,TSideMatrix>::s(const int64_t r,const int64_t c ) {
 }
 
 template<class TVar, class TSideMatrix>
+int64_t TPZMatRed<TVar,TSideMatrix>::Size() const
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"\nERROR: should not be called for TPZMatRed.\nAborting...\n";
+  DebugStop();
+  return -1;
+}
+template<class TVar, class TSideMatrix>
+TVar *&TPZMatRed<TVar,TSideMatrix>::Elem()
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"\nERROR: should not be called for TPZMatRed.\nAborting...\n";
+  DebugStop();
+  static TVar* t{nullptr};
+  return t;
+}
+template<class TVar, class TSideMatrix>
+const TVar *TPZMatRed<TVar,TSideMatrix>::Elem() const
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"\nERROR: should not be called for TPZMatRed.\nAborting...\n";
+  DebugStop();
+  return nullptr;
+}
+
+template<class TVar, class TSideMatrix>
 void TPZMatRed<TVar,TSideMatrix>::SetSolver(TPZAutoPointer<TPZMatrixSolver<TVar> > solver)
 {
 	fK00=solver->Matrix();

--- a/Matrix/pzmatred.cpp
+++ b/Matrix/pzmatred.cpp
@@ -58,8 +58,8 @@ TPZMatRed<TVar, TSideMatrix >::~TPZMatRed(){
 }
 
 template<class TVar, class TSideMatrix>
-int TPZMatRed<TVar, TSideMatrix>::IsSimetric() const {
-	if(fK00) return this->fK00->IsSimetric();
+int TPZMatRed<TVar, TSideMatrix>::IsSymmetric() const {
+	if(fK00) return this->fK00->IsSymmetric();
 	return 0;
 }
 
@@ -68,7 +68,7 @@ void TPZMatRed<TVar, TSideMatrix>::SimetrizeMatRed() {
 	// considering fK00 is simetric, only half of the object is assembled.
 	// this method simetrizes the matrix object
 	
-	if(!fK00 || !this->fK00->IsSimetric()) return;
+	if(!fK00 || !this->fK00->IsSymmetric()) return;
 	fK01.Transpose(&fK10);
 	
 	fK11.Simetrize();
@@ -87,7 +87,7 @@ template<class TVar, class TSideMatrix>
 int
 TPZMatRed<TVar, TSideMatrix>::PutVal(const int64_t r,const int64_t c,const TVar& value ){
 	int64_t row(r),col(c);
-	if (IsSimetric() && row > col ) Swap( &row, &col );
+	if (IsSymmetric() && row > col ) Swap( &row, &col );
 	if (row<fDim0 &&  col<fDim0)  fK00->PutVal(row,col,value);
 	if (row<fDim0 &&  col>=fDim0)  fK01.PutVal(row,col-fDim0,(TVar)value);
 	if (row>=fDim0 &&  col<fDim0)  fK10.PutVal(row-fDim0,col,(TVar)value);
@@ -101,7 +101,7 @@ const TVar
 TPZMatRed<TVar,TSideMatrix>::GetVal(const int64_t r,const int64_t c ) const {
 	int64_t row(r),col(c);
 	
-	if (IsSimetric() && row > col ) Swap( &row, &col );
+	if (IsSymmetric() && row > col ) Swap( &row, &col );
 	if (row<fDim0 &&  col<fDim0)  return ( fK00->GetVal(row,col) );
 	if (row<fDim0 &&  col>=fDim0)  return ( fK01.GetVal(row,col-fDim0) );
 	if (row>=fDim0 &&  col<fDim0)  return ( fK10.GetVal(row-fDim0,col) );
@@ -113,7 +113,7 @@ template<class TVar, class TSideMatrix>
 TVar& TPZMatRed<TVar,TSideMatrix>::s(const int64_t r,const int64_t c ) {
 	int64_t row(r),col(c);
 	
-	if (r < fDim0 && IsSimetric() && row > col ) Swap( &row, &col );
+	if (r < fDim0 && IsSymmetric() && row > col ) Swap( &row, &col );
 	if (row<fDim0 &&  col<fDim0)  return ( fK00->s(row,col) );
 	if (row<fDim0 &&  col>=fDim0)  return ( (TVar &)fK01.s(row,col-fDim0) );
 	if (row>=fDim0 &&  col<fDim0)  return ( (TVar &)(fK10.s(row-fDim0,col)) );

--- a/Matrix/pzmatred.h
+++ b/Matrix/pzmatred.h
@@ -60,6 +60,22 @@ public:
 	}
 	
 	CLONEDEF(TPZMatRed)
+
+  /** @brief Creates a copy from another TPZMatRed*/
+  void CopyFrom(const TPZMatrix<TVar> *  mat) override
+  {                                                           
+    auto *from = dynamic_cast<const TPZMatRed<TVar,TSideMatrix> *>(mat);                
+    if (from) {                                               
+      *this = *from;                                          
+    }                                                         
+    else                                                      
+      {                                                       
+        PZError<<__PRETTY_FUNCTION__;                         
+        PZError<<"\nERROR: Called with incompatible type\n."; 
+        PZError<<"Aborting...\n";                             
+        DebugStop();                                          
+      }                                                       
+  }
 	/** @brief Simple destructor */
 	~TPZMatRed();
 	

--- a/Matrix/pzmatred.h
+++ b/Matrix/pzmatred.h
@@ -64,7 +64,7 @@ public:
 	~TPZMatRed();
 	
 	/** @brief returns 1 or 0 depending on whether the fK00 matrix is zero or not */
-	virtual int IsSimetric() const override;
+	virtual int IsSymmetric() const override;
 	
 	/** @brief changes the declared dimension of the matrix to fDim1 */
 	void SetReduced()

--- a/Matrix/pzmatred.h
+++ b/Matrix/pzmatred.h
@@ -58,7 +58,7 @@ public:
 		
 		if(cp.fK00) fK00 = cp.fK00;
 	}
-	
+	inline TPZMatRed<TVar,TSideMatrix>*NewMatrix() const override {return new TPZMatRed<TVar,TSideMatrix>{};}
 	CLONEDEF(TPZMatRed)
 
   /** @brief Creates a copy from another TPZMatRed*/
@@ -233,7 +233,7 @@ public:
 	
 	/** @brief Saveable methods */
 	public:
-int ClassId() const override;
+  int ClassId() const override;
 
 	
 	void Write(TPZStream &buf, int withclassid) const override;

--- a/Matrix/pzmatred.h
+++ b/Matrix/pzmatred.h
@@ -222,7 +222,10 @@ int ClassId() const override;
 	
 	void Write(TPZStream &buf, int withclassid) const override;
 	void Read(TPZStream &buf, void *context) override;
-	
+protected:
+  int64_t Size() const override;
+  TVar *&Elem() override;
+  const TVar *Elem() const override;
 private:
 	
 	/**

--- a/Matrix/pzmatrix.cpp
+++ b/Matrix/pzmatrix.cpp
@@ -13,6 +13,7 @@
 //#include "pzfmatrix.h"
 #include "pzmatrix.h"
 #include "TPZMatrixSolver.h"
+#include "TPZFMatrixRef.h"
 #include "pzvec.h"
 #include "pzextractval.h"
 
@@ -55,7 +56,22 @@ const TVar TPZMatrix<TVar>::GetVal(const int64_t /*row*/, const int64_t /*col*/ 
     return (TVar)0;
 }
 
-
+template<class TVar>
+TPZFMatrixRef<TVar> TPZMatrix<TVar>::Storage()
+{
+  const auto size = Size();
+  const auto elem = Elem();
+	TPZFMatrixRef<TVar> ref(size,Elem());
+	return ref;
+}
+template<class TVar>
+const TPZFMatrix<TVar> TPZMatrix<TVar>::Storage() const
+{
+  const auto size = Size();
+  const auto elem = Elem();
+	TPZFMatrix<TVar> ref(size,1,const_cast<TVar*>(elem),size);
+	return ref;
+}
 
 template<class TVar>
 void TPZMatrix<TVar>::Add(const TPZMatrix<TVar>&A,TPZMatrix<TVar>&B) const {

--- a/Matrix/pzmatrix.cpp
+++ b/Matrix/pzmatrix.cpp
@@ -118,6 +118,17 @@ TPZFMatrix<TVar> operator*( TPZMatrix<TVar> &A, const TPZFMatrix<TVar> &B ) {
 	A.Multiply(B,res);
 	return res;
 }
+
+
+template<class TVar>
+void TPZMatrix<TVar>::CheckTypeCompatibility(const TPZMatrix<TVar>*A,
+                                             const TPZMatrix<TVar>*B) const
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"\nERROR: not implemented for your matrix type.\nAborting...\n";
+  DebugStop();
+}
+
 template<class TVar>
 void TPZMatrix<TVar>::PrepareZ(const TPZFMatrix<TVar> &y, TPZFMatrix<TVar> &z,const TVar beta,const int opt) const
 {
@@ -1777,6 +1788,7 @@ void TPZMatrix<TVar>::Add(const TPZMatrix<TVar>&A,TPZMatrix<TVar>&res) const {
       for ( int64_t c = 0; c < Cols(); c++ )
         res.PutVal( r, c, GetVal(r,c)+A.GetVal(r,c) );
   }else{
+    CheckTypeCompatibility(&res,&A);
     res.Storage() += A.Storage();
   }
   
@@ -1804,6 +1816,7 @@ void TPZMatrix<TVar>::Subtract(const TPZMatrix<TVar> &A,TPZMatrix<TVar> &res) co
       for ( int64_t c = 0; c < Cols(); c++ )
         res.PutVal( r, c, GetVal(r,c)-A.GetVal(r,c) );
   }else{
+    CheckTypeCompatibility(&res,&A);
     res.Storage() -= A.Storage();
   }
 }

--- a/Matrix/pzmatrix.cpp
+++ b/Matrix/pzmatrix.cpp
@@ -357,7 +357,7 @@ void TPZMatrix<TVar>::Print(const char *name, std::ostream& out,const MatrixOutp
 	}
     else if( form == EMatrixMarket)
     {
-        bool sym = IsSimetric();
+        bool sym = IsSymmetric();
         int64_t numzero = 0;
         int64_t nrow = Rows();
         for ( int64_t row = 0; row < Rows(); row++) {
@@ -531,7 +531,7 @@ void TPZMatrix<TVar>::AddKel(TPZFMatrix<TVar> &elmat, TPZVec<int64_t> &destinati
 	
 	int64_t nelem = elmat.Rows();
   	int64_t icoef,jcoef,ieq,jeq;
-	if(IsSimetric()) {
+	if(IsSymmetric()) {
 		for(icoef=0; icoef<nelem; icoef++) {
 			ieq = destinationindex[icoef];
 			for(jcoef=icoef; jcoef<nelem; jcoef++) {
@@ -560,7 +560,7 @@ void TPZMatrix<TVar>::AddKel(TPZFMatrix<TVar> &elmat, TPZVec<int64_t> &source, T
 	int64_t nelem = source.NElements();
   	int64_t icoef,jcoef,ieq,jeq,ieqs,jeqs;
     TVar prevval;
-	if(IsSimetric()) {
+	if(IsSymmetric()) {
 		for(icoef=0; icoef<nelem; icoef++) {
 			ieq = destinationindex[icoef];
 			ieqs = source[icoef];
@@ -1801,7 +1801,7 @@ int TPZMatrix<TVar>::Inverse(TPZFMatrix<TVar>&Inv, DecomposeType dec){
     }
     else
     {
-        const int issimetric = this->IsSimetric();
+        const int issimetric = this->IsSymmetric();
         if (issimetric)  return this->SolveDirect(Inv, ELDLt);
         if (!issimetric) return this->SolveDirect(Inv, ELU);
     }

--- a/Matrix/pzmatrix.cpp
+++ b/Matrix/pzmatrix.cpp
@@ -69,7 +69,7 @@ void TPZMatrix<TVar>::Add(const TPZMatrix<TVar>&A,TPZMatrix<TVar>&B) const {
 		for ( int64_t c = 0; c < Cols(); c++ ) B.PutVal( r, c, GetVal(r,c)+A.GetVal(r,c) );
 }
 template<class TVar>
-void TPZMatrix<TVar>::Substract(const TPZMatrix<TVar> &A,TPZMatrix<TVar> &result) const {
+void TPZMatrix<TVar>::Subtract(const TPZMatrix<TVar> &A,TPZMatrix<TVar> &result) const {
 	
 	if ((Rows() != A.Rows()) || (Cols() != A.Cols()) ) {
 		Error( "Add(TPZMatrix<>&, TPZMatrix<>&) <different dimensions>" );
@@ -116,7 +116,7 @@ TPZFMatrix<TVar> operator-(const TPZMatrix<TVar> &A, const TPZMatrix<TVar> &B ) 
 	TPZFMatrix<TVar> temp;
     TPZFMatrix<TVar> res;
     res.Redim( A.Rows(), A.Cols() );
-    A.Substract(B,res);
+    A.Subtract(B,res);
     return temp;
 }
 

--- a/Matrix/pzmatrix.cpp
+++ b/Matrix/pzmatrix.cpp
@@ -90,35 +90,14 @@ void TPZMatrix<TVar>::Simetrize() {
   
 }
 
-/** @brief Implements sum of matrices: \f$ A+B \f$ */
-template<class TVar>
-TPZFMatrix<TVar> operator+(const TPZMatrix<TVar> &A, const TPZMatrix<TVar> &B ) {
-	TPZFMatrix<TVar> temp;
-    temp.Redim( A.Rows(), A.Cols() );
-    A.Add(B,temp);
-    return temp;
-}
-
-
-/** @brief Implements difference of matrices: \f$ A-B \f$ */
-template<class TVar>
-TPZFMatrix<TVar> operator-(const TPZMatrix<TVar> &A, const TPZMatrix<TVar> &B ) {
-	TPZFMatrix<TVar> temp;
-    TPZFMatrix<TVar> res;
-    res.Redim( A.Rows(), A.Cols() );
-    A.Subtract(B,res);
-    return temp;
-}
-
 /** @brief Implements product of matrices: \f$ A*B \f$ */
 template<class TVar>
-TPZFMatrix<TVar> operator*( TPZMatrix<TVar> &A, const TPZFMatrix<TVar> &B ) {
-    TPZFMatrix<TVar> res;
-    res.Redim( A.Rows(), B.Cols() );
-	A.Multiply(B,res);
+TPZFMatrix<TVar> TPZMatrix<TVar>::operator*(const TPZFMatrix<TVar> &B ) {
+  TPZFMatrix<TVar> res;
+  res.Redim( this->Rows(), B.Cols() );
+	this->Multiply(B,res);
 	return res;
 }
-
 
 template<class TVar>
 void TPZMatrix<TVar>::CheckTypeCompatibility(const TPZMatrix<TVar>*A,
@@ -1826,6 +1805,15 @@ void TPZMatrix<TVar>::MultiplyByScalar(const TVar alpha, TPZMatrix<TVar>&res) co
 {
   res.CopyFrom(this);
   res.Storage() *= alpha;
+}
+
+template<class TVar>
+TPZMatrix<TVar> &TPZMatrix<TVar>::operator*=(const TVar val)
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"\nERROR: not implemented.\nAborting...\n";
+  DebugStop();
+  return *this;
 }
 
 template<class TVar>

--- a/Matrix/pzmatrix.cpp
+++ b/Matrix/pzmatrix.cpp
@@ -74,32 +74,6 @@ const TPZFMatrix<TVar> TPZMatrix<TVar>::Storage() const
 }
 
 template<class TVar>
-void TPZMatrix<TVar>::Add(const TPZMatrix<TVar>&A,TPZMatrix<TVar>&B) const {
-	if ((Rows() != A.Rows()) || (Cols() != A.Cols()) ) {
-		Error( "Add(TPZMatrix<>&, TPZMatrix) <different dimensions>" );
-	}
-	
-	B.Redim( A.Rows(), A.Cols() );
-	
-	for ( int64_t r = 0; r < Rows(); r++ )
-		for ( int64_t c = 0; c < Cols(); c++ ) B.PutVal( r, c, GetVal(r,c)+A.GetVal(r,c) );
-}
-template<class TVar>
-void TPZMatrix<TVar>::Subtract(const TPZMatrix<TVar> &A,TPZMatrix<TVar> &result) const {
-	
-	if ((Rows() != A.Rows()) || (Cols() != A.Cols()) ) {
-		Error( "Add(TPZMatrix<>&, TPZMatrix<>&) <different dimensions>" );
-	}
-	
-    result.Resize( Rows(), Cols() );
-    for ( int64_t r = 0; r < Rows(); r++ ) {
-        for ( int64_t c = 0; c < Cols(); c++ ) {
-            result.PutVal( r, c, GetVal(r,c)-A.GetVal(r,c) );
-        }
-    }
-}
-
-template<class TVar>
 void TPZMatrix<TVar>::Simetrize() {
   
   if ( Rows() != Cols() ) {
@@ -1779,6 +1753,66 @@ TVar TPZMatrix<TVar>::ConditionNumber(int p, int64_t numiter, REAL tol){
 	}
 	TVar invnorm = Inv.MatrixNorm(p, numiter, tol);
 	return thisnorm * invnorm;
+}
+
+template<class TVar>
+void TPZMatrix<TVar>::Add(const TPZMatrix<TVar>&A,TPZMatrix<TVar>&res) const {
+	if ((Rows() != A.Rows()) || (Cols() != A.Cols()) ) {
+		Error( "Add(TPZMatrix<>&, TPZMatrix) <different dimensions>" );
+	}
+  if(this->Size()!=A.Size()){
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"ERROR\nDifferent number of entries.\nAborting...\n";
+    DebugStop();
+  }
+  res.CopyFrom(this);
+  auto thisFmat =
+    dynamic_cast<const TPZFMatrix<TVar>*>(this);
+  auto aFmat =
+    dynamic_cast<const TPZFMatrix<TVar>*>(&A);
+  auto resFmat =
+    dynamic_cast<TPZFMatrix<TVar>*>(&res);
+  if(resFmat && (!thisFmat || !aFmat)){
+    for ( int64_t r = 0; r < Rows(); r++ )
+      for ( int64_t c = 0; c < Cols(); c++ )
+        res.PutVal( r, c, GetVal(r,c)+A.GetVal(r,c) );
+  }else{
+    res.Storage() += A.Storage();
+  }
+  
+}
+template<class TVar>
+void TPZMatrix<TVar>::Subtract(const TPZMatrix<TVar> &A,TPZMatrix<TVar> &res) const {
+	
+	if ((Rows() != A.Rows()) || (Cols() != A.Cols()) ) {
+		Error( "Add(TPZMatrix<>&, TPZMatrix<>&) <different dimensions>" );
+	}
+	if(this->Size()!=A.Size()){
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"ERROR\nDifferent number of entries.\nAborting...\n";
+    DebugStop();
+  }
+  res.CopyFrom(this);
+  auto thisFmat =
+    dynamic_cast<const TPZFMatrix<TVar>*>(this);
+  auto aFmat =
+    dynamic_cast<const TPZFMatrix<TVar>*>(&A);
+  auto resFmat =
+    dynamic_cast<TPZFMatrix<TVar>*>(&res);
+  if(resFmat && (!thisFmat || !aFmat)){
+    for ( int64_t r = 0; r < Rows(); r++ )
+      for ( int64_t c = 0; c < Cols(); c++ )
+        res.PutVal( r, c, GetVal(r,c)-A.GetVal(r,c) );
+  }else{
+    res.Storage() -= A.Storage();
+  }
+}
+
+template<class TVar>
+void TPZMatrix<TVar>::MultiplyByScalar(const TVar alpha, TPZMatrix<TVar>&res) const
+{
+  res.CopyFrom(this);
+  res.Storage() *= alpha;
 }
 
 template<class TVar>

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -177,7 +177,7 @@ public:
 	/** @brief Computes res = rhs - this * x */
 	virtual void Residual(const TPZFMatrix<TVar>& x,const TPZFMatrix<TVar>& rhs, TPZFMatrix<TVar>& res ) ;
 	/** @brief It substracts A from storing the result in result */
-	virtual void Substract(const TPZMatrix<TVar>& A,TPZMatrix<TVar>& result) const;
+	virtual void Subtract(const TPZMatrix<TVar>& A,TPZMatrix<TVar>& result) const;
 	
 	/** @brief Converts the matrix in an identity matrix*/
 	virtual void Identity();

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -23,6 +23,7 @@ class TPZStream;
 /** @brief To create clone matrix */
 #define CLONEDEF(A) virtual TPZMatrix<TVar>*Clone() const override { return new A(*this); }
 
+
 class TPZSolver;
 
 /** @brief Root matrix class (abstract). \ref matrix "Matrix" */
@@ -82,6 +83,10 @@ public:
     fCol = copy.Cols();
 
   }
+
+  /** @brief Creates a copy from a given matrix of arbitrary storage format. 
+      Every implementation should check for type compatibility */
+  virtual void CopyFrom(const TPZMatrix<TVar> *mat) = 0;
 
 	/** @brief Fill matrix storage with randomic values */
 	/** This method use GetVal and PutVal which are implemented by each type matrices */

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -71,7 +71,7 @@ public:
    of the matrix.
   This method is useful for arithmetic operations. Derived class should implement
   methods `Size()` and `Elem()`*/
-  TPZFMatrix<TVar> Storage();
+  TPZFMatrixRef<TVar> Storage();
   const TPZFMatrix<TVar> Storage() const;
   /** @} */
   template<class TVar2>
@@ -171,12 +171,20 @@ public:
 	 * @param opt Indicates if is Transpose or not
 	 */
 	virtual void Multiply(const TPZFMatrix<TVar>& A,TPZFMatrix<TVar>& res, int opt = 0) const;
+  /**
+	 * @brief It mutiplies itself by a scalar alpha putting the result in res
+	 * @param alpha scalar to be multiplied with
+	 * @param res TPZFMatrix<TVar>containing the result
+	 */
+  void MultiplyByScalar(const TVar alpha,TPZMatrix<TVar>& res) const;
 	/**
 	 * @brief It adds itself to TPZMatrix<TVar>A putting the result in res
 	 * @param A TPZMatrix<TVar>to added to current matrix
 	 * @param res Contains the result
 	 */
-	virtual void Add(const TPZMatrix<TVar>& A,TPZMatrix<TVar>& res) const;
+	void Add(const TPZMatrix<TVar>& A,TPZMatrix<TVar>& res) const;
+  /** @brief It substracts A from storing the result in result */
+	void Subtract(const TPZMatrix<TVar>& A,TPZMatrix<TVar>& result) const;
 	/**
 	 * @brief It computes z = beta * y + alpha * opt(this)*x but z and x can not overlap in memory.
 	 * @param x Is x on the above operation
@@ -191,8 +199,6 @@ public:
 	
 	/** @brief Computes res = rhs - this * x */
 	virtual void Residual(const TPZFMatrix<TVar>& x,const TPZFMatrix<TVar>& rhs, TPZFMatrix<TVar>& res ) ;
-	/** @brief It substracts A from storing the result in result */
-	virtual void Subtract(const TPZMatrix<TVar>& A,TPZMatrix<TVar>& result) const;
 	
 	/** @brief Converts the matrix in an identity matrix*/
 	virtual void Identity();

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -38,8 +38,8 @@ public:
 	{
 	}
 
-    /** @brief Move constructor */
-    TPZMatrix<TVar>(TPZMatrix<TVar> &&cp) = default;
+  /** @brief Move constructor */
+  TPZMatrix<TVar>(TPZMatrix<TVar> &&cp) = default;
 	/** @brief Simple destructor */
 	virtual ~TPZMatrix() = default;
 
@@ -820,14 +820,14 @@ inline TVar &TPZMatrix<TVar>::operator()(const int64_t row) {
 
 template<class TVar>
 inline int TPZMatrix<TVar>::Solve_LU( TPZFMatrix<TVar>*B, std::list<int64_t> &singular) {
-	if ( IsSimetric() )
+	if ( IsSymmetric() )
         Error( "LU decomposition is not a symmetric decomposition" );
 	return ( ( !Decompose_LU(singular) )?  0 : Substitution( B )  );
 }
 
 template<class TVar>
 inline int TPZMatrix<TVar>::Solve_LU( TPZFMatrix<TVar>*B ) {
-	if ( IsSimetric() )
+	if ( IsSymmetric() )
         Error( "LU decomposition is not a symmetric decomposition" );
 	return ( ( !Decompose_LU() )?  0 : Substitution( B )  );
 }

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -74,7 +74,7 @@ public:
   const TPZFMatrix<TVar> Storage() const;
   /** @} */
   template<class TVar2>
-  void CopyFrom(TPZMatrix<TVar2> &copy)
+  void CopyFromDiffPrecision(TPZMatrix<TVar2> &copy)
   {
     fDecomposed = copy.IsDecomposed();
     fDefPositive = copy.IsDefPositive();

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -185,6 +185,10 @@ public:
 	void Add(const TPZMatrix<TVar>& A,TPZMatrix<TVar>& res) const;
   /** @brief It substracts A from storing the result in result */
 	void Subtract(const TPZMatrix<TVar>& A,TPZMatrix<TVar>& result) const;
+
+  virtual TPZMatrix<TVar> &operator*=(const TVar val);
+
+  TPZFMatrix<TVar> operator*(const TPZFMatrix<TVar> &B );
 	/**
 	 * @brief It computes z = beta * y + alpha * opt(this)*x but z and x can not overlap in memory.
 	 * @param x Is x on the above operation

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -15,6 +15,8 @@ class TPZVec;
 template<class TVar>
 class TPZFMatrix;
 template<class TVar>
+class TPZFMatrixRef;
+template<class TVar>
 class TPZAutoPointer;
 
 class TPZStream;
@@ -43,12 +45,12 @@ public:
 	/** @brief Simple destructor */
 	virtual ~TPZMatrix() = default;
 
-    /** @brief Copy assignment operator*/
-    TPZMatrix<TVar> &operator=(const TPZMatrix<TVar> &);
-    /** @brief Move assignment operator*/
-    TPZMatrix<TVar> &operator=(TPZMatrix<TVar> &&);
+  /** @brief Copy assignment operator*/
+  TPZMatrix<TVar> &operator=(const TPZMatrix<TVar> &);
+  /** @brief Move assignment operator*/
+  TPZMatrix<TVar> &operator=(TPZMatrix<TVar> &&);
 
-    virtual TPZMatrix<TVar>*Clone() const = 0;
+  virtual TPZMatrix<TVar>*Clone() const = 0;
 
 	/**
 	 * @brief Returns the approximate size of the memory footprint (amount
@@ -62,16 +64,24 @@ public:
 	  //DebugStop();
 	  return 0;
 	}
-    
-    template<class TVar2>
-    void CopyFrom(TPZMatrix<TVar2> &copy)
-    {
-        fDecomposed = copy.IsDecomposed();
-        fDefPositive = copy.IsDefPositive();
-        fRow = copy.Rows();
-        fCol = copy.Cols();
 
-    }
+  /** @{ */
+  /** @brief Reference to a nx1 TPZFMatrix associated with the contiguous memory area 
+   of the matrix.
+  This method is useful for arithmetic operations. Derived class should implement
+  methods `Size()` and `Elem()`*/
+  TPZFMatrix<TVar> Storage();
+  const TPZFMatrix<TVar> Storage() const;
+  /** @} */
+  template<class TVar2>
+  void CopyFrom(TPZMatrix<TVar2> &copy)
+  {
+    fDecomposed = copy.IsDecomposed();
+    fDefPositive = copy.IsDefPositive();
+    fRow = copy.Rows();
+    fCol = copy.Cols();
+
+  }
 
 	/** @brief Fill matrix storage with randomic values */
 	/** This method use GetVal and PutVal which are implemented by each type matrices */
@@ -107,23 +117,23 @@ public:
 	 * @param col Column number.
 	 */
 	TVar operator() (const int64_t row,const int64_t col ) const;
-    /**
-     * @brief The operators check on the bounds if the DEBUG variable is defined
-     * @param row Row number.
-     * @param col Column number.
-     */
-    TVar &at(const std::pair<int64_t,int64_t> &rowcol )
-    {
-        return operator()(rowcol.first,rowcol.second);
-    }
-    const TVar at(const std::pair<int64_t,int64_t> &rowcol ) const
-    {
-        return Get(rowcol.first,rowcol.second);
-    }
+  /**
+   * @brief The operators check on the bounds if the DEBUG variable is defined
+   * @param row Row number.
+   * @param col Column number.
+   */
+  TVar &at(const std::pair<int64_t,int64_t> &rowcol )
+  {
+    return operator()(rowcol.first,rowcol.second);
+  }
+  const TVar at(const std::pair<int64_t,int64_t> &rowcol ) const
+  {
+    return Get(rowcol.first,rowcol.second);
+  }
 	/**
 	 * @brief The operators check on the bounds if the DEBUG variable is defined
-     * @param row Row number.
-     * @param col Column number.
+   * @param row Row number.
+   * @param col Column number.
 	 */
 	virtual TVar &s(const int64_t row, const int64_t col);
 	/**
@@ -670,7 +680,13 @@ public:
     bool CompareValues(TPZMatrix<TVar>&M, TVar tol);
 	
 protected:
-	
+  /** @brief Number of entries storaged in the Matrix*/
+  virtual int64_t Size() const = 0;
+  /** @{ */
+  /** @brief Pointer to the beginning of the storage of the matrix*/
+  virtual TVar* &Elem() = 0;
+  virtual const TVar* Elem() const = 0;
+  /** @} */
 	/**
 	 * @brief Is an auxiliar method used by MultiplyAdd
 	 * @see MultAdd

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -50,7 +50,9 @@ public:
   TPZMatrix<TVar> &operator=(const TPZMatrix<TVar> &);
   /** @brief Move assignment operator*/
   TPZMatrix<TVar> &operator=(TPZMatrix<TVar> &&);
-
+  /** @brief To create a matrix of the same type */
+  virtual TPZMatrix<TVar>*NewMatrix() const = 0;
+  /** @brief To create clone matrix */
   virtual TPZMatrix<TVar>*Clone() const = 0;
 
 	/**
@@ -87,7 +89,7 @@ public:
   /** @brief Creates a copy from a given matrix of arbitrary storage format. 
       Every implementation should check for type compatibility */
   virtual void CopyFrom(const TPZMatrix<TVar> *mat) = 0;
-
+  
 	/** @brief Fill matrix storage with randomic values */
 	/** This method use GetVal and PutVal which are implemented by each type matrices */
 	void AutoFill(int64_t nrow, int64_t ncol, int symmetric) override;

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -691,6 +691,9 @@ public:
     bool CompareValues(TPZMatrix<TVar>&M, TVar tol);
 	
 protected:
+  /** @brief Checks compatibility of matrices before Add/Subtract operations*/
+  virtual void CheckTypeCompatibility(const TPZMatrix<TVar>*A,
+                                      const TPZMatrix<TVar>*B)const;
   /** @brief Number of entries storaged in the Matrix*/
   virtual int64_t Size() const = 0;
   /** @{ */

--- a/Matrix/pzsbndmat.cpp
+++ b/Matrix/pzsbndmat.cpp
@@ -271,30 +271,25 @@ TPZSBMatrix<TVar>::operator+(const TPZSBMatrix<TVar> &A ) const
 {
     if ( this->Dim() != A.Dim() || fBand != A.fBand)
        this->Error(__PRETTY_FUNCTION__,"operator+( TPZSBMatrix ) <incompatible dimensions>" );
-    
-    // Define os ponteiros e tamanhos para os elementos da maior e da
-    //  menor banda.
-    TPZSBMatrix Res(*this);
-    Res += A;
-    return Res;
+    auto res(*this);
+    const auto size = res.fDiag.size();
+    for(auto i = 0; i < size; i++) res.fDiag[i] += A.fDiag[i];
+    return res;
 }
 
 /******************/
 /*** Operator - ***/
 
 template<class TVar>
-TPZSBMatrix<TVar>
+TPZSBMatrix<TVar> 
 TPZSBMatrix<TVar>::operator-(const TPZSBMatrix<TVar> &A ) const
 {
     if ( this->Dim() != A.Dim() || fBand != A.fBand)
-    {
-       this->Error(__PRETTY_FUNCTION__, "operator-( TPZSBMatrix ) <incompatible dimensions>" );
-    }
-    
-    TPZSBMatrix<TVar> res(*this);
-    res -= A;
-    
-    return( res );
+       this->Error(__PRETTY_FUNCTION__,"operator+( TPZSBMatrix ) <incompatible dimensions>" );
+    auto res(*this);
+    const auto size = res.fDiag.size();
+    for(auto i = 0; i < size; i++) res.fDiag[i] -= A.fDiag[i];
+    return res;
 }
 
 /*******************/
@@ -305,14 +300,9 @@ TPZSBMatrix<TVar> &
 TPZSBMatrix<TVar>::operator+=(const TPZSBMatrix<TVar> &A )
 {
     if ( this->Dim() != A.Dim() || fBand != A.fBand)
-    {
-       this->Error(__PRETTY_FUNCTION__, "operator+=( TPZSBMatrix ) <incompatible dimensions>" );
-    }
-    int64_t siz= fDiag.size();
-    for (int64_t i=0; i<siz; i++) {
-        fDiag[i] += A.fDiag[i];
-    }
-    return( *this );
+       this->Error(__PRETTY_FUNCTION__,"operator+( TPZSBMatrix ) <incompatible dimensions>" );
+    *this = *this+A;
+    return *this;
 }
 
 /*******************/
@@ -323,15 +313,9 @@ TPZSBMatrix<TVar> &
 TPZSBMatrix<TVar>::operator-=(const TPZSBMatrix<TVar> &A )
 {
     if ( this->Dim() != A.Dim() || fBand != A.fBand)
-    {
-       this->Error(__PRETTY_FUNCTION__, "operator-=( TPZSBMatrix ) <incompatible dimensions>" );
-    }
-    int64_t siz= fDiag.size();
-    for (int64_t i=0; i<siz; i++) {
-        fDiag[i] -= A.fDiag[i];
-    }
-    
-    return( *this );
+       this->Error(__PRETTY_FUNCTION__,"operator+( TPZSBMatrix ) <incompatible dimensions>" );
+    *this = *this-A;
+    return *this;
 }
 
 template<class TVar>
@@ -394,14 +378,9 @@ template<class TVar>
 TPZSBMatrix<TVar>
 TPZSBMatrix<TVar>::operator*(const TVar value ) const
 {
-    TPZSBMatrix<TVar> res( *this );
-    
-    int64_t siz= fDiag.size();
-    for (int64_t i=0; i<siz; i++) {
-        res.fDiag[i] *= value;
-    }
-    
-    return( res );
+    auto res(*this);
+    for(auto &el : res.fDiag) el*=value;
+    return res;
 }
 
 /******************************/

--- a/Matrix/pzsbndmat.cpp
+++ b/Matrix/pzsbndmat.cpp
@@ -263,18 +263,6 @@ operator<<(std::ostream& out,TPZSBMatrix<TVar>  &A)
 /******** Operacoes com matrizes BANDA SIMETRICA  ********/
 
 /******************/
-/*** Operator = ***/
-
-template<class TVar>
-TPZSBMatrix<TVar> &
-TPZSBMatrix<TVar>::operator=(const TPZSBMatrix<TVar> &A )
-{
-    Clear();
-    Copy( A );
-    return( *this );
-}
-
-/******************/
 /*** Operator + ***/
 
 template<class TVar>

--- a/Matrix/pzsbndmat.h
+++ b/Matrix/pzsbndmat.h
@@ -67,6 +67,22 @@ public:
             fDiag[el] = orig.fDiag[el];
         }
     }
+
+    /** @brief Creates a copy from another TPZSBMatrix*/
+    void CopyFrom(const TPZMatrix<TVar> *  mat) override
+    {                                                           
+        auto *from = dynamic_cast<const TPZSBMatrix<TVar> *>(mat);                
+        if (from) {                                               
+            *this = *from;                                          
+        }                                                         
+        else                                                      
+            {                                                       
+                PZError<<__PRETTY_FUNCTION__;                         
+                PZError<<"\nERROR: Called with incompatible type\n."; 
+                PZError<<"Aborting...\n";                             
+                DebugStop();                                          
+            }                                                       
+    }
     
     /** @brief Computes z = beta * y + alpha * opt(this)*x */
     /** z and x cannot overlap in memory */

--- a/Matrix/pzsbndmat.h
+++ b/Matrix/pzsbndmat.h
@@ -156,15 +156,24 @@ public:
     
     /** @} */
 
-    public:
 int ClassId() const override;
 
-private:
+protected:
+    inline TVar *&Elem() override
+    {
+        return fDiag.begin();
+    }
+    inline const TVar *Elem() const override
+    {
+        return fDiag.begin();
+    }
+
     
-    int64_t  Size() const
+    inline int64_t  Size() const override
     {
         return( this->Dim() * (fBand + 1) );
     }
+private:
 //    int  PutZero();
     //static int  Error(const char *msg1,const char* msg2="" ) ;
     int  Clear() override;

--- a/Matrix/pzsbndmat.h
+++ b/Matrix/pzsbndmat.h
@@ -35,11 +35,11 @@ public:
     TPZSBMatrix() : TPZRegisterClassId(&TPZSBMatrix::ClassId),
     TPZMatrix<TVar>() , fDiag() { fBand = 0; }
     TPZSBMatrix(const int64_t dim,const int64_t band );
-    TPZSBMatrix(const TPZSBMatrix<TVar> &A ) : TPZRegisterClassId(&TPZSBMatrix::ClassId),
-    TPZMatrix<TVar>(A)  { Copy(A); }
-    
+    TPZSBMatrix(const TPZSBMatrix<TVar> &A ) = default;
+    TPZSBMatrix(TPZSBMatrix<TVar> &&A ) = default;
     CLONEDEF(TPZSBMatrix)
-    
+    TPZSBMatrix &operator= (TPZSBMatrix<TVar> &&A ) = default;
+    TPZSBMatrix &operator= (const TPZSBMatrix<TVar> &A ) = default;
     ~TPZSBMatrix() { Clear(); }
     
     int    PutVal(const int64_t row,const int64_t col,const TVar& element ) override;
@@ -83,7 +83,6 @@ public:
     
     /// Operadores com matrizes SKY LINE.
     // @{
-    TPZSBMatrix &operator= (const TPZSBMatrix<TVar> &A );
     TPZSBMatrix operator+  (const TPZSBMatrix<TVar> &A ) const;
     TPZSBMatrix operator-  (const TPZSBMatrix<TVar> &A ) const;
     TPZSBMatrix &operator+=(const TPZSBMatrix<TVar> &A );

--- a/Matrix/pzsbndmat.h
+++ b/Matrix/pzsbndmat.h
@@ -105,7 +105,7 @@ public:
     TPZSBMatrix &operator-=(const TPZSBMatrix<TVar> &A );
     // @}
     TPZSBMatrix<TVar> operator*  (const TVar v ) const;
-    TPZSBMatrix<TVar> &operator*=(const TVar v );
+    TPZSBMatrix<TVar> &operator*=(const TVar v ) override;
     
     TPZSBMatrix<TVar> operator-() const { return operator*(-1.0); }
     

--- a/Matrix/pzsbndmat.h
+++ b/Matrix/pzsbndmat.h
@@ -58,9 +58,9 @@ public:
     
     /// copy the values from a matrix with a different precision
     template<class TVar2>
-    void CopyFrom(TPZSBMatrix<TVar2> &orig)
+    void CopyFromDiffPrecision(TPZSBMatrix<TVar2> &orig)
     {
-        TPZMatrix<TVar>::CopyFrom(orig);
+        TPZMatrix<TVar>::CopyFromDiffPrecision(orig);
         fDiag.resize(orig.fDiag.size());
         int64_t nel = fDiag.size();
         for (int64_t el=0; el<nel; el++) {

--- a/Matrix/pzsbndmat.h
+++ b/Matrix/pzsbndmat.h
@@ -48,7 +48,7 @@ public:
     TVar &operator()(int64_t row, int64_t col);
     
     /** @brief Checks if the current matrix is symmetric */
-    virtual int IsSimetric() const override
+    virtual int IsSymmetric() const override
     {
         return 1;
     }

--- a/Matrix/pzsbndmat.h
+++ b/Matrix/pzsbndmat.h
@@ -37,6 +37,7 @@ public:
     TPZSBMatrix(const int64_t dim,const int64_t band );
     TPZSBMatrix(const TPZSBMatrix<TVar> &A ) = default;
     TPZSBMatrix(TPZSBMatrix<TVar> &&A ) = default;
+    inline TPZSBMatrix<TVar>*NewMatrix() const override {return new TPZSBMatrix<TVar>{};}
     CLONEDEF(TPZSBMatrix)
     TPZSBMatrix &operator= (TPZSBMatrix<TVar> &&A ) = default;
     TPZSBMatrix &operator= (const TPZSBMatrix<TVar> &A ) = default;

--- a/Matrix/pzsbndmat.h
+++ b/Matrix/pzsbndmat.h
@@ -175,6 +175,18 @@ public:
 int ClassId() const override;
 
 protected:
+    /** @brief Checks compatibility of matrices before Add/Subtract operations*/
+    inline void CheckTypeCompatibility(const TPZMatrix<TVar>*A,
+                                       const TPZMatrix<TVar>*B)const override
+    {
+        auto aPtr = dynamic_cast<const TPZSBMatrix<TVar>*>(A);
+        auto bPtr = dynamic_cast<const TPZSBMatrix<TVar>*>(B);
+        if(!aPtr || !bPtr || aPtr->fBand!=bPtr->fBand){
+            PZError<<__PRETTY_FUNCTION__;
+            PZError<<"\nERROR: incompatible matrices\n.Aborting...\n";
+            DebugStop();
+        }
+    }
     inline TVar *&Elem() override
     {
         return fDiag.begin();

--- a/Matrix/pzsfulmat.cpp
+++ b/Matrix/pzsfulmat.cpp
@@ -651,7 +651,7 @@ TPZSFMatrix<TVar> ::Subst_Forward( TPZFMatrix<TVar>  *B ) const
 	if ( (B->Rows() != this->Dim()) || !this->fDecomposed )
 		return( 0 );
 	
-	if ( B->IsSimetric() )
+	if ( B->IsSymmetric() )
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__, "Subst_Forward <the matrix result can not be simetric>" );
 	
 	TVar *ptr_k = fElem;
@@ -687,7 +687,7 @@ TPZSFMatrix<TVar> ::Subst_Backward( TPZFMatrix<TVar>  *B ) const
 	if ( (B->Rows() != this->Dim()) || !this->fDecomposed )
 		return( 0 );
 	
-	if ( B->IsSimetric() )
+	if ( B->IsSymmetric() )
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__, "Subst_Backward <the matrix result can not be simetric>" );
 	
 	TVar *ptr_k = &fElem[ Size()-1 ];
@@ -727,7 +727,7 @@ TPZSFMatrix<TVar> ::Subst_LForward( TPZFMatrix<TVar>  *B ) const
 	if ( (B->Rows() != this->Dim()) || !this->fDecomposed )
 		return( 0 );
 	
-	if ( B->IsSimetric() )
+	if ( B->IsSymmetric() )
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__, "Subst_LForward <the matrix result can not be simetric>" );
 	
 	TVar *ptr_k = fElem;
@@ -761,7 +761,7 @@ TPZSFMatrix<TVar> ::Subst_LBackward( TPZFMatrix<TVar>  *B ) const
 	if ( (B->Rows() != this->Dim()) || !this->fDecomposed )
 		return( 0 );
 	
-	if ( B->IsSimetric() )
+	if ( B->IsSymmetric() )
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__, "Subst_LBackward <the matrix result can not be simetric>" );
 	
 	TVar *ptr_k = &fElem[ Size()-1 ];

--- a/Matrix/pzsfulmat.cpp
+++ b/Matrix/pzsfulmat.cpp
@@ -276,20 +276,19 @@ TPZSFMatrix<TVar> ::operator=(const TPZMatrix<TVar>  &A )
 /*** Operator + ***/
 
 template<class TVar>
-TPZSFMatrix<TVar> 
+TPZSFMatrix<TVar>
 TPZSFMatrix<TVar> ::operator+(const TPZMatrix<TVar>  &A ) const
 {
 	if ( this->Dim() != A.Dim() )
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__,"Operator+ <matrixs with incoompatible dimensions" );
 	
-	TPZSFMatrix<TVar>  res( this->Dim() );
-	TVar *pm = fElem;
+	auto  res(*this);
 	TVar *pr = res.fElem;
 	for ( int64_t c = 0; c < this->Dim(); c++ )
 		for ( int64_t r = 0; r <= c; r++ )
-			*pr++ = (*pm++) + A.Get( r, c );
+			*pr++ += A.Get( r, c );
 	
-	return( *this );
+	return res;
 }
 
 
@@ -298,20 +297,19 @@ TPZSFMatrix<TVar> ::operator+(const TPZMatrix<TVar>  &A ) const
 /*** Operator - ***/
 
 template<class TVar>
-TPZSFMatrix<TVar> 
+TPZSFMatrix<TVar>
 TPZSFMatrix<TVar> ::operator-( const TPZMatrix<TVar>  &A ) const
 {
 	if ( this->Dim() != A.Dim() )
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__,"Operator- <matrixs with incoompatible dimensions" );
 	
-	TPZSFMatrix<TVar>  res( this->Dim() );
-	TVar *pm = fElem;
+	auto res(*this);
 	TVar *pr = res.fElem;
 	for ( int64_t c = 0; c < this->Dim(); c++ )
 		for ( int64_t r = 0; r <= c; r++ )
-			*pr++ = (*pm++) - A.Get( r, c );
+			*pr++ -= A.Get( r, c );
 	
-	return( *this );
+	return res;
 }
 
 
@@ -401,18 +399,17 @@ TPZSFMatrix<TVar> ::operator+(const TVar value ) const
 /*** Operator*( value ) ***/
 
 template<class TVar>
-TPZSFMatrix<TVar> 
+TPZSFMatrix<TVar>
 TPZSFMatrix<TVar> ::operator*(const TVar value ) const
 {
-	TPZSFMatrix<TVar>  res( this->Dim() );
+	auto  res(*this);
 	
 	TVar *dst = res.fElem;
-	TVar *src = fElem;
-	TVar *end = &fElem[ Size() ];
-	while ( src < end )
-		*dst++ = (*src++) * value;
+	TVar *end = dst+Size();
+	while ( dst < end )
+		*dst++ *= value;
 	
-	return( res );
+	return res;
 }
 
 

--- a/Matrix/pzsfulmat.cpp
+++ b/Matrix/pzsfulmat.cpp
@@ -55,6 +55,14 @@ TPZMatrix<TVar> ( A.Dim(), A.Dim() )
 		*dst++ = *src++;
 }
 
+/*** Constructor( TPZSFMatrix& ) ***/
+template<class TVar>
+TPZSFMatrix<TVar> ::TPZSFMatrix (TPZSFMatrix<TVar>  && A)
+: TPZRegisterClassId(&TPZSFMatrix::ClassId),
+	TPZMatrix<TVar> (A),fElem(A.fElem)
+{
+	A.fElem=nullptr;
+}
 
 
 /*******************************/
@@ -91,12 +99,6 @@ TPZSFMatrix<TVar> ::~TPZSFMatrix ()
 }
 
 
-
-/******** Operacoes com matrizes FULL simetricas ********/
-
-/******************/
-/*** Operator = ***/
-
 template<class TVar>
 TPZSFMatrix<TVar> &
 TPZSFMatrix<TVar> ::operator=(const TPZSFMatrix<TVar>  &A )
@@ -126,6 +128,19 @@ TPZSFMatrix<TVar> ::operator=(const TPZSFMatrix<TVar>  &A )
 	
 	return *this;
 }
+
+template<class TVar>
+TPZSFMatrix<TVar> &
+TPZSFMatrix<TVar> ::operator=(TPZSFMatrix<TVar>  &&A )
+{
+	fElem=A.fElem;
+	A.fElem=nullptr;
+	return *this;
+}
+/******** Operacoes com matrizes FULL simetricas ********/
+
+/******************/
+
 
 
 

--- a/Matrix/pzsfulmat.h
+++ b/Matrix/pzsfulmat.h
@@ -135,13 +135,20 @@ public:
 	virtual int DerivedFrom(const char *classname) const;
 	
 #endif
-    public:
-int ClassId() const override;
 
+  int ClassId() const override;
+protected:
+  inline TVar *&Elem() override
+  {
+    return fElem;
+  }
+  inline const TVar *Elem() const override
+  {
+    return fElem;
+  }
+	
+	int64_t Size() const override { return (this->Dim() * (this->Dim()+1)) >> 1; }
 private:
-	
-	int64_t Size() const { return (this->Dim() * (this->Dim()+1)) >> 1; }
-	
 	int Clear() override;
 	
 	TVar   *fElem;

--- a/Matrix/pzsfulmat.h
+++ b/Matrix/pzsfulmat.h
@@ -37,7 +37,7 @@ public:
 	~TPZSFMatrix();
 	
     /** @brief Checks if the current matrix is symmetric */
-    virtual int IsSimetric() const  override {
+    virtual int IsSymmetric() const  override {
         return 1;
     }
 

--- a/Matrix/pzsfulmat.h
+++ b/Matrix/pzsfulmat.h
@@ -28,10 +28,12 @@ public:
     TPZMatrix<TVar>( 0,0 )  { fElem = NULL; }
 	TPZSFMatrix (const int64_t dim );
 	TPZSFMatrix (const TPZSFMatrix<TVar> & );
+  TPZSFMatrix (TPZSFMatrix<TVar> && );
 	// Usa o maior bloco quadrado possivel, comecado em (0,0).
 	// E inicializa com a parte triangular inferior do bloco.
 	TPZSFMatrix (const TPZMatrix<TVar> & );
-	
+	TPZSFMatrix &operator= (const TPZSFMatrix<TVar> &A );
+  TPZSFMatrix &operator= (TPZSFMatrix<TVar> &&A );
 	CLONEDEF(TPZSFMatrix)
 	
 	~TPZSFMatrix();
@@ -64,7 +66,6 @@ public:
 	 * @name Operators with Full simmetric matrices.
 	 * @{
 	 */
-	TPZSFMatrix &operator= (const TPZSFMatrix<TVar> &A );
 	TPZSFMatrix operator+  (const TPZSFMatrix<TVar> &A ) const;
 	TPZSFMatrix operator-  (const TPZSFMatrix<TVar> &A ) const;
 	TPZSFMatrix &operator+=(const TPZSFMatrix<TVar> &A );

--- a/Matrix/pzsfulmat.h
+++ b/Matrix/pzsfulmat.h
@@ -58,7 +58,22 @@ public:
         }
     }
     
-
+  /** @brief Creates a copy from another TPZSFMatrix*/
+  void CopyFrom(const TPZMatrix<TVar> *  mat) override
+  {                                                           
+    auto *from = dynamic_cast<const TPZSFMatrix<TVar> *>(mat);                
+    if (from) {                                               
+      *this = *from;                                          
+    }                                                         
+    else                                                      
+      {                                                       
+        PZError<<__PRETTY_FUNCTION__;                         
+        PZError<<"\nERROR: Called with incompatible type\n."; 
+        PZError<<"Aborting...\n";                             
+        DebugStop();                                          
+      }                                                       
+  }
+  
 	int PutVal(const int64_t row,const int64_t col,const TVar &value ) override;
 	const TVar GetVal(const int64_t row,const int64_t col ) const override;
 	

--- a/Matrix/pzsfulmat.h
+++ b/Matrix/pzsfulmat.h
@@ -108,7 +108,7 @@ public:
 	TPZSFMatrix operator*  (const TVar val ) const;
 	TPZSFMatrix &operator+=(const TVar val );
 	TPZSFMatrix &operator-=(const TVar val )  { return operator+=( -val ); }
-	TPZSFMatrix &operator*=(const TVar val );
+	TPZSFMatrix &operator*=(const TVar val ) override;
 	/** @} */
 	
 	TPZSFMatrix operator-() const  { return operator*( -1.0 ); }

--- a/Matrix/pzsfulmat.h
+++ b/Matrix/pzsfulmat.h
@@ -153,6 +153,18 @@ public:
 
   int ClassId() const override;
 protected:
+  /** @brief Checks compatibility of matrices before Add/Subtract operations*/
+  inline void CheckTypeCompatibility(const TPZMatrix<TVar>*A,
+                                     const TPZMatrix<TVar>*B)const override
+  {
+    auto aPtr = dynamic_cast<const TPZSFMatrix<TVar>*>(A);
+    auto bPtr = dynamic_cast<const TPZSFMatrix<TVar>*>(B);
+    if(!aPtr || !bPtr){
+      PZError<<__PRETTY_FUNCTION__;
+      PZError<<"\nERROR: incompatible matrices.Aborting...\n";
+      DebugStop();
+    }
+  }
   inline TVar *&Elem() override
   {
     return fElem;

--- a/Matrix/pzsfulmat.h
+++ b/Matrix/pzsfulmat.h
@@ -34,6 +34,7 @@ public:
 	TPZSFMatrix (const TPZMatrix<TVar> & );
 	TPZSFMatrix &operator= (const TPZSFMatrix<TVar> &A );
   TPZSFMatrix &operator= (TPZSFMatrix<TVar> &&A );
+  inline TPZSFMatrix<TVar>*NewMatrix() const override {return new TPZSFMatrix<TVar>{};}
 	CLONEDEF(TPZSFMatrix)
 	
 	~TPZSFMatrix();

--- a/Matrix/pzsfulmat.h
+++ b/Matrix/pzsfulmat.h
@@ -48,10 +48,10 @@ public:
     
     /// copy the values from a matrix with a different precision
     template<class TVar2>
-    void CopyFrom(TPZSFMatrix<TVar2> &orig)
+    void CopyFromDiffPrecision(TPZSFMatrix<TVar2> &orig)
     {
         Resize(orig.Rows(), orig.Cols());
-        TPZMatrix<TVar>::CopyFrom(orig);
+        TPZMatrix<TVar>::CopyFromDiffPrecision(orig);
         int64_t nel = (this->Rows()*(this->Rows()+1))/2;
         for (int64_t el=0; el<nel; el++) {
             fElem[el] = orig.fElem[el];

--- a/Matrix/pzskylmat.cpp
+++ b/Matrix/pzskylmat.cpp
@@ -516,49 +516,14 @@ template<class TVar>
 TPZSkylMatrix<TVar>
 TPZSkylMatrix<TVar>::operator+(const TPZSkylMatrix<TVar> &A) const
 {
+  
 	if ( this->Dim() != A.Dim() )
 		TPZMatrix<TVar>::Error(__PRETTY_FUNCTION__,"<incompatible dimensions>" );
-	
-	TPZVec<int64_t> skylinesize(this->Dim());
-	ComputeMaxSkyline(*this,A,skylinesize);
-	TPZSkylMatrix res( this->fRow, skylinesize );
-	
-	TVar *elemMax;
-	TVar *elemMin;
-	int64_t  sizeMax;
-	int64_t  sizeMin;
-	
-	for ( int64_t col = 0; col < this->Dim(); col++ )
-    {
-		// Define o tamanho e os elementos da maior e da menor
-		//  coluna.
-		if ( Size(col) > A.Size(col) )
-		{
-			sizeMax = Size(col);
-			elemMax = fElem[col];
-			sizeMin = A.Size(col);
-			elemMin = A.fElem[col];
-		}
-		else
-		{
-			sizeMax = A.Size(col);
-			elemMax = A.fElem[col];
-			sizeMin = Size(col);
-			elemMin = fElem[col];
-		}
-		
-		// Inicializa coluna da matriz resultado.
-		
-		// Efetua a SOMA.
-		TVar *dest = res.fElem[col];
-		int64_t i;
-		for ( i = 0; i < sizeMin; i++ )
-			*dest++ = (*elemMax++) + (*elemMin++);
-		for ( ; i < sizeMax; i++ )
-			*dest++ = *elemMax++;
-    }
-	
-	return( res );
+  CheckTypeCompatibility(this,&A);
+	auto res(*this);
+  const auto size = res.fStorage.size();
+  for(auto i = 0; i < size; i++) res.fStorage[i] += A.fStorage[i];
+	return res;
 }
 
 /******************/
@@ -568,32 +533,13 @@ template<class TVar>
 TPZSkylMatrix<TVar>
 TPZSkylMatrix<TVar>::operator-(const TPZSkylMatrix<TVar> &A ) const
 {
-	if ( this->Dim() != A.Dim() )
-		TPZMatrix<TVar>::Error(__PRETTY_FUNCTION__, "operator-( TPZSkylMatrix ) <incompatible dimensions>" );
-	
-	TPZVec<int64_t> skylinesize(this->Dim());
-	ComputeMaxSkyline(*this,A,skylinesize);
-	TPZSkylMatrix<TVar> res( this->fRow, skylinesize );
-	
-	for ( int64_t col = 0; col < this->fRow; col++ )
-    {
-		// Define o tamanho e os elementos das colunas das 2 matrizes.
-		int64_t  sizeThis  = Size(col);
-		TVar *elemThis = fElem[col];
-		int64_t  sizeA     = A.Size(col);
-		TVar *elemA    = A.fElem[col];
-		
-		// Inicializa coluna da matriz resultado.
-		
-		// Efetua a SUBTRACAO.
-		TVar *dest = res.fElem[col];
-		int64_t i;
-		for ( i = 0; (i < sizeThis) && (i < sizeA); i++ ) *dest++ = (*elemThis++) - (*elemA++);
-		if ( i == sizeA ) for ( ; i < sizeThis; i++ ) *dest++ = *elemThis++;
-		else for ( ; i < sizeA; i++ ) *dest++ = -(*elemA++);
-    }
-	
-	return( res );
+  if ( this->Dim() != A.Dim() )
+		TPZMatrix<TVar>::Error(__PRETTY_FUNCTION__,"<incompatible dimensions>" );
+  CheckTypeCompatibility(this,&A);
+	auto res(*this);
+  const auto size = res.fStorage.size();
+  for(auto i = 0; i < size; i++) res.fStorage[i] -= A.fStorage[i];
+	return res;
 }
 
 template<class TVar>
@@ -725,13 +671,13 @@ void TPZSkylMatrix<float>::AddKel(TPZFMatrix<float>&elmat,
 
 template<class TVar>
 TPZSkylMatrix<TVar> &
-TPZSkylMatrix<TVar>::operator+=(const TPZSkylMatrix<TVar> &A )
+TPZSkylMatrix<TVar>::operator+=(const TPZSkylMatrix<TVar> &A)
 {
+  
 	if ( this->Dim() != A.Dim() )
 		TPZMatrix<TVar>::Error(__PRETTY_FUNCTION__,"operator+=( TPZSkylMatrix ) <incompatible dimensions>" );
-	
-	TPZSkylMatrix res((*this)+A);
-	*this = res;
+
+	*this = *this + A;
 	return *this;
 }
 
@@ -742,11 +688,10 @@ template<class TVar>
 TPZSkylMatrix<TVar> &
 TPZSkylMatrix<TVar>::operator-=(const TPZSkylMatrix<TVar> &A )
 {
-	if ( this->Dim() != A.Dim() )
-		TPZMatrix<TVar>::Error(__PRETTY_FUNCTION__,"operator-=( TPZSkylMatrix ) <incompatible dimensions>" );
-	
-	TPZSkylMatrix res(*this-A);
-	*this = res;
+  if ( this->Dim() != A.Dim() )
+		TPZMatrix<TVar>::Error(__PRETTY_FUNCTION__,"operator+=( TPZSkylMatrix ) <incompatible dimensions>" );
+
+	*this = *this - A;
 	return *this;
 }
 
@@ -767,7 +712,7 @@ template<class TVar>
 TPZSkylMatrix<TVar>
 TPZSkylMatrix<TVar>::operator*(const TVar value ) const
 {
-	TPZSkylMatrix res( *this );
+	auto res(*this);
 	
 	for ( int64_t col = 0; col < this->Dim(); col++ )
     {
@@ -779,7 +724,7 @@ TPZSkylMatrix<TVar>::operator*(const TVar value ) const
 			*elemRes++ *= value;
     }
 	
-	return( res );
+	return res;
 }
 
 

--- a/Matrix/pzskylmat.cpp
+++ b/Matrix/pzskylmat.cpp
@@ -77,6 +77,29 @@ void TPZSkylMatrix<TVar>::AddSameStruct(TPZSkylMatrix<TVar> &B, double k){
 	
 }
 
+template<class TVar>
+void TPZSkylMatrix<TVar>::CheckTypeCompatibility(const TPZMatrix<TVar>*A,
+                                                 const TPZMatrix<TVar>*B)const
+{
+  auto incompatSkyline = [](){
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR: incompatible matrices\n.Aborting...\n";
+    DebugStop();
+  };
+  auto aPtr = dynamic_cast<const TPZSkylMatrix<TVar>*>(A);
+  auto bPtr = dynamic_cast<const TPZSkylMatrix<TVar>*>(B);
+  if(!aPtr || !bPtr){
+    incompatSkyline();
+  }
+
+  bool check{false};
+  auto ncols = aPtr->Cols();
+  for(auto i = 0; i < ncols; i++){
+    check = check || aPtr->Size(i) != bPtr->Size(i);
+  }
+  if(check) incompatSkyline();
+}
+
 /**
  * @brief Updates the values of the matrix based on the values of the matrix
  */

--- a/Matrix/pzskylmat.h
+++ b/Matrix/pzskylmat.h
@@ -39,7 +39,13 @@ public:
 	 */
 	TPZSkylMatrix(const int64_t dim ,const TPZVec<int64_t> &skyline);
 	TPZSkylMatrix(const TPZSkylMatrix<TVar> &A ) : TPZRegisterClassId(&TPZSkylMatrix::ClassId),TPZMatrix<TVar>(A), fElem(0), fStorage(0)  { Copy(A); }
-	
+
+  TPZSkylMatrix(TPZSkylMatrix<TVar> &&A) = default;
+  TPZSkylMatrix &operator= (const TPZSkylMatrix<TVar> &A );
+  TPZSkylMatrix &operator= (TPZSkylMatrix<TVar> &&A ) = default;
+    /** @brief destructor of the skyline matrix */
+	virtual ~TPZSkylMatrix() { Clear(); }
+  
 	CLONEDEF(TPZSkylMatrix)
     
 	virtual int64_t MemoryFootprint() const  override {
@@ -65,9 +71,6 @@ public:
 	
 	/** @brief declare the object as simetric matrix*/
 	virtual int IsSymmetric() const  override {return 1;}
-	
-    /** @brief destructor of the skyline matrix */
-	virtual ~TPZSkylMatrix() { Clear(); }
     
     /**
 	 * @brief Updates the values of the matrix based on the values of the matrix
@@ -111,7 +114,6 @@ public:
 	virtual void MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> &y, TPZFMatrix<TVar> &z,
 						 const TVar alpha,const TVar beta ,const int opt = 0) const  override;
 	// Operadores com matrizes SKY LINE.
-	TPZSkylMatrix &operator= (const TPZSkylMatrix<TVar> &A );
 	//TPZSkylMatrix &operator= (TTempMat<TPZSkylMatrix> A);
 	
 	TPZSkylMatrix operator+  (const TPZSkylMatrix<TVar> &A ) const;

--- a/Matrix/pzskylmat.h
+++ b/Matrix/pzskylmat.h
@@ -125,7 +125,7 @@ public:
 	
 	
 	TVar &operator()(const int64_t row);
-	
+
 	virtual void MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> &y, TPZFMatrix<TVar> &z,
 						 const TVar alpha,const TVar beta ,const int opt = 0) const  override;
 	// Operadores com matrizes SKY LINE.

--- a/Matrix/pzskylmat.h
+++ b/Matrix/pzskylmat.h
@@ -224,6 +224,8 @@ int ClassId() const override;
     }
     
 protected:
+  void CheckTypeCompatibility(const TPZMatrix<TVar>*A,
+                              const TPZMatrix<TVar>*B)const override;
 	inline TVar *&Elem() override
   {
     return fStorage.begin();

--- a/Matrix/pzskylmat.h
+++ b/Matrix/pzskylmat.h
@@ -45,7 +45,8 @@ public:
   TPZSkylMatrix &operator= (TPZSkylMatrix<TVar> &&A ) = default;
     /** @brief destructor of the skyline matrix */
 	virtual ~TPZSkylMatrix() { Clear(); }
-  
+
+  inline TPZSkylMatrix<TVar>*NewMatrix() const override {return new TPZSkylMatrix<TVar>{};}
 	CLONEDEF(TPZSkylMatrix)
     
 	virtual int64_t MemoryFootprint() const  override {

--- a/Matrix/pzskylmat.h
+++ b/Matrix/pzskylmat.h
@@ -139,7 +139,7 @@ public:
 	
 	// Operadores com valores NUMERICOS.
 	TPZSkylMatrix operator*  (const TVar v ) const;
-	TPZSkylMatrix &operator*=( TVar value );
+	TPZSkylMatrix &operator*=( TVar value ) override;
 	
 	TPZSkylMatrix operator-() const;// { return operator*(-1.0); }
 	

--- a/Matrix/pzskylmat.h
+++ b/Matrix/pzskylmat.h
@@ -64,7 +64,7 @@ public:
 	void AddSameStruct(TPZSkylMatrix<TVar> &B, double k = 1.);
 	
 	/** @brief declare the object as simetric matrix*/
-	virtual int IsSimetric() const  override {return 1;}
+	virtual int IsSymmetric() const  override {return 1;}
 	
     /** @brief destructor of the skyline matrix */
 	virtual ~TPZSkylMatrix() { Clear(); }

--- a/Matrix/pzskylmat.h
+++ b/Matrix/pzskylmat.h
@@ -82,9 +82,9 @@ public:
     
     /// copy the values from a matrix with a different precision
     template<class TVar2>
-    void CopyFrom(TPZSkylMatrix<TVar2> &orig)
+    void CopyFromDiffPrecision(TPZSkylMatrix<TVar2> &orig)
     {
-        TPZMatrix<TVar>::CopyFrom(orig);
+        TPZMatrix<TVar>::CopyFromDiffPrecision(orig);
         int64_t nel = orig.fStorage.size();
         fElem.resize(orig.fElem.size());
         fStorage.resize(nel);

--- a/Matrix/pzskylmat.h
+++ b/Matrix/pzskylmat.h
@@ -209,7 +209,18 @@ int ClassId() const override;
     }
     
 protected:
-	
+	inline TVar *&Elem() override
+  {
+    return fStorage.begin();
+  }
+  inline const TVar *Elem() const override
+  {
+    return fStorage.begin();
+  }
+  inline int64_t Size() const override
+  {
+    return fStorage.size();
+  }
 	/**
      @brief This method returns a pointer to the diagonal element of the matrix of the col column
 	 */

--- a/Matrix/pzskylmat.h
+++ b/Matrix/pzskylmat.h
@@ -77,30 +77,45 @@ public:
 	 */
 	virtual void UpdateFrom(TPZAutoPointer<TPZMatrix<TVar> > mat) override;
     
-    friend class TPZSkylMatrix<float>;
-    friend class TPZSkylMatrix<double>;
+  friend class TPZSkylMatrix<float>;
+  friend class TPZSkylMatrix<double>;
     
-    /// copy the values from a matrix with a different precision
-    template<class TVar2>
-    void CopyFromDiffPrecision(TPZSkylMatrix<TVar2> &orig)
-    {
-        TPZMatrix<TVar>::CopyFromDiffPrecision(orig);
-        int64_t nel = orig.fStorage.size();
-        fElem.resize(orig.fElem.size());
-        fStorage.resize(nel);
-        for (int64_t el=0; el<nel; el++) {
-            fStorage[el] = orig.fStorage[el];
-        }
-        int64_t size_el = fElem.size();
-        TVar *first = &fStorage[0];
-        TVar2 *first_orig = &orig.fStorage[0];
-        for (int64_t el=0; el<size_el; el++) {
-            fElem[el] = first+(orig.fElem[el]-first_orig);
-        }
-        
+  /// copy the values from a matrix with a different precision
+  template<class TVar2>
+  void CopyFromDiffPrecision(TPZSkylMatrix<TVar2> &orig)
+  {
+    TPZMatrix<TVar>::CopyFromDiffPrecision(orig);
+    int64_t nel = orig.fStorage.size();
+    fElem.resize(orig.fElem.size());
+    fStorage.resize(nel);
+    for (int64_t el=0; el<nel; el++) {
+      fStorage[el] = orig.fStorage[el];
     }
-    
-    
+    int64_t size_el = fElem.size();
+    TVar *first = &fStorage[0];
+    TVar2 *first_orig = &orig.fStorage[0];
+    for (int64_t el=0; el<size_el; el++) {
+      fElem[el] = first+(orig.fElem[el]-first_orig);
+    }
+        
+  }
+  
+  /** @brief Creates a copy from another TPZSkylMatrix*/
+  void CopyFrom(const TPZMatrix<TVar> *  mat) override
+  {                                                           
+    auto *from = dynamic_cast<const TPZSkylMatrix<TVar> *>(mat);                
+    if (from) {                                               
+      *this = *from;                                          
+    }                                                         
+    else                                                      
+      {                                                       
+        PZError<<__PRETTY_FUNCTION__;                         
+        PZError<<"\nERROR: Called with incompatible type\n."; 
+        PZError<<"Aborting...\n";                             
+        DebugStop();                                          
+      }                                                       
+  }
+  
 	int    PutVal(const int64_t row,const int64_t col,const TVar &element ) override;
 	const TVar GetVal(const int64_t row,const int64_t col ) const override;
 	

--- a/Matrix/pzskylnsymmat.cpp
+++ b/Matrix/pzskylnsymmat.cpp
@@ -164,7 +164,7 @@ Computes the highest skyline of both objects
  */
 template <class TVar>
 void TPZSkylNSymMatrix<TVar>::ComputeMaxSkyline(const TPZSkylNSymMatrix &first,
-  const TPZSkylNSymMatrix &second, TPZVec<int> &res)
+  const TPZSkylNSymMatrix &second, TPZVec<int64_t> &res)
 {
 
   if (first.Rows() != second.Rows())
@@ -576,149 +576,166 @@ const TVar & TPZSkylNSymMatrix<TVar>::GetValB(const int64_t r, const int64_t c)c
 /** ****** Operacoes com matrizes SKY LINE  ******* */
 
 /** *************** */
-/** * Operator = ** */
 
-/*
 
-TPZSkylMatrix & TPZSkylMatrix:: operator = (const TPZSkylMatrix & A)
-{
-Clear();
-Copy(A);
-return(*this);
-}
 
- */
 
 /** *************** */
 /** * Operator + ** */
 
-/*
-TPZSkylMatrix TPZSkylMatrix:: operator +(const TPZSkylMatrix & A)const
+template<class TVar>
+TPZSkylNSymMatrix<TVar>
+TPZSkylNSymMatrix<TVar>::operator+(const TPZSkylNSymMatrix<TVar> & A)const
 {
-if (Dim() != A.Dim())
-TPZMatrix::Error(__PRETTY_FUNCTION__, "<incompatible dimensions>");
+  const auto dim = this->Dim();
+  if (dim != A.Dim())
+    TPZMatrix<TVar>::Error(__PRETTY_FUNCTION__, "<incompatible dimensions>");
 
-TPZVec<int>skylinesize(Dim());
-ComputeMaxSkyline(*this, A, skylinesize);
-TPZSkylMatrix res(fRow, skylinesize);
+  TPZVec<int64_t> skylinesize(dim);
+  ComputeMaxSkyline(*this, A, skylinesize);
+  TPZSkylNSymMatrix<TVar> res(this->Rows(),this->Cols());
+  res.SetSkyline(skylinesize);
 
-REAL *elemMax;
-REAL *elemMin;
-int sizeMax;
-int sizeMin;
+  TVar *elemMaxA;
+  TVar *elemMinA;
+  TVar *elemMaxB;
+  TVar *elemMinB;
+  int sizeMax;
+  int sizeMin;
 
-for (int col = 0; col < Dim(); col++)
-{
-// Define o tamanho e os elementos da maior e da menor
-// coluna.
-if (Size(col) > A.Size(col))
-{
-sizeMax = Size(col);
-elemMax = fElem[col];
-sizeMin = A.Size(col);
-elemMin = A.fElem[col];
+  for (int col = 0; col < dim; col++)
+    {
+      // Define o tamanho e os elementos da maior e da menor
+      // coluna.
+      if (Size(col) > A.Size(col))
+        {
+          sizeMax = Size(col);
+          sizeMin = A.Size(col);
+          elemMaxA = fElem[col];
+          elemMinA = A.fElem[col];
+          elemMaxB = fElemb[col];
+          elemMinB = A.fElemb[col];
+        }
+      else
+        {
+          sizeMax = A.Size(col);
+          sizeMin = Size(col);
+          elemMaxA = A.fElem[col];
+          elemMinA = fElem[col];
+          elemMaxB = A.fElem[col];
+          elemMinB = fElem[col];
+        }
+
+      // Inicializa coluna da matriz resultado.
+
+      // Efetua a SOMA.
+      TVar *destA = res.fElem[col];
+      TVar *destB = res.fElemb[col];
+      int i;
+      for (i = 0; i < sizeMin; i++)
+        * destA++ = (*elemMaxA++) + (*elemMinA++);
+      for (; i < sizeMax; i++)
+        * destA++ = *elemMaxA++;
+      for (i = 0; i < sizeMin; i++)
+        * destB++ = (*elemMaxB++) + (*elemMinB++);
+      for (; i < sizeMax; i++)
+        * destB++ = *elemMaxB++;
+    }
+
+  return(res);
 }
-else
-{
-sizeMax = A.Size(col);
-elemMax = A.fElem[col];
-sizeMin = Size(col);
-elemMin = fElem[col];
-}
 
-// Inicializa coluna da matriz resultado.
-
-// Efetua a SOMA.
-REAL *dest = res.fElem[col];
-int i;
-for (i = 0; i < sizeMin; i++)
- * dest++ = (*elemMax++) + (*elemMin++);
-for (; i < sizeMax; i++)
- * dest++ = *elemMax++;
-}
-
-return(res);
-}
-
- */
 
 /** *************** */
 /** * Operator - ** */
-
-/*
-
-TPZSkylMatrix TPZSkylMatrix:: operator -(const TPZSkylMatrix & A)const
+template<class TVar>
+TPZSkylNSymMatrix<TVar>
+TPZSkylNSymMatrix<TVar>::operator-(const TPZSkylNSymMatrix<TVar> & A)const
 {
-if (Dim() != A.Dim())
-TPZMatrix::Error(__PRETTY_FUNCTION__,
-"operator-( TPZSkylMatrix ) <incompatible dimensions>");
+  const auto dim = this->Dim();
+  if (dim != A.Dim())
+    TPZMatrix<TVar>::Error(__PRETTY_FUNCTION__, "<incompatible dimensions>");
 
-TPZVec<int>skylinesize(Dim());
-ComputeMaxSkyline(*this, A, skylinesize);
-TPZSkylMatrix res(fRow, skylinesize);
+  TPZVec<int64_t> skylinesize(dim);
+  ComputeMaxSkyline(*this, A, skylinesize);
+  TPZSkylNSymMatrix<TVar> res(this->Rows(),this->Cols());
+  res.SetSkyline(skylinesize);
 
-for (int col = 0; col < fRow; col++)
-{
-// Define o tamanho e os elementos das colunas das 2 matrizes.
-int sizeThis = Size(col);
-REAL *elemThis = fElem[col];
-int sizeA = A.Size(col);
-REAL *elemA = A.fElem[col];
+  TVar *elemMaxA;
+  TVar *elemMinA;
+  TVar *elemMaxB;
+  TVar *elemMinB;
+  int sizeMax;
+  int sizeMin;
 
-// Inicializa coluna da matriz resultado.
+  for (int col = 0; col < dim; col++)
+    {
+      // Define o tamanho e os elementos da maior e da menor
+      // coluna.
+      if (Size(col) > A.Size(col))
+        {
+          sizeMax = Size(col);
+          sizeMin = A.Size(col);
+          elemMaxA = fElem[col];
+          elemMinA = A.fElem[col];
+          elemMaxB = fElemb[col];
+          elemMinB = A.fElemb[col];
+        }
+      else
+        {
+          sizeMax = A.Size(col);
+          sizeMin = Size(col);
+          elemMaxA = A.fElem[col];
+          elemMinA = fElem[col];
+          elemMaxB = A.fElem[col];
+          elemMinB = fElem[col];
+        }
 
-// Efetua a SUBTRACAO.
-REAL *dest = res.fElem[col];
-int i;
-for (i = 0; (i < sizeThis) && (i < sizeA); i++)
- * dest++ = (*elemThis++) - (*elemA++);
-if (i == sizeA)
-for (; i < sizeThis; i++)
- * dest++ = *elemThis++;
-else
-for (; i < sizeA; i++)
- * dest++ = -(*elemA++);
+      // Inicializa coluna da matriz resultado.
+
+      
+      TVar *destA = res.fElem[col];
+      TVar *destB = res.fElemb[col];
+      int i;
+      for (i = 0; i < sizeMin; i++)
+        * destA++ = (*elemMaxA++) - (*elemMinA++);
+      for (; i < sizeMax; i++)
+        * destA++ = -(*elemMaxA++);
+      for (i = 0; i < sizeMin; i++)
+        * destB++ = (*elemMaxB++) - (*elemMinB++);
+      for (; i < sizeMax; i++)
+        * destB++ = -(*elemMaxB++);
+    }
+  return(res);
 }
-
-return(res);
-}
-
- */
 
 /** **************** */
 /** * Operator += ** */
 
-/*
-TPZSkylMatrix & TPZSkylMatrix:: operator += (const TPZSkylMatrix & A)
+template<class TVar>
+TPZSkylNSymMatrix<TVar> &
+TPZSkylNSymMatrix<TVar>:: operator += (const TPZSkylNSymMatrix<TVar> & A)
 {
-if (Dim() != A.Dim())
-TPZMatrix::Error(__PRETTY_FUNCTION__,
-"operator+=( TPZSkylMatrix ) <incompatible dimensions>");
-
-TPZSkylMatrix res((*this) + A);
- *this = res;
-return *this;
+  TPZSkylNSymMatrix<TVar> res((*this) + A);
+  *this = res;
+  return *this;
 }
 
- */
+ 
 
 /** **************** */
 /** * Operator -= ** */
 
-/*
 
-TPZSkylMatrix & TPZSkylMatrix:: operator -= (const TPZSkylMatrix & A)
+template<class TVar>
+TPZSkylNSymMatrix<TVar> &
+TPZSkylNSymMatrix<TVar>:: operator -= (const TPZSkylNSymMatrix<TVar> & A)
 {
-if (Dim() != A.Dim())
-TPZMatrix::Error(__PRETTY_FUNCTION__,
-"operator-=( TPZSkylMatrix ) <incompatible dimensions>");
-
-TPZSkylMatrix res(*this -A);
- *this = res;
-return *this;
+  TPZSkylNSymMatrix<TVar> res(*this -A);
+  *this = res;
+  return *this;
 }
 
- */
 
 /** ****** Operacoes com valores NUMERICOS ******* */
 //
@@ -730,25 +747,27 @@ return *this;
 /** ************************** */
 /** * Operator * ( REAL ) ** */
 
-/*
-TPZSkylMatrix TPZSkylMatrix:: operator*(const REAL value)const
+template<class TVar>
+TPZSkylNSymMatrix<TVar> TPZSkylNSymMatrix<TVar>:: operator*(const TVar value)const
 {
-TPZSkylMatrix res(*this);
+  TPZSkylNSymMatrix<TVar> res(*this);
 
-for (int col = 0; col < Dim(); col++)
-{
-// Aloca nova coluna para o resultado.
-int colsize = Size(col);
-// Efetua a SOMA.
-REAL *elemRes = res.fElem[col];
-for (int i = 0; i < colsize; i++)
- * elemRes++ *= value;
+  for (int col = 0; col < this->Dim(); col++)
+    {
+      // Aloca nova coluna para o resultado.
+      int colsize = Size(col);
+      // Efetua a SOMA.
+      TVar *elemRes = res.fElem[col];
+      for (int i = 0; i < colsize; i++)
+        * elemRes++ *= value;
+      elemRes = res.fElemb[col];
+      for (int i = 0; i < colsize; i++)
+        * elemRes++ *= value;
+    }
+
+  return(res);
 }
 
-return(res);
-}
-
- */
 
 template<class TVar>
 TVar* &TPZSkylNSymMatrix<TVar>::Elem()
@@ -772,30 +791,29 @@ const TVar* TPZSkylNSymMatrix<TVar>::Elem()const
 /** *************************** */
 /** * Operator *= ( REAL ) ** */
 
-/*
-TPZSkylMatrix & TPZSkylMatrix:: operator *= (const REAL value)
+template<class TVar>
+TPZSkylNSymMatrix<TVar> & TPZSkylNSymMatrix<TVar>:: operator *= (const TVar value)
 {
-if (IsZero(value))
-{
-Zero();
-return(*this);
+  if (IsZero(value))
+    {
+      Zero();
+      return(*this);
+    }
+
+  int col, colmax = this->Dim();
+  for (col = 0; col < colmax; col++)
+    {
+      // Efetua a MULTIPLICACAO.
+      TVar *elem = fElem[col];
+      TVar *end = fElem[col + 1];
+      while (elem < end)
+        * elem++ *= value;
+    }
+
+  this->fDecomposed = 0;
+  return(*this);
 }
 
-int col, colmax = Dim();
-for (col = 0; col < colmax; col++)
-{
-// Efetua a MULTIPLICACAO.
-REAL *elem = fElem[col];
-REAL *end = fElem[col + 1];
-while (elem < end)
- * elem++ *= value;
-}
-
-fDecomposed = 0;
-return(*this);
-}
-
- */
 
 /** *********** */
 /** * Resize ** */

--- a/Matrix/pzskylnsymmat.cpp
+++ b/Matrix/pzskylnsymmat.cpp
@@ -593,7 +593,7 @@ TPZSkylNSymMatrix<TVar>::operator+(const TPZSkylNSymMatrix<TVar> & A)const
 
   TPZVec<int64_t> skylinesize(dim);
   ComputeMaxSkyline(*this, A, skylinesize);
-  TPZSkylNSymMatrix<TVar> res(this->Rows(),this->Cols());
+  TPZSkylNSymMatrix<TVar>res(this->Rows(),this->Cols());
   res.SetSkyline(skylinesize);
 
   TVar *elemMaxA;
@@ -642,7 +642,7 @@ TPZSkylNSymMatrix<TVar>::operator+(const TPZSkylNSymMatrix<TVar> & A)const
         * destB++ = *elemMaxB++;
     }
 
-  return(res);
+  return res;
 }
 
 
@@ -706,7 +706,7 @@ TPZSkylNSymMatrix<TVar>::operator-(const TPZSkylNSymMatrix<TVar> & A)const
       for (; i < sizeMax; i++)
         * destB++ = -(*elemMaxB++);
     }
-  return(res);
+  return res;
 }
 
 /** **************** */
@@ -731,7 +731,7 @@ template<class TVar>
 TPZSkylNSymMatrix<TVar> &
 TPZSkylNSymMatrix<TVar>:: operator -= (const TPZSkylNSymMatrix<TVar> & A)
 {
-  TPZSkylNSymMatrix<TVar> res(*this -A);
+  TPZSkylNSymMatrix<TVar> res((*this) - A);
   *this = res;
   return *this;
 }
@@ -750,7 +750,7 @@ TPZSkylNSymMatrix<TVar>:: operator -= (const TPZSkylNSymMatrix<TVar> & A)
 template<class TVar>
 TPZSkylNSymMatrix<TVar> TPZSkylNSymMatrix<TVar>:: operator*(const TVar value)const
 {
-  TPZSkylNSymMatrix<TVar> res(*this);
+  auto res(*this);
 
   for (int col = 0; col < this->Dim(); col++)
     {
@@ -765,7 +765,7 @@ TPZSkylNSymMatrix<TVar> TPZSkylNSymMatrix<TVar>:: operator*(const TVar value)con
         * elemRes++ *= value;
     }
 
-  return(res);
+  return res;
 }
 
 

--- a/Matrix/pzskylnsymmat.cpp
+++ b/Matrix/pzskylnsymmat.cpp
@@ -750,6 +750,25 @@ return(res);
 
  */
 
+template<class TVar>
+TVar* &TPZSkylNSymMatrix<TVar>::Elem()
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"ERROR:Not implemented\n.Aborting...\n";
+  DebugStop();
+  static TVar* t{nullptr};
+  return t;
+}
+
+template<class TVar>
+const TVar* TPZSkylNSymMatrix<TVar>::Elem()const
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"ERROR:Not implemented\n.Aborting...\n";
+  DebugStop();
+  return nullptr;
+}
+
 /** *************************** */
 /** * Operator *= ( REAL ) ** */
 

--- a/Matrix/pzskylnsymmat.cpp
+++ b/Matrix/pzskylnsymmat.cpp
@@ -77,6 +77,15 @@ TPZMatrix<TVar>(dim, dim), fElem(dim + 1), fElemb(dim + 1), fStorage(0), fStorag
   InitializeElem(skyline, fStorageb, fElemb);
 }
 
+template<class TVar>
+TPZSkylNSymMatrix<TVar> &
+TPZSkylNSymMatrix<TVar>::operator=(const TPZSkylNSymMatrix<TVar> &A )
+{
+	Clear();
+	Copy( A );
+	return( *this );
+}
+
 /* IMPLEMENTAR
 void TPZSkylNSymMatrix::AddSameStruct(TPZSkylMatrix &B, double k)
 {

--- a/Matrix/pzskylnsymmat.h
+++ b/Matrix/pzskylnsymmat.h
@@ -202,6 +202,13 @@ int ClassId() const override;
 
 
 protected:
+  TVar *&Elem() override;
+  const TVar *Elem() const override;
+  
+  inline int64_t Size() const override
+  {
+    return fStorage.size();
+  }
   /**
      fElem is of size number of equation+1
      fElem[i] is the first element of the skyline of equation i

--- a/Matrix/pzskylnsymmat.h
+++ b/Matrix/pzskylnsymmat.h
@@ -67,7 +67,7 @@ class TPZSkylNSymMatrix : public TPZMatrix<TVar>
   //void AddSameStruct(TPZSkylNSymMatrix &B, double k = 1.);
 
   /**declare the object as non-symmetric matrix*/
-  virtual int IsSimetric() const  override {return 0;}
+  virtual int IsSymmetric() const  override {return 0;}
 
   virtual ~TPZSkylNSymMatrix() { Clear(); }
 

--- a/Matrix/pzskylnsymmat.h
+++ b/Matrix/pzskylnsymmat.h
@@ -115,15 +115,15 @@ class TPZSkylNSymMatrix : public TPZMatrix<TVar>
 
   // Operadores com matrizes SKY LINE.
 
-  TPZSkylNSymMatrix operator+(const TPZSkylNSymMatrix &A ) const;
-  TPZSkylNSymMatrix operator-(const TPZSkylNSymMatrix &A ) const;
+  TPZSkylNSymMatrix operator+(const TPZSkylNSymMatrix<TVar> &A ) const;
+  TPZSkylNSymMatrix operator-(const TPZSkylNSymMatrix<TVar> &A ) const;
 
-  TPZSkylNSymMatrix &operator+=(const TPZSkylNSymMatrix &A );
-  TPZSkylNSymMatrix &operator-=(const TPZSkylNSymMatrix &A );
+  TPZSkylNSymMatrix &operator+=(const TPZSkylNSymMatrix<TVar> &A );
+  TPZSkylNSymMatrix &operator-=(const TPZSkylNSymMatrix<TVar> &A );
 
   // Operadores com valores NUMERICOS.
   TPZSkylNSymMatrix operator*(const TVar v ) const;
-  TPZSkylNSymMatrix &operator*=( TVar v );
+  TPZSkylNSymMatrix &operator*=( TVar v ) override;
 
   //TPZSkylNSymMatrix operator-() const;// { return operator*(-1.0); }
 

--- a/Matrix/pzskylnsymmat.h
+++ b/Matrix/pzskylnsymmat.h
@@ -49,6 +49,10 @@ class TPZSkylNSymMatrix : public TPZMatrix<TVar>
         Copy(A); 
     }
   TPZSkylNSymMatrix(TPZSkylNSymMatrix &&A ) = default;
+  inline TPZSkylNSymMatrix<TVar>*NewMatrix() const override
+  {
+    return new TPZSkylNSymMatrix<TVar>{};
+  }
   CLONEDEF(TPZSkylNSymMatrix)
   TPZSkylNSymMatrix& operator=(const TPZSkylNSymMatrix&A);
   TPZSkylNSymMatrix& operator=(TPZSkylNSymMatrix&&A) = default;

--- a/Matrix/pzskylnsymmat.h
+++ b/Matrix/pzskylnsymmat.h
@@ -48,8 +48,11 @@ class TPZSkylNSymMatrix : public TPZMatrix<TVar>
     { 
         Copy(A); 
     }
-
+  TPZSkylNSymMatrix(TPZSkylNSymMatrix &&A ) = default;
   CLONEDEF(TPZSkylNSymMatrix)
+  TPZSkylNSymMatrix& operator=(const TPZSkylNSymMatrix&A);
+  TPZSkylNSymMatrix& operator=(TPZSkylNSymMatrix&&A) = default;
+  virtual ~TPZSkylNSymMatrix() { Clear(); }
   /**
      modify the skyline of the matrix, throwing away its values
      skyline indicates the minimum row number which will be accessed by each equation
@@ -68,8 +71,6 @@ class TPZSkylNSymMatrix : public TPZMatrix<TVar>
 
   /**declare the object as non-symmetric matrix*/
   virtual int IsSymmetric() const  override {return 0;}
-
-  virtual ~TPZSkylNSymMatrix() { Clear(); }
 
   int PutVal(const int64_t row,const int64_t col,const TVar &element ) override;
 

--- a/Matrix/pzskylnsymmat.h
+++ b/Matrix/pzskylnsymmat.h
@@ -53,6 +53,22 @@ class TPZSkylNSymMatrix : public TPZMatrix<TVar>
   TPZSkylNSymMatrix& operator=(const TPZSkylNSymMatrix&A);
   TPZSkylNSymMatrix& operator=(TPZSkylNSymMatrix&&A) = default;
   virtual ~TPZSkylNSymMatrix() { Clear(); }
+
+  /** @brief Creates a copy from another TPZSkylNSymMatrix*/
+  void CopyFrom(const TPZMatrix<TVar> *  mat) override
+  {                                                           
+    auto *from = dynamic_cast<const TPZSkylNSymMatrix<TVar> *>(mat);                
+    if (from) {                                               
+      *this = *from;                                          
+    }                                                         
+    else                                                      
+      {                                                       
+        PZError<<__PRETTY_FUNCTION__;                         
+        PZError<<"\nERROR: Called with incompatible type\n."; 
+        PZError<<"Aborting...\n";                             
+        DebugStop();                                          
+      }                                                       
+  }
   /**
      modify the skyline of the matrix, throwing away its values
      skyline indicates the minimum row number which will be accessed by each equation

--- a/Matrix/pzskylnsymmat.h
+++ b/Matrix/pzskylnsymmat.h
@@ -114,18 +114,16 @@ class TPZSkylNSymMatrix : public TPZMatrix<TVar>
     virtual void UpdateFrom(TPZAutoPointer<TPZMatrix<TVar> > mat) override;
 
   // Operadores com matrizes SKY LINE.
-  //TPZSkylNSymMatrix &operator= (const TPZSkylNSymMatrix &A );
-  //TPZSkylMatrix &operator= (TTempMat<TPZSkylMatrix> A);
 
-  //TPZSkylNSymMatrix operator+  (const TPZSkylNSymMatrix &A ) const;
-  //TPZSkylNSymMatrix operator-  (const TPZSkylNSymMatrix &A ) const;
+  TPZSkylNSymMatrix operator+(const TPZSkylNSymMatrix &A ) const;
+  TPZSkylNSymMatrix operator-(const TPZSkylNSymMatrix &A ) const;
 
-  //TPZSkylNSymMatrix &operator+=(const TPZSkylNSymMatrix &A );
-  //TPZSkylNSymMatrix &operator-=(const TPZSkylNSymMatrix &A );
+  TPZSkylNSymMatrix &operator+=(const TPZSkylNSymMatrix &A );
+  TPZSkylNSymMatrix &operator-=(const TPZSkylNSymMatrix &A );
 
   // Operadores com valores NUMERICOS.
-  //TPZSkylNSymMatrix operator*  (const REAL v ) const;
-  //TPZSkylNSymMatrix &operator*=( REAL v );
+  TPZSkylNSymMatrix operator*(const TVar v ) const;
+  TPZSkylNSymMatrix &operator*=( TVar v );
 
   //TPZSkylNSymMatrix operator-() const;// { return operator*(-1.0); }
 
@@ -207,7 +205,7 @@ int ClassId() const override;
   /**
      Computes the highest skyline of both objects
   */
-  static void ComputeMaxSkyline(const TPZSkylNSymMatrix &first, const TPZSkylNSymMatrix &second, TPZVec<int> &res);
+  static void ComputeMaxSkyline(const TPZSkylNSymMatrix &first, const TPZSkylNSymMatrix &second, TPZVec<int64_t> &res);
 	
 	/** @brief Zeroes the matrix */
 	virtual int Zero() override {

--- a/Matrix/pzsysmp.cpp
+++ b/Matrix/pzsysmp.cpp
@@ -136,14 +136,54 @@ void TPZSYsmpMatrix<TVar>::CheckTypeCompatibility(const TPZMatrix<TVar>*A,
 // Multiply and Multiply-Add
 //
 // ****************************************************************************
+template<class TVar>
+TPZSYsmpMatrix<TVar> TPZSYsmpMatrix<TVar>::operator+(const TPZSYsmpMatrix<TVar>&mat) const
+{
+  CheckTypeCompatibility(this,&mat);
+	auto res(*this);
+  const auto sizeA = res.fA.size();
+  for(auto i = 0; i < sizeA; i++) res.fA[i] += mat.fA[i];
+	return res;
+}
 
+template<class TVar>
+TPZSYsmpMatrix<TVar> TPZSYsmpMatrix<TVar>::operator-(const TPZSYsmpMatrix<TVar>&mat) const
+{
+	CheckTypeCompatibility(this,&mat);
+	auto res(*this);
+  const auto sizeA = res.fA.size();
+  for(auto i = 0; i < sizeA; i++) res.fA[i] -= mat.fA[i];
+	return res;
+}
 
 template<class TVar>
 TPZSYsmpMatrix<TVar> TPZSYsmpMatrix<TVar>::operator*(const TVar alpha) const
 {
-	TPZSYsmpMatrix<TVar> res(*this);
+	auto res(*this);
 	for(auto &el : res.fA) el *= alpha;
 	return res;
+}
+
+template<class TVar>
+TPZSYsmpMatrix<TVar> &TPZSYsmpMatrix<TVar>::operator+=(const TPZSYsmpMatrix<TVar> &A )
+{
+	TPZSYsmpMatrix<TVar> res((*this)+A);
+	*this = res;
+	return *this;
+}
+template<class TVar>
+TPZSYsmpMatrix<TVar> &TPZSYsmpMatrix<TVar>::operator-=(const TPZSYsmpMatrix<TVar> &A )
+{
+	TPZSYsmpMatrix<TVar> res((*this)-A);
+	*this = res;
+	return *this;
+}
+template<class TVar>
+TPZSYsmpMatrix<TVar> &TPZSYsmpMatrix<TVar>::operator*=(const TVar val)
+{
+	TPZSYsmpMatrix<TVar> res((*this)*val);
+	*this = res;
+	return *this;
 }
 
 template<class TVar>

--- a/Matrix/pzsysmp.cpp
+++ b/Matrix/pzsysmp.cpp
@@ -104,6 +104,33 @@ int TPZSYsmpMatrix<TVar>::PutVal(const int64_t r,const int64_t c,const TVar & va
 }
 
 
+
+template<class TVar>
+void TPZSYsmpMatrix<TVar>::CheckTypeCompatibility(const TPZMatrix<TVar>*A,
+                                                  const TPZMatrix<TVar>*B)const
+{
+  auto incompatSparse = [](){
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR: incompatible matrices\n.Aborting...\n";
+    DebugStop();
+  };
+  auto aPtr = dynamic_cast<const TPZSYsmpMatrix<TVar>*>(A);
+  auto bPtr = dynamic_cast<const TPZSYsmpMatrix<TVar>*>(B);
+  if(!aPtr || !bPtr){
+    incompatSparse();
+  }
+	bool check{false};
+	const auto nIA = aPtr->fIA.size();
+	for(auto i = 0; i < nIA; i++){
+		check = check || aPtr->fIA[i] != bPtr->fIA[i];
+	}
+
+	const auto nJA = aPtr->fJA.size();
+	for(auto i = 0; i < nJA; i++){
+		check = check || aPtr->fJA[i] != bPtr->fJA[i];
+	}
+	if(check) incompatSparse();
+}
 // ****************************************************************************
 //
 // Multiply and Multiply-Add

--- a/Matrix/pzsysmp.cpp
+++ b/Matrix/pzsysmp.cpp
@@ -110,6 +110,15 @@ int TPZSYsmpMatrix<TVar>::PutVal(const int64_t r,const int64_t c,const TVar & va
 //
 // ****************************************************************************
 
+
+template<class TVar>
+TPZSYsmpMatrix<TVar> TPZSYsmpMatrix<TVar>::operator*(const TVar alpha) const
+{
+	TPZSYsmpMatrix<TVar> res(*this);
+	for(auto &el : res.fA) el *= alpha;
+	return res;
+}
+
 template<class TVar>
 void TPZSYsmpMatrix<TVar>::MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> &y,
 							 TPZFMatrix<TVar> &z,

--- a/Matrix/pzsysmp.cpp
+++ b/Matrix/pzsysmp.cpp
@@ -22,13 +22,7 @@ TPZMatrix<TVar>() {
     cerr << "TPZSYsmpMatrix(int rows,int cols)\n";
 #endif
 }
-template<class TVar>
-TPZSYsmpMatrix<TVar>::TPZSYsmpMatrix(const TPZSYsmpMatrix<TVar> &cp) : 
-    TPZRegisterClassId(&TPZSYsmpMatrix::ClassId),
-    TPZMatrix<TVar>(cp), fIA(cp.fIA), fJA(cp.fJA), fA(cp.fA), fDiag(cp.fDiag)
-{
 
-}
 
 template<class TVar>
 TPZSYsmpMatrix<TVar>::TPZSYsmpMatrix(const int64_t rows,const int64_t cols ) : TPZRegisterClassId(&TPZSYsmpMatrix::ClassId),
@@ -45,17 +39,6 @@ TPZSYsmpMatrix<TVar>::~TPZSYsmpMatrix() {
 #ifdef DESTRUCTOR
 	cerr << "~TPZSYsmpMatrix()\n";
 #endif
-}
-
-template<class TVar>
-TPZSYsmpMatrix<TVar> &TPZSYsmpMatrix<TVar>::operator=(const TPZSYsmpMatrix<TVar> &copy) 
-{
-    TPZMatrix<TVar>::operator=(copy);
-    fIA =copy.fIA;
-    fJA = copy.fJA;
-    fA = copy.fA;
-    fDiag = copy.fDiag;
-    return *this;
 }
 
 template <class TVar> int TPZSYsmpMatrix<TVar>::Zero() {

--- a/Matrix/pzsysmp.h
+++ b/Matrix/pzsysmp.h
@@ -91,7 +91,12 @@ public :
     virtual int PutVal(const int64_t /*row*/,const int64_t /*col*/,const TVar & val ) override;
   /** @name Arithmetic*/
   /** @{ */
+  TPZSYsmpMatrix<TVar> operator+(const TPZSYsmpMatrix<TVar> & A) const;
+  TPZSYsmpMatrix<TVar> operator-(const TPZSYsmpMatrix<TVar> & A) const;
   TPZSYsmpMatrix<TVar> operator*(const TVar alpha) const;
+  TPZSYsmpMatrix<TVar> &operator+=(const TPZSYsmpMatrix<TVar> &A );
+  TPZSYsmpMatrix<TVar> &operator-=(const TPZSYsmpMatrix<TVar> &A );
+  TPZSYsmpMatrix<TVar> &operator*=(const TVar val) override;
   
 	/** @brief Computes z = beta * y + alpha * opt(this)*x */
 	/** @note z and x cannot overlap in memory */

--- a/Matrix/pzsysmp.h
+++ b/Matrix/pzsysmp.h
@@ -81,21 +81,23 @@ public :
     /** @brief Fill matrix storage with randomic values */
     /** This method use GetVal and PutVal which are implemented by each type matrices */
     void AutoFill(int64_t nrow, int64_t ncol, int symmetric) override;
-	
-	/** @brief Get the matrix entry at (row,col) without bound checking */
-	virtual const TVar GetVal(const int64_t row, const int64_t col ) const override;
+	  
+	  /** @brief Get the matrix entry at (row,col) without bound checking */
+	  virtual const TVar GetVal(const int64_t row, const int64_t col ) const override;
     
     /** @brief Put values without bounds checking \n
      *  This method is faster than "Put" if DEBUG is defined.
      */
     virtual int PutVal(const int64_t /*row*/,const int64_t /*col*/,const TVar & val ) override;
-
-	
+  /** @name Arithmetic*/
+  /** @{ */
+  TPZSYsmpMatrix<TVar> operator*(const TVar alpha) const;
+  
 	/** @brief Computes z = beta * y + alpha * opt(this)*x */
 	/** @note z and x cannot overlap in memory */
 	virtual void MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> &y, TPZFMatrix<TVar> &z,
 						 const TVar alpha=1.,const TVar beta = 0.,const int opt = 0) const override;
-	
+	/** @} */
 	/** @brief Sets data to the class */
 	virtual void SetData(const TPZVec<int64_t> &IA,const TPZVec<int64_t> &JA, const TPZVec<TVar> &A );
 
@@ -211,7 +213,7 @@ private:
 	TPZVec<int64_t>  fJA;
 	TPZVec<TVar> fA;
 	
-    TPZPardisoSolver<TVar> fPardisoControl;
+  TPZPardisoSolver<TVar> fPardisoControl;
 	
 	TPZVec<TVar> fDiag;
 };

--- a/Matrix/pzsysmp.h
+++ b/Matrix/pzsysmp.h
@@ -194,6 +194,8 @@ public :
 
     void ComputeDiagonal();
 protected:
+  void CheckTypeCompatibility(const TPZMatrix<TVar>*aPtr,
+                              const TPZMatrix<TVar>*bPtr)const override;
   inline TVar *&Elem() override
   {
     return fA.begin();

--- a/Matrix/pzsysmp.h
+++ b/Matrix/pzsysmp.h
@@ -36,31 +36,47 @@ public :
   /** @brief Move-assignment operator*/
   TPZSYsmpMatrix &operator=(TPZSYsmpMatrix<TVar> &&copy) = default;
     
-    CLONEDEF(TPZSYsmpMatrix)
+  CLONEDEF(TPZSYsmpMatrix)
 	/** @brief Destructor */
 	virtual ~TPZSYsmpMatrix();
-    
-    /** @brief Checks if the current matrix is symmetric */
-    virtual int IsSymmetric() const  override { return 1; }
-    /** @brief Checks if current matrix is square */
-    inline int IsSquare() const { return 1;}
-    
-    /** @brief Zeroes the matrix */
-    virtual int Zero() override;
 
-    /** @brief Zeroes the matrix */
-    virtual int Redim(int64_t rows, int64_t cols) override
-    {
-        if(rows == this->fRow && cols == this->fCol)
-        {
-            Zero();
-        }
-        else
-        {
-            DebugStop();
-        }
-        return 0;
-    }
+  /** @brief Creates a copy from another TPZSYsmpMatrix*/
+  void CopyFrom(const TPZMatrix<TVar> *  mat) override
+  {                                                           
+    auto *from = dynamic_cast<const TPZSYsmpMatrix<TVar> *>(mat);                
+    if (from) {                                               
+      *this = *from;                                          
+    }                                                         
+    else                                                      
+      {                                                       
+        PZError<<__PRETTY_FUNCTION__;                         
+        PZError<<"\nERROR: Called with incompatible type\n."; 
+        PZError<<"Aborting...\n";                             
+        DebugStop();                                          
+      }                                                       
+  }
+  
+  /** @brief Checks if the current matrix is symmetric */
+  virtual int IsSymmetric() const  override { return 1; }
+  /** @brief Checks if current matrix is square */
+  inline int IsSquare() const { return 1;}
+    
+  /** @brief Zeroes the matrix */
+  virtual int Zero() override;
+
+  /** @brief Zeroes the matrix */
+  virtual int Redim(int64_t rows, int64_t cols) override
+  {
+    if(rows == this->fRow && cols == this->fCol)
+      {
+        Zero();
+      }
+    else
+      {
+        DebugStop();
+      }
+    return 0;
+  }
     
     /** @brief Fill matrix storage with randomic values */
     /** This method use GetVal and PutVal which are implemented by each type matrices */

--- a/Matrix/pzsysmp.h
+++ b/Matrix/pzsysmp.h
@@ -37,7 +37,7 @@ public :
 	virtual ~TPZSYsmpMatrix();
     
     /** @brief Checks if the current matrix is symmetric */
-    virtual int IsSimetric() const  override { return 1; }
+    virtual int IsSymmetric() const  override { return 1; }
     /** @brief Checks if current matrix is square */
     inline int IsSquare() const { return 1;}
     

--- a/Matrix/pzsysmp.h
+++ b/Matrix/pzsysmp.h
@@ -24,13 +24,17 @@ class TPZSYsmpMatrix : public TPZMatrix<TVar>{
     
 public :
     /** @brief Constructor based on number of rows and columns */
-    TPZSYsmpMatrix();
+  TPZSYsmpMatrix();
 	/** @brief Constructor based on number of rows and columns */
-    TPZSYsmpMatrix(const int64_t rows, const int64_t cols );
+  TPZSYsmpMatrix(const int64_t rows, const int64_t cols );
 	/** @brief Copy constructor */
-    TPZSYsmpMatrix(const TPZSYsmpMatrix<TVar> &cp);
-    
-    TPZSYsmpMatrix &operator=(const TPZSYsmpMatrix<TVar> &copy);
+  TPZSYsmpMatrix(const TPZSYsmpMatrix<TVar> &cp) = default;
+  /** @brief Move constructor*/
+  TPZSYsmpMatrix(TPZSYsmpMatrix<TVar> &&cp) = default;
+  /** @brief Copy-assignment operator*/
+  TPZSYsmpMatrix &operator=(const TPZSYsmpMatrix<TVar> &copy) = default;
+  /** @brief Move-assignment operator*/
+  TPZSYsmpMatrix &operator=(TPZSYsmpMatrix<TVar> &&copy) = default;
     
     CLONEDEF(TPZSYsmpMatrix)
 	/** @brief Destructor */

--- a/Matrix/pzsysmp.h
+++ b/Matrix/pzsysmp.h
@@ -35,7 +35,7 @@ public :
   TPZSYsmpMatrix &operator=(const TPZSYsmpMatrix<TVar> &copy) = default;
   /** @brief Move-assignment operator*/
   TPZSYsmpMatrix &operator=(TPZSYsmpMatrix<TVar> &&copy) = default;
-    
+  inline TPZSYsmpMatrix<TVar>*NewMatrix() const override {return new TPZSYsmpMatrix<TVar>{};}
   CLONEDEF(TPZSYsmpMatrix)
 	/** @brief Destructor */
 	virtual ~TPZSYsmpMatrix();

--- a/Matrix/pzsysmp.h
+++ b/Matrix/pzsysmp.h
@@ -175,7 +175,19 @@ public :
     int ClassId() const override;
 
     void ComputeDiagonal();
-
+protected:
+  inline TVar *&Elem() override
+  {
+    return fA.begin();
+  }
+  inline const TVar *Elem() const override
+  {
+    return fA.begin();
+  }
+  inline int64_t Size() const override
+  {
+    return fA.size();
+  }
 private:
 	
 	

--- a/Matrix/pztrnsform.h
+++ b/Matrix/pztrnsform.h
@@ -54,8 +54,8 @@ public:
 	/** @brief Overloading equal operator for transformation */
 	TPZTransform<T> &operator=(const TPZTransform<T> &t);
 	
-    /** @brief Create a copy form a real transformation */
-    void CopyFrom(const TPZTransform<REAL> &cp);
+  /** @brief Create a copy form a real transformation */
+  void CopyFrom(const TPZTransform<REAL> &cp);
     
 	const TPZFMatrix<T>  & Mult() const {return fMult;}
 	

--- a/Matrix/pzysmp.cpp
+++ b/Matrix/pzysmp.cpp
@@ -945,11 +945,11 @@ int TPZFYsmpMatrix<TVar>::Decompose_LU()
         DebugStop();
     }
 	typename TPZPardisoSolver<TVar>::MStructure str =
-        this->IsSimetric() ?
+        this->IsSymmetric() ?
 		TPZPardisoSolver<TVar>::MStructure::ESymmetric:
 		TPZPardisoSolver<TVar>::MStructure::ENonSymmetric;
 	typename TPZPardisoSolver<TVar>::MSystemType sysType =
-		this->IsSimetric() ?
+		this->IsSymmetric() ?
 		TPZPardisoSolver<TVar>::MSystemType::ESymmetric:
 		TPZPardisoSolver<TVar>::MSystemType::ENonSymmetric;
 	typename TPZPardisoSolver<TVar>::MProperty prop =

--- a/Matrix/pzysmp.cpp
+++ b/Matrix/pzysmp.cpp
@@ -64,17 +64,6 @@ TPZMatrix<TVar>(), fIA(1,0),fJA(),fA(),fDiag()
 }
 
 template<class TVar>
-TPZFYsmpMatrix<TVar> &TPZFYsmpMatrix<TVar>::operator=(const TPZFYsmpMatrix<TVar> &cp) {
-	// Deletes everything associated with a TPZFYsmpMatrix
-	TPZMatrix<TVar>::operator=(cp);
-    fIA = cp.fIA;
-    fA = cp.fA;
-    fJA = cp.fJA;
-    fDiag = cp.fDiag;
-	return *this;
-}
-
-template<class TVar>
 TPZFYsmpMatrix<TVar> &TPZFYsmpMatrix<TVar>::operator=(const TPZVerySparseMatrix<TVar> &cp)
 {
 	// Deletes everything associated with a TPZFYsmpMatrix

--- a/Matrix/pzysmp.cpp
+++ b/Matrix/pzysmp.cpp
@@ -351,6 +351,13 @@ const TVar TPZFYsmpMatrix<TVar>::GetVal(const int64_t row,const int64_t col ) co
 // ****************************************************************************
 
 
+template<class TVar>
+TPZFYsmpMatrix<TVar> TPZFYsmpMatrix<TVar>::operator*(const TVar alpha) const
+{
+	TPZFYsmpMatrix<TVar> res(*this);
+	for(auto& el : res.fA) el *= alpha;
+	return res;
+}
 
 template<class TVar>
 void TPZFYsmpMatrix<TVar>::MultAddMT(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> &y,

--- a/Matrix/pzysmp.cpp
+++ b/Matrix/pzysmp.cpp
@@ -344,6 +344,33 @@ const TVar TPZFYsmpMatrix<TVar>::GetVal(const int64_t row,const int64_t col ) co
 	return (TVar) 0;
 }
 
+template<class TVar>
+void TPZFYsmpMatrix<TVar>::CheckTypeCompatibility(const TPZMatrix<TVar>*A,
+																									const TPZMatrix<TVar>*B)const
+{
+  auto incompatSparse = [](){
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nERROR: incompatible matrices\n.Aborting...\n";
+    DebugStop();
+  };
+	auto aPtr = dynamic_cast<const TPZFYsmpMatrix<TVar>*>(A);
+  auto bPtr = dynamic_cast<const TPZFYsmpMatrix<TVar>*>(B);
+  if(!aPtr || !bPtr){
+    incompatSparse();
+  }
+	bool check{false};
+	const auto nIA = aPtr->fIA.size();
+	for(auto i = 0; i < nIA; i++){
+		check = check || aPtr->fIA[i] != bPtr->fIA[i];
+	}
+
+	const auto nJA = aPtr->fJA.size();
+	for(auto i = 0; i < nJA; i++){
+		check = check || aPtr->fJA[i] != bPtr->fJA[i];
+	}
+	if(check) incompatSparse();
+}
+
 // ****************************************************************************
 //
 // Multiply and Multiply-Add

--- a/Matrix/pzysmp.cpp
+++ b/Matrix/pzysmp.cpp
@@ -377,13 +377,53 @@ void TPZFYsmpMatrix<TVar>::CheckTypeCompatibility(const TPZMatrix<TVar>*A,
 //
 // ****************************************************************************
 
+template<class TVar>
+TPZFYsmpMatrix<TVar> TPZFYsmpMatrix<TVar>::operator+(const TPZFYsmpMatrix<TVar>&mat) const
+{
+	CheckTypeCompatibility(this,&mat);
+	auto res(*this);
+  const auto sizeA = res.fA.size();
+  for(auto i = 0; i < sizeA; i++) res.fA[i] += mat.fA[i];
+	return res;
+}
+template<class TVar>
+TPZFYsmpMatrix<TVar> TPZFYsmpMatrix<TVar>::operator-(const TPZFYsmpMatrix<TVar>&mat) const
+{
+	CheckTypeCompatibility(this,&mat);
+	auto res(*this);
+  const auto sizeA = res.fA.size();
+  for(auto i = 0; i < sizeA; i++) res.fA[i] -= mat.fA[i];
+	return res;
+}
 
 template<class TVar>
 TPZFYsmpMatrix<TVar> TPZFYsmpMatrix<TVar>::operator*(const TVar alpha) const
 {
-	TPZFYsmpMatrix<TVar> res(*this);
-	for(auto& el : res.fA) el *= alpha;
+	auto res(*this);
+	for(auto &el : res.fA) el *= alpha;
 	return res;
+}
+
+template<class TVar>
+TPZFYsmpMatrix<TVar> &TPZFYsmpMatrix<TVar>::operator+=(const TPZFYsmpMatrix<TVar> &A )
+{
+	TPZFYsmpMatrix<TVar> res((*this)+A);
+	*this = res;
+	return *this;
+}
+template<class TVar>
+TPZFYsmpMatrix<TVar> &TPZFYsmpMatrix<TVar>::operator-=(const TPZFYsmpMatrix<TVar> &A )
+{
+	TPZFYsmpMatrix<TVar> res((*this)-A);
+	*this = res;
+	return *this;
+}
+template<class TVar>
+TPZFYsmpMatrix<TVar> &TPZFYsmpMatrix<TVar>::operator*=(const TVar val)
+{
+	TPZFYsmpMatrix<TVar> res((*this)*val);
+	*this = res;
+	return *this;
 }
 
 template<class TVar>

--- a/Matrix/pzysmp.h
+++ b/Matrix/pzysmp.h
@@ -59,7 +59,7 @@ public:
   TPZFYsmpMatrix &operator=(TPZFYsmpMatrix<TVar> &&copy) = default;
 	
 	TPZFYsmpMatrix &operator=(const TPZVerySparseMatrix<TVar> &cp);
-    
+  inline TPZFYsmpMatrix<TVar>*NewMatrix() const override {return new TPZFYsmpMatrix<TVar>{};}
 	CLONEDEF(TPZFYsmpMatrix)
 	
 	virtual ~TPZFYsmpMatrix();	

--- a/Matrix/pzysmp.h
+++ b/Matrix/pzysmp.h
@@ -95,7 +95,12 @@ public:
 	int PutVal(const int64_t row, const int64_t col, const TVar &Value) override;
   /**@name Arithmetics */
   /** @{ */
+  TPZFYsmpMatrix<TVar> operator+(const TPZFYsmpMatrix<TVar> & A) const;
+  TPZFYsmpMatrix<TVar> operator-(const TPZFYsmpMatrix<TVar> & A) const;
   TPZFYsmpMatrix<TVar> operator*(const TVar alpha) const;
+  TPZFYsmpMatrix<TVar> &operator+=(const TPZFYsmpMatrix<TVar> &A );
+  TPZFYsmpMatrix<TVar> &operator-=(const TPZFYsmpMatrix<TVar> &A );
+  TPZFYsmpMatrix<TVar> &operator*=(const TVar val) override;
   
 	virtual void MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> &y, TPZFMatrix<TVar> &z,
 						 const TVar alpha=1.,const TVar beta = 0., const int opt = 0) const override;

--- a/Matrix/pzysmp.h
+++ b/Matrix/pzysmp.h
@@ -63,12 +63,26 @@ public:
 	CLONEDEF(TPZFYsmpMatrix)
 	
 	virtual ~TPZFYsmpMatrix();	
-	
-    /** @brief Fill matrix storage with randomic values */
-    /** This method use GetVal and PutVal which are implemented by each type matrices */
-    void AutoFill(int64_t nrow, int64_t ncol, int symmetric) override;
-    
 
+  /** @brief Creates a copy from another TPZFYsmpMatrix*/
+  void CopyFrom(const TPZMatrix<TVar> *  mat) override
+  {                                                           
+    auto *from = dynamic_cast<const TPZFYsmpMatrix<TVar> *>(mat);                
+    if (from) {                                               
+      *this = *from;                                          
+    }                                                         
+    else                                                      
+      {                                                       
+        PZError<<__PRETTY_FUNCTION__;                         
+        PZError<<"\nERROR: Called with incompatible type\n."; 
+        PZError<<"Aborting...\n";                             
+        DebugStop();                                          
+      }                                                       
+  }
+  
+  /** @brief Fill matrix storage with randomic values */
+  /** This method use GetVal and PutVal which are implemented by each type matrices */
+  void AutoFill(int64_t nrow, int64_t ncol, int symmetric) override;
     
 	/** @brief Get the matrix entry at (row,col) without bound checking */
 	virtual const TVar GetVal(const int64_t row,const int64_t col ) const override;

--- a/Matrix/pzysmp.h
+++ b/Matrix/pzysmp.h
@@ -182,6 +182,19 @@ private:
 	void RowLUUpdate(int64_t sourcerow, int64_t destrow);
 	
 protected:
+
+  inline TVar *&Elem() override
+  {
+    return fA.begin();
+  }
+  inline const TVar *Elem() const override
+  {
+    return fA.begin();
+  }
+  inline int64_t Size() const override
+  {
+    return fA.size();
+  }
 	TPZVec<int64_t>  fIA;
 	TPZVec<int64_t>  fJA;
 	TPZVec<TVar> fA;
@@ -190,7 +203,7 @@ protected:
 	
 	int   fSymmetric;
 	
-    TPZPardisoSolver<TVar> fPardisoControl;
+  TPZPardisoSolver<TVar> fPardisoControl;
 protected:
 	
 	/**

--- a/Matrix/pzysmp.h
+++ b/Matrix/pzysmp.h
@@ -202,7 +202,8 @@ private:
 	void RowLUUpdate(int64_t sourcerow, int64_t destrow);
 	
 protected:
-
+  void CheckTypeCompatibility(const TPZMatrix<TVar>*aPtr,
+                              const TPZMatrix<TVar>*bPtr) const override;
   inline TVar *&Elem() override
   {
     return fA.begin();

--- a/Matrix/pzysmp.h
+++ b/Matrix/pzysmp.h
@@ -48,13 +48,15 @@ private:
 	
 public:
     
-    TPZFYsmpMatrix();
-    
-    TPZFYsmpMatrix(const int64_t rows,const int64_t cols );
-	
+  TPZFYsmpMatrix();
+  TPZFYsmpMatrix(const int64_t rows,const int64_t cols );
+	TPZFYsmpMatrix(const TPZFYsmpMatrix<TVar>&) = default;
+  TPZFYsmpMatrix(TPZFYsmpMatrix<TVar>&&) = default;
+  
 	TPZFYsmpMatrix(const TPZVerySparseMatrix<TVar> &cp);
 	
-	TPZFYsmpMatrix &operator=(const TPZFYsmpMatrix<TVar> &copy);
+	TPZFYsmpMatrix &operator=(const TPZFYsmpMatrix<TVar> &copy) = default;
+  TPZFYsmpMatrix &operator=(TPZFYsmpMatrix<TVar> &&copy) = default;
 	
 	TPZFYsmpMatrix &operator=(const TPZVerySparseMatrix<TVar> &cp);
     

--- a/Matrix/pzysmp.h
+++ b/Matrix/pzysmp.h
@@ -93,18 +93,24 @@ public:
 	}
 	
 	int PutVal(const int64_t row, const int64_t col, const TVar &Value) override;
-	
+  /**@name Arithmetics */
+  /** @{ */
+  TPZFYsmpMatrix<TVar> operator*(const TVar alpha) const;
+  
 	virtual void MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> &y, TPZFMatrix<TVar> &z,
 						 const TVar alpha=1.,const TVar beta = 0., const int opt = 0) const override;
 	
 	virtual void MultAddMT(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> &y, TPZFMatrix<TVar> &z,
 						   const TVar alpha=1.,const TVar beta = 0., const int opt = 0);
-	
+	/** @} */
 	virtual int GetSub(const int64_t sRow,const int64_t sCol,const int64_t rowSize,
 					   const int64_t colSize, TPZFMatrix<TVar> & A ) const override;
 	
 	void GetSub(const TPZVec<int64_t> &indices,TPZFMatrix<TVar> &block) const override;
-	
+
+
+  
+  
 	/** @brief Pass the data to the class. */
 	virtual void SetData( int64_t *IA, int64_t *JA, TVar *A );
     

--- a/Matrix/tpzverysparsematrix.cpp
+++ b/Matrix/tpzverysparsematrix.cpp
@@ -136,6 +136,24 @@ const TVar TPZVerySparseMatrix<TVar>::GetVal(const int64_t row, const int64_t co
 }
 
 template<class TVar>
+TVar* &TPZVerySparseMatrix<TVar>::Elem()
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"ERROR:Not implemented\n.Aborting...\n";
+  DebugStop();
+  static TVar* t{nullptr};
+  return t;
+}
+
+template<class TVar>
+const TVar* TPZVerySparseMatrix<TVar>::Elem()const
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"ERROR:Not implemented\n.Aborting...\n";
+  DebugStop();
+  return nullptr;
+}
+template<class TVar>
 void TPZVerySparseMatrix<TVar>::MultAdd(const TPZFMatrix<TVar> & x, const TPZFMatrix<TVar> & y, TPZFMatrix<TVar> & z,
 								  const TVar alpha, const TVar beta, const int opt) const
 {

--- a/Matrix/tpzverysparsematrix.h
+++ b/Matrix/tpzverysparsematrix.h
@@ -80,7 +80,22 @@ public:
 	}
 	
 	CLONEDEF(TPZVerySparseMatrix)
-	
+
+	/** @brief Creates a copy from another TPZVerySparseMatrix*/
+  void CopyFrom(const TPZMatrix<TVar> *  mat) override
+  {                                                           
+    auto *from = dynamic_cast<const TPZVerySparseMatrix<TVar> *>(mat);                
+    if (from) {                                               
+      *this = *from;                                          
+    }                                                         
+    else                                                      
+      {                                                       
+        PZError<<__PRETTY_FUNCTION__;                         
+        PZError<<"\nERROR: Called with incompatible type\n."; 
+        PZError<<"Aborting...\n";                             
+        DebugStop();                                          
+      }                                                       
+  }
 	/**
 	 * @brief It computes z = beta * y + alpha * opt(this)*x but z and x can not overlap in memory.
 	 * @param x Is x on the above operation

--- a/Matrix/tpzverysparsematrix.h
+++ b/Matrix/tpzverysparsematrix.h
@@ -78,7 +78,8 @@ public:
 #endif
 		return fExtraSparseData[std::pair<int64_t, int64_t>(row, col)];
 	}
-	
+	inline TPZVerySparseMatrix<TVar>*NewMatrix() const override
+  {return new TPZVerySparseMatrix<TVar>{};}
 	CLONEDEF(TPZVerySparseMatrix)
 
 	/** @brief Creates a copy from another TPZVerySparseMatrix*/

--- a/Matrix/tpzverysparsematrix.h
+++ b/Matrix/tpzverysparsematrix.h
@@ -116,7 +116,11 @@ private:
 	void ReadMap(TPZStream &buf, void *context, std::map<std::pair<int64_t, int64_t>, TVar> & TheMap);
 	
 protected:
-    
+	TVar *&Elem() override;
+  const TVar *Elem() const override;
+	inline int64_t Size() const override{
+		return fExtraSparseData.size();
+	}
     /** @brief Save elements different from zero, of Sparse matrix */
 	std::map<std::pair<int64_t, int64_t>, TVar> fExtraSparseData;
     

--- a/Solvers/Multigrid/pztransfer.h
+++ b/Solvers/Multigrid/pztransfer.h
@@ -46,6 +46,22 @@ public :
 	}
 	
 	virtual TPZMatrix<TVar> *Clone() const  override { return new TPZTransfer(*this); }
+
+	/** @brief Creates a copy from another TPZTransfer*/
+  void CopyFrom(const TPZMatrix<TVar> *  mat) override        
+  {                                                           
+    auto *from = dynamic_cast<const TPZTransfer<TVar> *>(mat);                
+    if (from) {                                               
+      *this = *from;                                          
+    }                                                         
+    else                                                      
+      {                                                       
+        PZError<<__PRETTY_FUNCTION__;                         
+        PZError<<"\nERROR: Called with incompatible type\n."; 
+        PZError<<"Aborting...\n";                             
+        DebugStop();                                          
+      }                                                       
+  }
 	
 	//TPZMatrix<REAL> : EFormatted, EInputFormat, EMathematicaInput
 	virtual void Print(const char *name = NULL, std::ostream &out = std::cout , const MatrixOutputFormat form = EFormatted) const override;

--- a/Solvers/Multigrid/pztransfer.h
+++ b/Solvers/Multigrid/pztransfer.h
@@ -44,7 +44,7 @@ public :
 	fDoubleValLastUsed(cp.fDoubleValLastUsed)
 	{
 	}
-	
+	inline TPZTransfer*NewMatrix() const override {return new TPZTransfer{};}
 	virtual TPZMatrix<TVar> *Clone() const  override { return new TPZTransfer(*this); }
 
 	/** @brief Creates a copy from another TPZTransfer*/

--- a/Solvers/Multigrid/pztransfer.h
+++ b/Solvers/Multigrid/pztransfer.h
@@ -100,7 +100,19 @@ public :
 //	void Multiply(const TPZFMatrix<TVar> &A, TPZFMatrix<TVar> &B, int opt) const override;
 	
     void MultiplyScalar(const TPZFMatrix<TVar> &A, TPZFMatrix<TVar> &B, int opt) const;
-    
+protected:
+	inline TVar *&Elem() override
+  {
+    return fDoubleValues.begin();
+  }
+  inline const TVar *Elem() const override
+  {
+    return fDoubleValues.begin();
+  }
+  inline int64_t Size() const override
+  {
+    return fDoubleValues.size();
+  }
 private:
 	
 	/** @brief Increases the storage allocated

--- a/Solvers/TPZPardisoSolver.cpp
+++ b/Solvers/TPZPardisoSolver.cpp
@@ -65,9 +65,10 @@ TPZPardisoSolver<TVar>::~TPZPardisoSolver()
     void *a= &av,*b = &bv, *x = &xv;
     long long ia,ja,perm,nrhs = 1;
     long long Error = 0;
-    
-    pardiso_64 (fHandle,  &fMax_num_factors, &fMatrix_num, &fMatrixType, &phase, &n, a, &ia, &ja, &perm,
-                &nrhs, &fParam[0], &fMessageLevel, b, x, &Error);
+    if(fPardisoInitialized)
+        pardiso_64 (fHandle,  &fMax_num_factors, &fMatrix_num, &fMatrixType,
+                    &phase, &n, a, &ia, &ja, &perm,
+                    &nrhs, &fParam[0], &fMessageLevel, b, x, &Error);
     
     if (Error) {
         DebugStop();
@@ -445,6 +446,7 @@ long long TPZPardisoSolver<TVar>::MatrixType()
     int matrixtype = fMatrixType;
 #ifdef USING_MKL
     pardisoinit(fHandle,&matrixtype,param);
+    fPardisoInitialized = true;
 #endif
     for (int i=0; i<64; i++) {
         fParam[i] = param[i];

--- a/Solvers/TPZPardisoSolver.cpp
+++ b/Solvers/TPZPardisoSolver.cpp
@@ -100,7 +100,7 @@ void TPZPardisoSolver<TVar>::SetMatrix(TPZAutoPointer<TPZBaseMatrix> refmat)
        fProperty == MProperty::ENonInitialized){
         const MProperty prop = refmat->IsDefPositive() ?
             MProperty::EPositiveDefinite : MProperty::EIndefinite;
-        const MSystemType sym = refmat->IsSimetric() ?
+        const MSystemType sym = refmat->IsSymmetric() ?
             MSystemType::ESymmetric : MSystemType::ENonSymmetric;
         SetMatrixType(sym,prop);
     }

--- a/Solvers/TPZPardisoSolver.h
+++ b/Solvers/TPZPardisoSolver.h
@@ -128,6 +128,8 @@ protected:
 
     /// whether the matrix has been decomposed
     bool fDecomposed{false};
+    /// whether pardisoinit has been called
+    bool fPardisoInitialized{false};
 };
 
 #endif /* TPZPARDISOSOLVER_H */

--- a/SubStruct/tpzdohrmatrix.cpp
+++ b/SubStruct/tpzdohrmatrix.cpp
@@ -21,6 +21,32 @@ static TPZLogger logger("substruct.dohrsubstruct");
 
 
 template<class TVar, class TSubStruct>
+int64_t TPZDohrMatrix<TVar,TSubStruct>::Size() const
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"ERROR:Should not be called\n.Aborting...\n";
+  DebugStop();
+	return -1;
+}
+template<class TVar, class TSubStruct>
+TVar* &TPZDohrMatrix<TVar,TSubStruct>::Elem()
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"ERROR:Should not be called\n.Aborting...\n";
+  DebugStop();
+	static TVar* t{nullptr};
+  return t;
+}
+template<class TVar, class TSubStruct>
+const TVar* TPZDohrMatrix<TVar,TSubStruct>::Elem() const
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"ERROR:Should not be called\n.Aborting...\n";
+  DebugStop();
+	return nullptr;
+}
+
+template<class TVar, class TSubStruct>
 TPZDohrMatrix<TVar,TSubStruct>::TPZDohrMatrix(TPZAutoPointer<TPZDohrAssembly<TVar> > assembly)
 : TPZMatrix<TVar>(), fNumThreads(0), fAssembly(assembly)
 {

--- a/SubStruct/tpzdohrmatrix.h
+++ b/SubStruct/tpzdohrmatrix.h
@@ -60,6 +60,7 @@ public:
 	}
 	
 	//	CLONEDEF(TPZDohrMatrix)
+	inline TPZDohrMatrix*NewMatrix() const override {return new TPZDohrMatrix{};}
 	virtual TPZMatrix<TVar>*Clone() const  override { return new TPZDohrMatrix(*this); }
 	
 	~TPZDohrMatrix();

--- a/SubStruct/tpzdohrmatrix.h
+++ b/SubStruct/tpzdohrmatrix.h
@@ -63,7 +63,21 @@ public:
 	virtual TPZMatrix<TVar>*Clone() const  override { return new TPZDohrMatrix(*this); }
 	
 	~TPZDohrMatrix();
-	
+
+	void CopyFrom(const TPZMatrix<TVar> *  mat) override        
+  {                                                           
+    auto *from = dynamic_cast<const TPZDohrMatrix<TVar,TSubStruct> *>(mat);                
+    if (from) {                                               
+      *this = *from;                                          
+    }                                                         
+    else                                                      
+      {                                                       
+        PZError<<__PRETTY_FUNCTION__;                         
+        PZError<<"\nERROR: Called with incompatible type\n."; 
+        PZError<<"Aborting...\n";                             
+        DebugStop();                                          
+      }                                                       
+  }
 	const SubsList &SubStructures() const
 	{
 		return fGlobal;

--- a/SubStruct/tpzdohrmatrix.h
+++ b/SubStruct/tpzdohrmatrix.h
@@ -38,6 +38,10 @@ private:
 	
 	/** @brief Number of threads that will be used during the matrix vector multiplication */
 	int fNumThreads;
+
+	int64_t Size() const override;
+  TVar* &Elem() override;
+  const TVar* Elem() const override;
 	
 public:
 	

--- a/SubStruct/tpzdohrprecond.cpp
+++ b/SubStruct/tpzdohrprecond.cpp
@@ -34,6 +34,32 @@ static TPZLogger loggerv1v2("substruct.v1v2");
 using namespace std;
 
 template<class TVar, class TSubStruct>
+int64_t TPZDohrPrecond<TVar,TSubStruct>::Size() const
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"ERROR:Should not be called\n.Aborting...\n";
+  DebugStop();
+	return -1;
+}
+template<class TVar, class TSubStruct>
+TVar* &TPZDohrPrecond<TVar,TSubStruct>::Elem()
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"ERROR:Should not be called\n.Aborting...\n";
+  DebugStop();
+	static TVar* t{nullptr};
+  return t;
+}
+template<class TVar, class TSubStruct>
+const TVar* TPZDohrPrecond<TVar,TSubStruct>::Elem() const
+{
+  PZError<<__PRETTY_FUNCTION__;
+  PZError<<"ERROR:Should not be called\n.Aborting...\n";
+  DebugStop();
+	return nullptr;
+}
+
+template<class TVar, class TSubStruct>
 TPZDohrPrecond<TVar, TSubStruct>::TPZDohrPrecond(TPZDohrMatrix<TVar, TSubStruct> &origin, TPZAutoPointer<TPZDohrAssembly<TVar> > assemble)
 : TPZMatrix<TVar>(origin), fGlobal(origin.SubStructures()), fCoarse(0), fNumCoarse(origin.NumCoarse()), fNumThreads(0), fAssemble(assemble)
 {

--- a/SubStruct/tpzdohrprecond.h
+++ b/SubStruct/tpzdohrprecond.h
@@ -42,7 +42,9 @@ class TPZDohrPrecond : public TPZMatrix<TVar>
 	
 	TPZAutoPointer<TPZDohrAssembly<TVar> > fAssemble;
 	
-    //
+	int64_t Size() const override;
+  TVar* &Elem() override;
+  const TVar* Elem() const override;
     
 public:
     /** @brief Constructor with matrix */

--- a/SubStruct/tpzdohrprecond.h
+++ b/SubStruct/tpzdohrprecond.h
@@ -64,7 +64,21 @@ public:
     {
         return fGlobal;
     }
-	
+
+	void CopyFrom(const TPZMatrix<TVar> *  mat) override        
+  {                                                           
+    auto *from = dynamic_cast<const TPZDohrPrecond<TVar,TSubStruct> *>(mat);                
+    if (from) {                                               
+      *this = *from;                                          
+    }                                                         
+    else                                                      
+      {                                                       
+        PZError<<__PRETTY_FUNCTION__;                         
+        PZError<<"\nERROR: Called with incompatible type\n."; 
+        PZError<<"Aborting...\n";                             
+        DebugStop();                                          
+      }                                                       
+  }
 	/** @brief Initialize the necessary datastructures */
 	/** It will compute the coarse matrix, coarse residual and any other necessary data structures */
 	void Initialize();

--- a/SubStruct/tpzdohrprecond.h
+++ b/SubStruct/tpzdohrprecond.h
@@ -57,6 +57,7 @@ public:
     ~TPZDohrPrecond();
     
 	// CLONEDEF(TPZDohrPrecond)
+  inline TPZDohrPrecond*NewMatrix() const override {return new TPZDohrPrecond{};}
 	virtual TPZMatrix<TVar>*Clone() const  override { return new TPZDohrPrecond(*this); }
     
     /** @brief The matrix class is a placeholder for a list of substructures */

--- a/SubStruct/tpzdohrsubstructCondense.cpp
+++ b/SubStruct/tpzdohrsubstructCondense.cpp
@@ -47,7 +47,7 @@ void TPZDohrSubstructCondense<TVar>::Contribute_Kc(TPZMatrix<TVar> &Kc, TPZVec<i
 	int j;
 	for (i=0;i<fCoarseNodes.NElements();i++) {
 		for (j=0;j<fCoarseNodes.NElements();j++) {
-			if ((Kc.IsSimetric() && coarseindex[j] >= coarseindex[i]) || !Kc.IsSimetric()) {
+			if ((Kc.IsSymmetric() && coarseindex[j] >= coarseindex[i]) || !Kc.IsSymmetric()) {
 				Kc(coarseindex[i],coarseindex[j]) += fKCi(i,j);				
 			}
 		}

--- a/UnitTest_PZ/TestMatrix/TestMatrix.cpp
+++ b/UnitTest_PZ/TestMatrix/TestMatrix.cpp
@@ -92,6 +92,21 @@ void TestingMultiplyWithAutoFill(int dim, int symmetric);
  * @note Process: build square matrix with randomic values, compute its square twice using Multiply function with two different copies of itself and checks whether the result is the same
  */
 
+/*
+Test Add operation
+*/
+template <class matx, class TVar>
+void TestingAdd(int row, int col, int symmetric);
+/*
+Test Subtract operation
+*/
+template <class matx, class TVar>
+void TestingSubtract(int row, int col, int symmetric);
+/*
+Test MultiplyByScalar operation
+*/
+template <class matx, class TVar>
+void TestingMultiplyByScalar(int row, int col, int symmetric);
 /**
  * Check if the result is a identity matrix.
  */
@@ -260,6 +275,95 @@ void TestSVD(int nrows, int ncols);
         }
     }
 
+  template<class TVar>
+    void Add(){
+      for (auto dim = 5; dim < 100; dim += 500) {
+          SECTION("TPZFMatrix"){
+              TestingAdd<TPZFMatrix<TVar>, TVar>(10, dim, 0);
+          }
+          SECTION("TPZSFMatrix"){
+              TestingAdd<TPZSFMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+          SECTION("TPZFBMatrix"){
+              TestingAdd<TPZFBMatrix<TVar>,TVar>(dim, dim, 0);
+          }
+          SECTION("TPZSBMatrix"){
+              TestingAdd<TPZSBMatrix<TVar>,TVar>(dim, dim,1);
+          }
+          SECTION("TPZFYsmpMatrix"){
+              TestingAdd<TPZFYsmpMatrix<TVar>, TVar>(10, dim, 0);
+          }
+          SECTION("TPZSYsmpMatrix"){
+              TestingAdd<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+          // SECTION("TPZSkylNSymMatrix"){
+          //     TestingAdd<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, 0);
+          // }
+          SECTION("TPZSkylMatrix"){
+              TestingAdd<TPZSkylMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+      }
+    }
+
+  template<class TVar>
+    void Subtract(){
+      for (auto dim = 5; dim < 100; dim += 500) {
+          SECTION("TPZFMatrix"){
+              TestingSubtract<TPZFMatrix<TVar>, TVar>(10, dim, 0);
+          }
+          SECTION("TPZSFMatrix"){
+              TestingSubtract<TPZSFMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+          SECTION("TPZFBMatrix"){
+              TestingSubtract<TPZFBMatrix<TVar>,TVar>(dim, dim, 0);
+          }
+          SECTION("TPZSBMatrix"){
+              TestingSubtract<TPZSBMatrix<TVar>,TVar>(dim, dim,1);
+          }
+          SECTION("TPZFYsmpMatrix"){
+              TestingSubtract<TPZFYsmpMatrix<TVar>, TVar>(10, dim, 0);
+          }
+          SECTION("TPZSYsmpMatrix"){
+              TestingSubtract<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+          // SECTION("TPZSkylNSymMatrix"){
+          //     TestingSubtract<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, 0);
+          // }
+          SECTION("TPZSkylMatrix"){
+              TestingSubtract<TPZSkylMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+      }
+    }
+template<class TVar>
+    void MultiplyByScalar(){
+      for (auto dim = 5; dim < 100; dim += 500) {
+          SECTION("TPZFMatrix"){
+              TestingMultiplyByScalar<TPZFMatrix<TVar>, TVar>(10, dim, 0);
+          }
+          SECTION("TPZSFMatrix"){
+              TestingMultiplyByScalar<TPZSFMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+          SECTION("TPZFBMatrix"){
+              TestingMultiplyByScalar<TPZFBMatrix<TVar>,TVar>(dim, dim, 0);
+          }
+          SECTION("TPZSBMatrix"){
+              TestingMultiplyByScalar<TPZSBMatrix<TVar>,TVar>(dim, dim,1);
+          }
+          SECTION("TPZFYsmpMatrix"){
+              TestingMultiplyByScalar<TPZFYsmpMatrix<TVar>, TVar>(10, dim, 0);
+          }
+          SECTION("TPZSYsmpMatrix"){
+              TestingMultiplyByScalar<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+          // SECTION("TPZSkylNSymMatrix"){
+          //     TestingMultiplyByScalar<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, 0);
+          // }
+          SECTION("TPZSkylMatrix"){
+              TestingMultiplyByScalar<TPZSkylMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+      }
+    }
+  
     template<class TVar>
     void MultiplyTranspose(){
       for (auto dim = 5; dim < 100; dim += 500) {
@@ -486,6 +590,39 @@ TEMPLATE_TEST_CASE("Inverse (CPLX)","[matrix_tests]",
     testmatrix::Inverse<TestType>();
 }
 
+TEMPLATE_TEST_CASE("Add","[matrix_tests]",
+                   float,
+                   double,
+                   long double,
+                   std::complex<float>,
+                   std::complex<double>,
+                   std::complex<long double>
+                   ) {
+    testmatrix::Add<TestType>();
+}
+
+TEMPLATE_TEST_CASE("Subtract","[matrix_tests]",
+                   float,
+                   double,
+                   long double,
+                   std::complex<float>,
+                   std::complex<double>,
+                   std::complex<long double>
+                   ) {
+    testmatrix::Subtract<TestType>();
+}
+
+TEMPLATE_TEST_CASE("MultiplyByScalar","[matrix_tests]",
+                   float,
+                   double,
+                   long double,
+                   std::complex<float>,
+                   std::complex<double>,
+                   std::complex<long double>
+                   ) {
+    testmatrix::MultiplyByScalar<TestType>();
+}
+
 TEMPLATE_TEST_CASE("Multiply transpose (REAL)","[matrix_tests]",
                    float,
                    double,
@@ -493,6 +630,7 @@ TEMPLATE_TEST_CASE("Multiply transpose (REAL)","[matrix_tests]",
                    ) {
     testmatrix::MultiplyTranspose<TestType>();
 }
+
 TEMPLATE_TEST_CASE("Multiply transpose (CPLX)","[matrix_tests]",
                    std::complex<float>,
                    std::complex<double>,
@@ -654,12 +792,12 @@ void CheckDiagonalDominantMatrix(matx &matr) {
         sum = 0.0;
         for (int j = 0; j < matr.Cols(); j++) {
             if (i != j)
-                sum += fabs(matr.GetVal(i, j));
+                sum += fabs(matr.Get(i, j));
         }
-        CAPTURE(fabs(matr.GetVal(i,i)));
+        CAPTURE(fabs(matr.Get(i,i)));
         CAPTURE(sum);
-        REQUIRE(fabs(matr.GetVal(i, i)) > sum);
-        if (!(fabs(matr.GetVal(i, i)) > sum)) {
+        REQUIRE(fabs(matr.Get(i, i)) > sum);
+        if (!(fabs(matr.Get(i, i)) > sum)) {
             std::cout << "line i " << i << " failed\n";
             // matr.Print("matrix = ", std::cout, EMathematicaInput);
             return;
@@ -688,13 +826,13 @@ void TestGeneratingHermitianMatrix() {
     for (auto i = 0; i < nrows; i++) {
         auto j = i;
         if constexpr (is_complex<TVar>::value){
-            CAPTURE(i,j,mat.GetVal(i,j));
-            REQUIRE(mat.GetVal(i,j).imag() == (RTVar)0);
+            CAPTURE(i,j,mat.Get(i,j));
+            REQUIRE(mat.Get(i,j).imag() == (RTVar)0);
         }
         j++;
         for(; j < ncols; j++){
-            CAPTURE(i,j,mat.GetVal(i,j));
-            REQUIRE(mat.GetVal(i,j)-std::conj(mat.GetVal(j,i)) == (TVar)0);
+            CAPTURE(i,j,mat.Get(i,j));
+            REQUIRE(mat.Get(i,j)-std::conj(mat.Get(j,i)) == (TVar)0);
         }
     }
 }
@@ -703,6 +841,7 @@ template <class matx, class TVar>
 void TestingInverseWithAutoFill(int dim, int symmetric, DecomposeType dec) {
   int i, j;
   auto oldPrecision = Catch::StringMaker<RTVar>::precision;
+  Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
   matx ma;
   ma.AutoFill(dim, dim, symmetric);  
   // Making ma copy because ma is modified by Inverse method (it's decomposed)
@@ -719,7 +858,7 @@ void TestingInverseWithAutoFill(int dim, int symmetric, DecomposeType dec) {
   for (i = 0; i < dim; i++) {
       for (j = 0; j < dim; j++) {
           RTVar diff =
-              fabs(cpma.GetVal(i, j) - res.GetVal(i, j));
+              fabs(cpma.Get(i, j) - res.Get(i, j));
         
           bool loccheck = IsZero(diff / (RTVar) 10.);
           if (loccheck == false) {
@@ -746,11 +885,12 @@ void TestingMultiplyOperatorWithAutoFill(int dim, int symmetric) {
     square2 = duplicate*duplicate;
     square = ma*duplicate;
     auto oldPrecision = Catch::StringMaker<RTVar>::precision;
+    Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
     // Checking whether both matrices are equal
     bool check = true;
     for (int i = 0; i < dim; i++) {
         for (int j = 0; j < dim; j++) {
-            RTVar diff = fabs(square.GetVal(i, j) - square2.GetVal(i, j));
+            RTVar diff = fabs(square.Get(i, j) - square2.Get(i, j));
             if (!IsZero(diff)) {
                 CAPTURE(i,j,diff);
                 check = false;
@@ -774,6 +914,7 @@ void TestingMultiplyWithAutoFill(int dim, int symmetric) {
     ma.Multiply(duplicate, square);
     duplicate.Multiply(duplicate, square2);
     auto oldPrecision = Catch::StringMaker<RTVar>::precision;
+    Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
     // Checking whether result matrix is the identity matrix
     bool check = true;
     constexpr RTVar tol = [](){
@@ -797,6 +938,99 @@ void TestingMultiplyWithAutoFill(int dim, int symmetric) {
     Catch::StringMaker<RTVar>::precision = oldPrecision;
 }
 
+template <class matx, class TVar>
+void TestingAdd(int row, int col, int symmetric) {
+  auto oldPrecision = Catch::StringMaker<RTVar>::precision;
+  Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
+  matx ma1, res;
+  ma1.AutoFill(row, col, symmetric);
+  //this is to ensure that they have the same sparsity pattern
+  matx ma2(ma1);
+
+  
+  ma1.Add(ma2,res);
+    
+  bool check = true;
+  constexpr RTVar tol = [](){
+    if constexpr (std::is_same_v<RTVar,float>) return (RTVar)10;
+    else return (RTVar)1;
+  }();
+  for (int i = 0; i < col; i++) {
+    for (int j = 0; (j < col) && check; j++) {
+      CAPTURE(i,j,res.Get(i,j),(TVar)2*ma1.Get(i,j));
+      if (!IsZero((res.Get(i, j)-(ma1.Get(i,j)+ma2.Get(i,j)))/tol)) {
+        check = false;
+      }
+      REQUIRE(check);
+    }
+  }
+  Catch::StringMaker<RTVar>::precision = oldPrecision;
+}
+
+template <class matx, class TVar>
+void TestingSubtract(int row, int col, int symmetric) {
+  auto oldPrecision = Catch::StringMaker<RTVar>::precision;
+  Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
+  matx ma1, res;
+  ma1.AutoFill(row, col, symmetric);
+  //this is to ensure that they have the same sparsity pattern
+  matx ma2(ma1);
+
+  
+  ma1.Subtract(ma2,res);
+    
+  bool check = true;
+  constexpr RTVar tol = [](){
+    if constexpr (std::is_same_v<RTVar,float>) return (RTVar)10;
+    else return (RTVar)1;
+  }();
+  for (int i = 0; i < col; i++) {
+    for (int j = 0; (j < col) && check; j++) {
+      CAPTURE(i,j,res.Get(i,j));
+      if (!IsZero((res.Get(i, j)-(ma1.Get(i,j)-ma2.Get(i,j)))/tol)) {
+        check = false;
+      }
+      REQUIRE(check);
+    }
+  }
+  Catch::StringMaker<RTVar>::precision = oldPrecision;
+}
+
+template <class matx, class TVar>
+void TestingMultiplyByScalar(int row, int col, int symmetric) {
+  auto oldPrecision = Catch::StringMaker<RTVar>::precision;
+  Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
+  matx ma1, res;
+  ma1.AutoFill(row, col, symmetric);
+  
+  const TVar val = [](){
+    constexpr RTVar lower_bound = 0;
+    constexpr RTVar upper_bound = 1;
+    static std::uniform_real_distribution<RTVar> unif(lower_bound,upper_bound);
+    static std::default_random_engine re;
+    const TVar a_random = (TVar)unif(re);
+    return a_random;
+  }();
+
+  
+  ma1.MultiplyByScalar(val,res);
+    
+  bool check = true;
+  constexpr RTVar tol = [](){
+    if constexpr (std::is_same_v<RTVar,float>) return (RTVar)10;
+    else return (RTVar)1;
+  }();
+  for (int i = 0; i < col; i++) {
+    for (int j = 0; (j < col) && check; j++) {
+      CAPTURE(i,j,res.Get(i,j),ma1.Get(i,j)*val);
+      if (!IsZero((res.Get(i, j)-(ma1.Get(i,j)*val))/tol)) {
+        check = false;
+      }
+      REQUIRE(check);
+    }
+  }
+  Catch::StringMaker<RTVar>::precision = oldPrecision;
+}
 
 template <class matx, class TVar>
 void TestingTransposeMultiply(int row, int col, int symmetric) {
@@ -859,7 +1093,7 @@ void TestingTransposeWithAutoFill(int rows, int cols, int symmetric) {
     /// Checking whether the res matrix is identical to m1 matrix
     for (i = 0; i < rows; i++)
         for (j = 0; j < cols; j++)
-            REQUIRE(IsZero(ma.GetVal(i, j) - matransptransp.GetVal(i, j)));
+            REQUIRE(IsZero(ma.Get(i, j) - matransptransp.Get(i, j)));
 }
 
 template <class matx, class TVar>
@@ -969,7 +1203,7 @@ matx ma;
     TPZFMatrix< CTVar > cpma(dim, dim);
     for (int i = 0; i < dim; i++) {
         for (int j = 0; j < dim; j++) {
-            cpma(i, j) = ma.GetVal(i, j);
+            cpma(i, j) = ma.Get(i, j);
         }
     }
 

--- a/UnitTest_PZ/TestMatrix/TestMatrix.cpp
+++ b/UnitTest_PZ/TestMatrix/TestMatrix.cpp
@@ -107,6 +107,19 @@ Test MultiplyByScalar operation
 */
 template <class matx, class TVar>
 void TestingMultiplyByScalar(int row, int col, int symmetric);
+
+template <class matx, class TVar>
+void TestingAddOperator(int row, int col, int symmetric);
+/*
+Test Subtract operation
+*/
+template <class matx, class TVar>
+void TestingSubtractOperator(int row, int col, int symmetric);
+/*
+Test MultiplyByScalar operation
+*/
+template <class matx, class TVar>
+void TestingMultiplyByScalarOperator(int row, int col, int symmetric);
 /**
  * Check if the result is a identity matrix.
  */
@@ -360,6 +373,94 @@ template<class TVar>
           // }
           SECTION("TPZSkylMatrix"){
               TestingMultiplyByScalar<TPZSkylMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+      }
+    }
+template<class TVar>
+    void AddOperator(){
+      for (auto dim = 5; dim < 100; dim += 500) {
+          SECTION("TPZFMatrix"){
+              TestingAddOperator<TPZFMatrix<TVar>, TVar>(10, dim, 0);
+          }
+          SECTION("TPZSFMatrix"){
+              TestingAddOperator<TPZSFMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+          SECTION("TPZFBMatrix"){
+              TestingAddOperator<TPZFBMatrix<TVar>,TVar>(dim, dim, 0);
+          }
+          SECTION("TPZSBMatrix"){
+              TestingAddOperator<TPZSBMatrix<TVar>,TVar>(dim, dim,1);
+          }
+          SECTION("TPZFYsmpMatrix"){
+              TestingAddOperator<TPZFYsmpMatrix<TVar>, TVar>(10, dim, 0);
+          }
+          SECTION("TPZSYsmpMatrix"){
+              TestingAddOperator<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+          // SECTION("TPZSkylNSymMatrix"){
+          //     TestingAddOperator<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, 0);
+          // }
+          SECTION("TPZSkylMatrix"){
+              TestingAddOperator<TPZSkylMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+      }
+    }
+
+  template<class TVar>
+    void SubtractOperator(){
+      for (auto dim = 5; dim < 100; dim += 500) {
+          SECTION("TPZFMatrix"){
+              TestingSubtractOperator<TPZFMatrix<TVar>, TVar>(10, dim, 0);
+          }
+          SECTION("TPZSFMatrix"){
+              TestingSubtractOperator<TPZSFMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+          SECTION("TPZFBMatrix"){
+              TestingSubtractOperator<TPZFBMatrix<TVar>,TVar>(dim, dim, 0);
+          }
+          SECTION("TPZSBMatrix"){
+              TestingSubtractOperator<TPZSBMatrix<TVar>,TVar>(dim, dim,1);
+          }
+          SECTION("TPZFYsmpMatrix"){
+              TestingSubtractOperator<TPZFYsmpMatrix<TVar>, TVar>(10, dim, 0);
+          }
+          SECTION("TPZSYsmpMatrix"){
+              TestingSubtractOperator<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+          // SECTION("TPZSkylNSymMatrix"){
+          //     TestingSubtractOperator<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, 0);
+          // }
+          SECTION("TPZSkylMatrix"){
+              TestingSubtractOperator<TPZSkylMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+      }
+    }
+template<class TVar>
+    void MultiplyByScalarOperator(){
+      for (auto dim = 5; dim < 100; dim += 500) {
+          SECTION("TPZFMatrix"){
+              TestingMultiplyByScalarOperator<TPZFMatrix<TVar>, TVar>(10, dim, 0);
+          }
+          SECTION("TPZSFMatrix"){
+              TestingMultiplyByScalarOperator<TPZSFMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+          SECTION("TPZFBMatrix"){
+              TestingMultiplyByScalarOperator<TPZFBMatrix<TVar>,TVar>(dim, dim, 0);
+          }
+          SECTION("TPZSBMatrix"){
+              TestingMultiplyByScalarOperator<TPZSBMatrix<TVar>,TVar>(dim, dim,1);
+          }
+          SECTION("TPZFYsmpMatrix"){
+              TestingMultiplyByScalarOperator<TPZFYsmpMatrix<TVar>, TVar>(10, dim, 0);
+          }
+          SECTION("TPZSYsmpMatrix"){
+              TestingMultiplyByScalarOperator<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, 1);
+          }
+          // SECTION("TPZSkylNSymMatrix"){
+          //     TestingMultiplyByScalarOperator<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, 0);
+          // }
+          SECTION("TPZSkylMatrix"){
+              TestingMultiplyByScalarOperator<TPZSkylMatrix<TVar>, TVar>(dim, dim, 1);
           }
       }
     }
@@ -622,6 +723,40 @@ TEMPLATE_TEST_CASE("MultiplyByScalar","[matrix_tests]",
                    ) {
     testmatrix::MultiplyByScalar<TestType>();
 }
+
+TEMPLATE_TEST_CASE("AddOperator","[matrix_tests]",
+                   float,
+                   double,
+                   long double,
+                   std::complex<float>,
+                   std::complex<double>,
+                   std::complex<long double>
+                   ) {
+    testmatrix::AddOperator<TestType>();
+}
+
+TEMPLATE_TEST_CASE("SubtractOperator","[matrix_tests]",
+                   float,
+                   double,
+                   long double,
+                   std::complex<float>,
+                   std::complex<double>,
+                   std::complex<long double>
+                   ) {
+    testmatrix::SubtractOperator<TestType>();
+}
+
+TEMPLATE_TEST_CASE("MultiplyByScalarOperator","[matrix_tests]",
+                   float,
+                   double,
+                   long double,
+                   std::complex<float>,
+                   std::complex<double>,
+                   std::complex<long double>
+                   ) {
+    testmatrix::MultiplyByScalarOperator<TestType>();
+}
+
 
 TEMPLATE_TEST_CASE("Multiply transpose (REAL)","[matrix_tests]",
                    float,
@@ -1032,6 +1167,102 @@ void TestingMultiplyByScalar(int row, int col, int symmetric) {
   Catch::StringMaker<RTVar>::precision = oldPrecision;
 }
 
+template <class matx, class TVar>
+void TestingAddOperator(int row, int col, int symmetric) {
+  auto oldPrecision = Catch::StringMaker<RTVar>::precision;
+  Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
+  matx ma1;
+  ma1.AutoFill(row, col, symmetric);
+  //this is to ensure that they have the same sparsity pattern
+  matx ma2(ma1);
+
+  
+  
+  TPZMatrix<TVar> &&res = ma1 + ma2;
+    
+  bool check = true;
+  constexpr RTVar tol = [](){
+    if constexpr (std::is_same_v<RTVar,float>) return (RTVar)10;
+    else return (RTVar)1;
+  }();
+  for (int i = 0; i < col; i++) {
+    for (int j = 0; (j < col) && check; j++) {
+      CAPTURE(i,j,res.Get(i,j),(TVar)2*ma1.Get(i,j));
+      if (!IsZero((res.Get(i, j)-(ma1.Get(i,j)+ma2.Get(i,j)))/tol)) {
+        check = false;
+      }
+      REQUIRE(check);
+    }
+  }
+  Catch::StringMaker<RTVar>::precision = oldPrecision;
+}
+
+template <class matx, class TVar>
+void TestingSubtractOperator(int row, int col, int symmetric) {
+  auto oldPrecision = Catch::StringMaker<RTVar>::precision;
+  Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
+  matx ma1;
+  ma1.AutoFill(row, col, symmetric);
+  //this is to ensure that they have the same sparsity pattern
+  matx ma2(ma1);
+
+  
+  TPZMatrix<TVar>&& res = ma1-ma2;
+    
+  bool check = true;
+  constexpr RTVar tol = [](){
+    if constexpr (std::is_same_v<RTVar,float>) return (RTVar)10;
+    else return (RTVar)1;
+  }();
+  for (int i = 0; i < col; i++) {
+    for (int j = 0; (j < col) && check; j++) {
+      CAPTURE(i,j,res.Get(i,j));
+      if (!IsZero((res.Get(i, j)-(ma1.Get(i,j)-ma2.Get(i,j)))/tol)) {
+        check = false;
+      }
+      REQUIRE(check);
+    }
+  }
+  Catch::StringMaker<RTVar>::precision = oldPrecision;
+}
+
+template <class matx, class TVar>
+void TestingMultiplyByScalarOperator(int row, int col, int symmetric) {
+  auto oldPrecision = Catch::StringMaker<RTVar>::precision;
+  Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
+  matx ma1;
+  ma1.AutoFill(row, col, symmetric);
+  
+  const TVar val = [](){
+    constexpr RTVar lower_bound = 0;
+    constexpr RTVar upper_bound = 1;
+    static std::uniform_real_distribution<RTVar> unif(lower_bound,upper_bound);
+    static std::default_random_engine re;
+    const TVar a_random = (TVar)unif(re);
+    return a_random;
+  }();
+
+  
+  TPZMatrix<TVar>&& res = ma1 * val;
+    
+  bool check = true;
+  constexpr RTVar tol = [](){
+    if constexpr (std::is_same_v<RTVar,float>) return (RTVar)10;
+    else return (RTVar)1;
+  }();
+  for (int i = 0; i < col; i++) {
+    for (int j = 0; (j < col) && check; j++) {
+      CAPTURE(i,j,res.Get(i,j),ma1.Get(i,j)*val);
+      if (!IsZero((res.Get(i, j)-(ma1.Get(i,j)*val))/tol)) {
+        check = false;
+      }
+      REQUIRE(check);
+    }
+  }
+  Catch::StringMaker<RTVar>::precision = oldPrecision;
+}
+
+  
 template <class matx, class TVar>
 void TestingTransposeMultiply(int row, int col, int symmetric) {
     // ma times inv must to be a identity matrix

--- a/UnitTest_PZ/TestStruct/StructMatrixUnitTest.cpp
+++ b/UnitTest_PZ/TestStruct/StructMatrixUnitTest.cpp
@@ -208,7 +208,7 @@ namespace structTest{
     const int nc = matParallel->Cols();
   
     TPZFMatrix<STATE> matDiff(nr,nc, 0.0);
-    matSerial->Substract(matParallel, matDiff);
+    matSerial->Subtract(matParallel, matDiff);
     const auto normDiff = Norm(matDiff);
     auto oldPrecision = Catch::StringMaker<STATE>::precision;
     CAPTURE(normDiff);
@@ -245,7 +245,7 @@ namespace structTest{
     const int nc = mat2->Cols();
   
     TPZFMatrix<STATE> matDiff(nr,nc, 0.0);
-    mat1->Substract(mat2, matDiff);
+    mat1->Subtract(mat2, matDiff);
     const auto normDiff = Norm(matDiff);
     auto oldPrecision = Catch::StringMaker<STATE>::precision;
     CAPTURE(normDiff);

--- a/Util/pzvec.h
+++ b/Util/pzvec.h
@@ -171,13 +171,13 @@ public:
 	
 	/** @brief Casting operator. Returns The fStore pointer. */
 	//operator T*() const { return fStore; }
-    
-    /** @brief Returns a pointer to the first element */
-    T *begin() const;
-    
-    /** @brief Returns a pointer to the last+1 element */
-    T *end() const;
-	
+  /** @{ */
+  /** @brief Returns a pointer to the first element */
+  T *begin() const;
+  T *&begin();
+  /** @{ */
+  /** @brief Returns a pointer to the last+1 element */
+  T *end() const;
 	/**
 	 * @brief Will fill the elements of the vector with a copy object.
 	 * @param copy object which will be copied
@@ -505,6 +505,10 @@ T *TPZVec<T>::begin() const {
     return fStore;
 }
 
+template<class T>
+T *&TPZVec<T>::begin() {
+    return fStore;
+}
 template<class T>
 T *TPZVec<T>::end() const {
     return fStore+fNElements;


### PR DESCRIPTION
- Move constructor/assignment operator
- Fixed destructor of `TPZPardisoSolver`
- Fixed `IsSimetric` instances to `IsSymmetric`
- Fixed `Substract` to `Subtract`
- Added `Subtract` methods to many matrices types: now, when they are called with matrices of the same type, the result is no longer a `TPZFMatrix`
- Added `Add` methods to many matrices types (same reasoning as `Subtract`)
- Added `MultiplyByScalar` method
- Added Unit Tests for these three new methods
- Added `+`,`-` and `*` operators for all appropriate matrix types
- Added Unit Tests for these new operators
- Added `NewMatrix` method for creating an empty matrix of a given type