### PR TITLE
New TPZNullMaterialCS and a few fixes

### DIFF
--- a/Material/CMakeLists.txt
+++ b/Material/CMakeLists.txt
@@ -31,6 +31,7 @@ set(public_headers
     TPZMatInterfaceCombinedSpaces.h
     #other
     TPZNullMaterial.h
+    TPZNullMaterialCS.h
     TPZLagrangeMultiplier.h
     TPZLagrangeMultiplierCS.h
     )
@@ -61,6 +62,7 @@ set(headers
     TPZMatInterfaceCombinedSpaces.h
     #other
     TPZNullMaterial.h
+    TPZNullMaterialCS.h
     TPZLagrangeMultiplier.h
     TPZLagrangeMultiplierCS.h
    )
@@ -86,6 +88,7 @@ set(sources
     TPZMatInterfaceCombinedSpaces.cpp
     #other
     TPZNullMaterial.cpp
+    TPZNullMaterialCS.cpp
     TPZLagrangeMultiplier.cpp
     TPZLagrangeMultiplierCS.cpp
    )

--- a/Material/TPZNullMaterialCS.cpp
+++ b/Material/TPZNullMaterialCS.cpp
@@ -1,0 +1,56 @@
+//
+// Created by Gustavo A. Batistela on 01/06/2021.
+//
+
+#include "TPZNullMaterialCS.h"
+#include "TPZMaterialDataT.h"
+
+template<class TVar>
+int TPZNullMaterialCS<TVar>::ClassId() const {
+    return Hash("TPZNullMaterial") ^ TBase::ClassId() << 1;
+}
+
+template<class TVar>
+void TPZNullMaterialCS<TVar>::Write(TPZStream &buf, int withclassid) const {
+    TBase::Write(buf, withclassid);
+    if (fDim < 1 || fDim > 3) {
+        DebugStop();
+    }
+    buf.Write(&fDim);
+    buf.Write(&fNState);
+}
+
+template<class TVar>
+void TPZNullMaterialCS<TVar>::Read(TPZStream &buf, void *context) {
+    TBase::Read(buf, context);
+    buf.Read(&fDim);
+    buf.Read(&fNState);
+}
+
+
+template<class TVar>
+void TPZNullMaterialCS<TVar>::FillDataRequirements(TPZVec<TPZMaterialDataT<TVar>> &datavec) const {
+    for (auto i = 0; i < datavec.size(); i++) {
+        datavec[i].SetAllRequirements(false);
+        datavec[i].fActiveApproxSpace = false;
+    }
+}
+
+template<class TVar>
+void TPZNullMaterialCS<TVar>::SetDimension(int dim) {
+#ifdef PZDEBUG
+    if (fDim < 1 || fDim > 3) { DebugStop(); }
+#endif
+    fDim = dim;
+}
+
+template<class TVar>
+void TPZNullMaterialCS<TVar>::Print(std::ostream &out) const {
+    out << __PRETTY_FUNCTION__ << std::endl;
+    TPZMaterial::Print(out);
+    out << "Dimension " << fDim << std::endl;
+    out << "NState " << fNState << std::endl;
+}
+
+template class TPZNullMaterialCS<STATE>;
+template class TPZNullMaterialCS<CSTATE>;

--- a/Material/TPZNullMaterialCS.h
+++ b/Material/TPZNullMaterialCS.h
@@ -1,0 +1,112 @@
+//
+// Created by Gustavo A. Batistela on 01/06/2021.
+//
+
+#ifndef TPZNULLMATERIALCS_H
+#define TPZNULLMATERIALCS_H
+
+#include "TPZMatBase.h"
+#include "TPZMatCombinedSpaces.h"
+
+/**
+   @brief Material used in atomic meshes when working with combined approximation spaces.
+   * It does not compute any contribution or shape functions.
+   */
+template<class TVar=STATE>
+class TPZNullMaterialCS : public TPZMatBase<TVar, TPZMatCombinedSpacesT<TVar>> {
+    using TBase = TPZMatBase<TVar, TPZMatCombinedSpacesT<TVar>>;
+public:
+
+    explicit TPZNullMaterialCS(int matid)
+            : TPZRegisterClassId(&TPZNullMaterialCS::ClassId), TBase(matid) {
+        fDim = 1;
+        fNState = 1;
+    }
+
+    TPZNullMaterialCS(int matid, int dimension, int nstate)
+            : TPZRegisterClassId(&TPZNullMaterialCS::ClassId),
+              TBase(matid) {
+#ifdef PZDEBUG
+        if (dimension < 1 || dimension >3) {
+            DebugStop();
+        }
+#endif
+        fDim = dimension;
+        fNState = nstate;
+    }
+
+    /** @brief Default constructor */
+    TPZNullMaterialCS() = default;
+
+    /** @brief Returns the name of the material */
+    [[nodiscard]] std::string
+    Name() const override { return "TPZNullMaterialCS"; }
+
+    /** @brief Returns the integrable dimension of the material */
+    [[nodiscard]] int Dimension() const override { return fDim; }
+
+    /** @brief Sets the material dimension */
+    void SetDimension(int dim);
+
+    /** @brief Returns the number of state variables associated with the material */
+    [[nodiscard]] int NStateVariables() const override {
+        return fNState;
+    }
+
+    /** @brief Sets the number of state variables */
+    void SetNStateVariables(int nstate) {
+        fNState = nstate;
+    }
+
+    void FillDataRequirements(TPZVec<TPZMaterialDataT<TVar>> &datavec) const override;
+
+    void Solution(const TPZVec<TPZMaterialDataT<TVar>> &datavec, int var,
+                  TPZVec<TVar> &sol) override {}
+
+    void Contribute(const TPZVec<TPZMaterialDataT<TVar>> &datavec, REAL weight,
+                    TPZFMatrix<TVar> &ek, TPZFMatrix<TVar> &ef) override {}
+
+    void ContributeBC(const TPZVec<TPZMaterialDataT<TVar>> &datavec, REAL weight,
+                      TPZFMatrix<TVar> &ek, TPZFMatrix<TVar> &ef,
+                      TPZBndCondT<TVar> &bc) override {}
+
+    /** @brief Prints out the data associated with the material */
+    void Print(std::ostream &out) const override;
+
+    /** @brief Returns the variable index associated with the name */
+    [[nodiscard]] int
+    VariableIndex(const std::string &name) const override { return 0; }
+
+    /**
+	 * @brief Returns the number of variables associated with the variable indexed by var.
+	 * @param var Index variable into the solution, is obtained by calling VariableIndex
+	 */
+    [[nodiscard]] int NSolutionVariables(int var) const override { return 0; }
+
+    /** @brief Unique identifier for serialization purposes */
+    [[nodiscard]] int ClassId() const override;
+
+    /** @brief Saves the element data to a stream */
+    void Write(TPZStream &buf, int withclassid) const override;
+
+    /** @brief Reads the element data from a stream */
+    void Read(TPZStream &buf, void *context) override;
+
+    [[nodiscard]] TPZMaterial *NewMaterial() const override {
+        return new TPZNullMaterialCS(*this);
+    }
+
+protected:
+
+
+    /** @brief Problem dimension */
+    int fDim = -1;
+
+    /// Number of state variables
+    int fNState = 1;
+};
+
+extern template class TPZNullMaterialCS<STATE>;
+extern template class TPZNullMaterialCS<CSTATE>;
+
+#endif //TPZNULLMATERIALCS_H

