### PR TITLE
H1HCurl DeRham compatibility tests

### DIFF
--- a/UnitTest_PZ/TestDeRham/TPZMatDeRhamH1HCurl.cpp
+++ b/UnitTest_PZ/TestDeRham/TPZMatDeRhamH1HCurl.cpp
@@ -10,20 +10,20 @@ void TPZMatDeRhamH1HCurl::Contribute(
   const TPZVec<TPZMaterialDataT<STATE>> &datavec, REAL weight,
   TPZFMatrix<STATE> &ek, TPZFMatrix<STATE> &ef)
 {
-  const TPZFMatrix<REAL> &phiH1 = datavec[fH1MeshIndex].phi;
+  
   const TPZFMatrix<REAL> &gradPhiH1axes = datavec[fH1MeshIndex].dphix;
-  TPZFNMatrix<3,REAL> gradPhiH1(3, phiH1.Rows(), 0.);
+  TPZFNMatrix<3,REAL> gradPhiH1(3, gradPhiH1axes.Rows(), 0.);
   TPZAxesTools<REAL>::Axes2XYZ(gradPhiH1axes, gradPhiH1, datavec[fH1MeshIndex].axes);
   
   TPZFNMatrix<30,REAL> phiHCurl;
   
   TPZHCurlAuxClass::ComputeShape(datavec[fHCurlMeshIndex].fVecShapeIndex,
-                                 phiH1,
+                                 datavec[fHCurlMeshIndex].phi,
                                  datavec[fHCurlMeshIndex].fDeformedDirections,
                                  phiHCurl);
 
   const int nHCurl  = phiHCurl.Rows();
-  const int nH1  = phiH1.Rows();
+  const int nH1  = gradPhiH1.Cols();
   //position of first h1 func
   const int firstH1 = fH1MeshIndex * nHCurl;
   //position of first hcurl func

--- a/UnitTest_PZ/TestDeRham/TPZMatDeRhamH1HCurl.cpp
+++ b/UnitTest_PZ/TestDeRham/TPZMatDeRhamH1HCurl.cpp
@@ -63,3 +63,46 @@ void TPZMatDeRhamH1HCurl::Contribute(
     }
   }
 }
+
+
+int TPZMatDeRhamH1HCurl::VariableIndex(const std::string &name) const
+{
+  if( strcmp(name.c_str(), "SolutionLeft") == 0) return 0;
+  if( strcmp(name.c_str(), "SolutionRight") == 0) return 1;
+  DebugStop();
+  return -1;
+}
+
+int TPZMatDeRhamH1HCurl::NSolutionVariables(int var) const
+{
+  switch (var) {
+  case 0: // SolutionLeft
+    return 1;
+  case 1: // SolutionRight
+    return fDim;
+  default:
+    DebugStop();
+    break;
+  }
+  return 1;
+}
+
+void TPZMatDeRhamH1HCurl::Solution(const TPZVec<TPZMaterialDataT<STATE>> &datavec, int var,
+              TPZVec<STATE> &solout)
+{
+  auto solH1 = datavec[fH1MeshIndex].sol[0];
+  auto solHCurl = datavec[fHCurlMeshIndex].sol[0];
+
+  switch (var) {
+  case 0: {
+    solout = solH1;
+    break;
+  }
+  case 1: {
+    solout = solHCurl;
+    break;
+  }
+  default:
+    DebugStop();
+  }
+}

--- a/UnitTest_PZ/TestDeRham/TPZMatDeRhamH1HCurl.h
+++ b/UnitTest_PZ/TestDeRham/TPZMatDeRhamH1HCurl.h
@@ -51,19 +51,19 @@ public:
        @name SolutionMethods
        @{*/
     //! Variable index of a given solution
-    int VariableIndex(const std::string &name) const override {return 0;}
+    int VariableIndex(const std::string &name) const override;
     //! Number of variables associated with a given solution
-    int NSolutionVariables(int var) const override {return 0;}
+    int NSolutionVariables(int var) const override;
     //! Computes the solution at an integration point
     void Solution(const TPZVec<TPZMaterialDataT<STATE>> &datavec,
-                  int var, TPZVec<STATE> &solout) override {}
+                  int var, TPZVec<STATE> &solout) override;
     /**@}*/
 
 protected:
     TPZMatDeRhamH1HCurl() = default;
     int fDim{-1};
