### PR TITLE
Fixes when copying BC mats

### DIFF
--- a/Material/TPZBndCond.h
+++ b/Material/TPZBndCond.h
@@ -35,10 +35,8 @@ public :
 	//! Set type of BC.
 	void SetType(int type){ this->fType = type; }
     //! Material identifier
-    [[nodiscard]] int Id() const {
-        return fMaterial->Id();
-    }
-    
+    [[nodiscard]] virtual int Id() const = 0;
+
     [[nodiscard]] int ClassId() const override;
     //! Whether the boundary condition has a forcing function
     [[nodiscard]] virtual bool HasForcingFunctionBC() const = 0;

--- a/Material/TPZBndCondBase.h
+++ b/Material/TPZBndCondBase.h
@@ -35,9 +35,9 @@ class TPZBndCondBase :
 
     void SetMaterial(TPZMaterial *) final;
     
-    int Dimension() const final
+    [[nodiscard]] int Dimension() const final
     {return this->fMaterial->Dimension();}
-    int NStateVariables() const final
+    [[nodiscard]] int NStateVariables() const final
     {return this->fMaterial->NStateVariables();}
 
     [[nodiscard]] int Id() const override {

--- a/Material/TPZBndCondBase.h
+++ b/Material/TPZBndCondBase.h
@@ -39,7 +39,10 @@ class TPZBndCondBase :
     {return this->fMaterial->Dimension();}
     int NStateVariables() const final
     {return this->fMaterial->NStateVariables();}
-    
+
+    [[nodiscard]] int Id() const override {
+        return TPZMaterial::Id();
+    }
 };
 
 template<class TVar, class...Interfaces>

--- a/Material/TPZBndCondBase.h
+++ b/Material/TPZBndCondBase.h
@@ -43,6 +43,10 @@ class TPZBndCondBase :
     [[nodiscard]] int Id() const override {
         return TPZMaterial::Id();
     }
+
+    [[nodiscard]] TPZMaterial* NewMaterial() const override {
+        return new TPZBndCondBase(*this);
+    }
 };
 
 template<class TVar, class...Interfaces>


### PR DESCRIPTION
This little PR solves the problem of cloning BCs in the `TPZCompMesh::CopyMaterials` method.

Mainly it:
- Fixes the access of BC mat ids to return its own id instead of the id of its associated material;
- Implements TPZBndCondBase::NewMaterial;
- Changes `TPZCompMesh::CopyMaterials` such that cloned BC's point to **cloned** materials.