--- a/Mesh/TPZMultiphysicsInterfaceEl.cpp
+++ b/Mesh/TPZMultiphysicsInterfaceEl.cpp
@@ -799,13 +799,12 @@ void TPZMultiphysicsInterfaceElement::ComputeRequiredDataT(TPZMaterialDataT<TVar
     
     TPZMaterial *mat = Material();
     auto *matInterface =
-       dynamic_cast<TPZMatInterfaceSingleSpace<TVar>*>(mat);
+       dynamic_cast<TPZMatInterfaceCombinedSpaces<TVar>*>(mat);
     if (!matInterface) {
         PZError<<__PRETTY_FUNCTION__;
         PZError<<" requires an interface material.\nAborting...\n";
         DebugStop();
     }
-    matInterface->FillDataRequirementsInterface(data);
     if (data.fNeedsNormal)
     {
         

--- a/Pre/TPZHybridizeHDiv.cpp
+++ b/Pre/TPZHybridizeHDiv.cpp
@@ -22,6 +22,7 @@
 #include "pztrnsform.h"
 #include "tpzintpoints.h"
 #include "TPZNullMaterial.h"
+#include "TPZNullMaterialCS.h"
 
 #include "TPZMultiphysicsCompMesh.h"
 
@@ -601,14 +602,14 @@ void TPZHybridizeHDiv::InsertPeriferalMaterialObjects(TPZCompMesh *cmesh_Hybrid,
     
     if (!cmesh_Hybrid->FindMaterial(fLagrangeInterface)) {
         std::cout<<"LagrangeInterface MatId "<<fLagrangeInterface<<std::endl;
-        auto matPerif = new TPZNullMaterial(fLagrangeInterface);
+        auto matPerif = new TPZNullMaterialCS<STATE>(fLagrangeInterface);
         matPerif->SetNStateVariables(fNState);
         matPerif->SetDimension(dim-1);
         cmesh_Hybrid->InsertMaterialObject(matPerif);
     }
     if (!cmesh_Hybrid->FindMaterial(fHDivWrapMatid)) {
         std::cout<<"HDivWrapMatid MatId "<<fHDivWrapMatid<<std::endl;
-        auto matPerif = new TPZNullMaterial(fHDivWrapMatid);
+        auto matPerif = new TPZNullMaterialCS<STATE>(fHDivWrapMatid);
         matPerif->SetNStateVariables(fNState);
         matPerif->SetDimension(dim-1);
         cmesh_Hybrid->InsertMaterialObject(matPerif);

--- a/Pre/TPZMHMixedMeshControl.cpp
+++ b/Pre/TPZMHMixedMeshControl.cpp
@@ -29,7 +29,7 @@
 #include "TPZMultiphysicsInterfaceEl.h"
 
 #include "TPZVTKGeoMesh.h"
-#include "TPZNullMaterial.h"
+#include "TPZNullMaterialCS.h"
 #include "pzlog.h"
 
 #ifdef PZ_LOG
@@ -121,7 +121,7 @@ void TPZMHMixedMeshControl::InsertPeriferalMaterialObjects()
         return;
     }
     
-    auto *nullmat = new TPZNullMaterial<STATE>(fSkeletonMatId);
+    auto *nullmat = new TPZNullMaterialCS<STATE>(fSkeletonMatId);
     nullmat->SetDimension(mat->Dimension()-1);
     nullmat->SetNStateVariables(nstate);
     fCMesh->InsertMaterialObject(nullmat);


### PR DESCRIPTION
In this PR TPZNullMaterialCS is created to substitute TPZNullMaterial in multiphysics meshes.