### PR TITLE
Logging in a single line

### DIFF
--- a/Util/pzlog.h
+++ b/Util/pzlog.h
@@ -140,18 +140,48 @@ private:
 //the following macros are for internal usage
 
 /// Define log for debug
-#define LOGPZ_DEBUG(A,B) pzinternal::LogPzDebugImpl(A,B,__FILE__,__LINE__);
+#define LOGPZ_DEBUG(logger, msg) { \
+   if (logger.isDebugEnabled()) {\
+      std::stringstream msg_stream; \
+      msg_stream << msg; \
+      pzinternal::LogPzDebugImpl(logger, msg_stream.str(),__FILE__,__LINE__); \
+   }\
+}
 
 /// Define log for info
-#define LOGPZ_INFO(A,B) pzinternal::LogPzInfoImpl(A,B,__FILE__,__LINE__);
+#define LOGPZ_INFO(logger, msg) { \
+   if (logger.isInfoEnabled()) {\
+      std::stringstream msg_stream; \
+      msg_stream << msg; \
+      pzinternal::LogPzInfoImpl(logger, msg_stream.str(),__FILE__,__LINE__); \
+   }\
+}
 
 /// Define log for warnings
-#define LOGPZ_WARN(A,B) pzinternal::LogPzWarnImpl(A,B,__FILE__,__LINE__);
+#define LOGPZ_WARN(logger, msg) { \
+   if (logger.isWarnEnabled()) {\
+      std::stringstream msg_stream; \
+      msg_stream << msg; \
+      pzinternal::LogPzWarnImpl(logger, msg_stream.str(),__FILE__,__LINE__); \
+   }\
+}
 
 /// Define log for errors
-#define LOGPZ_ERROR(A,B) pzinternal::LogPzErrorImpl(A,B,__FILE__,__LINE__);
+#define LOGPZ_ERROR(logger, msg) { \
+   if (logger.isErrorEnabled()) {\
+      std::stringstream msg_stream; \
+      msg_stream << msg; \
+      pzinternal::LogPzErrorImpl(logger, msg_stream.str(),__FILE__,__LINE__); \
+   }\
+}
 /// Define log for fatal errors
-#define LOGPZ_FATAL(A,B) pzinternal::LogPzFatalImpl(A,B,__FILE__,__LINE__);
+#define LOGPZ_FATAL(logger, msg) { \
+   if (logger.isFatalEnabled()) {\
+      std::stringstream msg_stream; \
+      msg_stream << msg; \
+      pzinternal::LogPzFatalImpl(logger, msg_stream.str(),__FILE__,__LINE__); \
+   }\
+}
 
 
 #else
@@ -174,21 +204,21 @@ public:
 };
 // Just to allow the macros being called regardless
 // of whether the log is enabled or not
-#define LOGPZ_DEBUG(A,B)
+#define LOGPZ_DEBUG(logger, msg)
 
-#define LOGPZ_INFO(A,B)
+#define LOGPZ_INFO(logger, msg)
 
-#define LOGPZ_WARN(A,B)
+#define LOGPZ_WARN(logger, msg)
 
-#define LOGPZ_ERROR(A,B)   \
+#define LOGPZ_ERROR(logger, msg)   \
 {                          \
-  std::cout<<B<<std::endl; \
+  std::cout<<msg<<std::endl; \
   DebugStop();             \
 }
 
-#define LOGPZ_FATAL(A,B)   \
+#define LOGPZ_FATAL(logger, msg)   \
 {                          \
-  std::cout<<B<<std::endl; \
+  std::cout<<msg<<std::endl; \
   DebugStop();             \
 }
 


### PR DESCRIPTION
Yes, I said it. :smile: 
I was discussing some Log changes with @orlandini today, when the idea came up.
I'm proposing that we write Log macros in such a way that we can hide the `isDebugEnabled()` condition, and the log message will only get built if the condition passes. The alterations put in place by @orlandini and @gustavobat also make the `#ifdef PZ_LOG` replaceable by a `if(isDebugEnabled){...}`. This, together with my macro proposal, allows us to Log in a single line in multiple situations.

Here's the macro
https://github.com/labmec/neopz/blob/6b283262807ca303b75565bc9e8ada9ee1064e8f/Util/pzlog.h#L142-L149

Remember, macro is a snippet replacement by the compiler, so this should enable us to log in a syntax like:
```cpp
LOGPZ_DEBUG(logger, " x = " << x << "\n y = " << y << "\n x+y = " << x+y)
```
but not touching the string building if `isDebugEnabled()` evaluates to false. If PZ is compiled without LOG4CXX, Gustavo and Fran's alterations just completely ignores the log call.

Note that this can easily be extended to complex classes by simply overloading the `operator<<` to call on that class' `Print(ostream)` function.

I checked CompilerExplorer to confirm with the following snippet
```cpp
#include <sstream>

#define LOGPZ_DEBUG(logger,msg) { \
   if (logger.isDebugEnabled()) {\
      std::stringstream msg_stream; \
      msg_stream << msg; \
   }\
}

class pzlogger{
    bool fdebug_Q = true;

public:
    bool isDebugEnabled() const {
        return fdebug_Q;
    }
};

int main() {
    pzlogger logger;
    LOGPZ_DEBUG(logger, "test" << 1 << "using macro");
    return 0;
}
```

But I admit that my assembly knowledge is likely the closest to zero within the reviewers I'm setting in this PR. So you're welcomed to double check it.

Please, give me some input. This was just a first draft, and I can see room for more improvements. Specially because we move a string through a few string streams (there's the first one in my macro, then it gets copied into a local string for `LogPzDebugImpl()`, which passes it to a `log4cxx::MessageBuffer`).

@philippedevloo you are the one true fan of Logging, so we eagerly await your review. 