-    static constexpr int fH1MeshIndex{1};
-    static constexpr int fHCurlMeshIndex{0};
+    static constexpr int fH1MeshIndex{0};
+    static constexpr int fHCurlMeshIndex{1};
 };
 
 inline TPZMatDeRhamH1HCurl::TPZMatDeRhamH1HCurl(int id, int dim) :

--- a/UnitTest_PZ/TestDeRham/TestDeRham.cpp
+++ b/UnitTest_PZ/TestDeRham/TestDeRham.cpp
@@ -35,7 +35,7 @@ void CheckCompatibilityUniformMesh(int k);
 /** @brief Checks if the functions of the right space span the range of the
     operator of the left space*/
 template <ESpace leftSpace, ESpace rightSpace, int dim>
-void CheckInclusionUniformMesh(int kRight);
+void CheckExactSequence(int kRight);
 
 TEMPLATE_TEST_CASE("Compatibility Uniform Mesh", "[derham_tests]",
                    (typename std::integral_constant<int,2>),
@@ -95,7 +95,7 @@ TEMPLATE_TEST_CASE("Inclusion Uniform Mesh", "[derham_tests]",
   SECTION(names.at(leftSpace)) {
     switch (leftSpace) {
     case ESpace::H1:
-      CheckInclusionUniformMesh<ESpace::H1,ESpace::HCurl,dim>(k);
+      CheckExactSequence<ESpace::H1,ESpace::HCurl,dim>(k);
       //TODOFIX
       // if constexpr (dim == 2){
       //   CheckCompatibilityUniformMesh<ESpace::H1, ESpace::HDiv, dim>(k);
@@ -249,7 +249,7 @@ void CheckCompatibilityUniformMesh(int kRight) {
 }
 
 template <ESpace leftSpace, ESpace rightSpace, int dim>
-void CheckInclusionUniformMesh(int kRight) {
+void CheckExactSequence(int kRight) {
   const auto nameLeft = names.at(leftSpace);
   const auto nameRight = names.at(rightSpace);
   constexpr int matId = 1;
@@ -282,17 +282,9 @@ void CheckInclusionUniformMesh(int kRight) {
     auto *matRight = new TPZNullMaterial<STATE>(matId,dim,1);
 
     CAPTURE(nameLeft, nameRight, elName);
-
-    auto gmesh = CreateGMesh(dim, elType, matId);
-    
-    for(int i = 1; i < gmesh->NElements(); i++){
-      if(gmesh->ElementVec()[i]) delete gmesh->ElementVec()[i];
-      gmesh->ElementVec()[i] = nullptr;
-    }
-    gmesh->ElementVec().Resize(1);
-    gmesh->SetMaxElementId(0);
-    gmesh->ResetConnectivities();
-    gmesh->BuildConnectivity();
+    constexpr bool createBoundEls{false};
+    TPZAutoPointer<TPZGeoMesh> gmesh =
+        TPZGeoMeshTools::CreateGeoMeshSingleEl(elType, matId, createBoundEls);
     
     auto cmeshL = CreateCMesh(gmesh, matLeft, matId, kLeft, leftSpace);
     auto cmeshR = CreateCMesh(gmesh, matRight, matId, kRight, rightSpace);


### PR DESCRIPTION
This PR adds a unit test for checking the de rham compatibility between approximation spaces, comparing if the span of an operator associated with a given space is contained in the span of the basis functions associated with the next space in the De Rham diagram.

The test has been implemented only for H1 x HCurl spaces on simplices in 2 and 3 dimensions. More tests are to follow.