### PR TITLE
Restored information regarding function/file/line on log4cxx logs

### DIFF
--- a/Util/pzlog.cpp
+++ b/Util/pzlog.cpp
@@ -32,88 +32,52 @@ void TPZLogger::InitializeLogLevels()
      fIsInfoEnabled = logPtr->isInfoEnabled();
      fIsErrorEnabled = logPtr->isErrorEnabled();
      fIsFatalEnabled = logPtr->isFatalEnabled();
-    fLogNotInitialized = false;
+     fLogNotInitialized = false;
 }
 
 
-void pzinternal::LogPzDebugImpl(TPZLogger pzlg, std::string msg, const char *fileName, const std::size_t lineN){
+void pzinternal::LogPzDebugImpl(TPZLogger pzlg, std::string msg,
+                                const char *funcName,const char *fileName,
+                                const std::size_t lineN){
   log4cxx::LoggerPtr lg = log4cxx::LoggerPtr(log4cxx::Logger::getLogger(pzlg.fLogName));
-  if (lg->isDebugEnabled()) {
-    std::scoped_lock lock(glogmutex);
-    LOG4CXX_DEBUG(lg,msg);
-  } else {
-    static bool firstTime{true};
-      if (firstTime) {
-        std::cout << "Please set isDebugEnabled at ";
-        std::cout << fileName << ":" << lineN;
-        std::cout << std::endl;
-        firstTime = false;
-      }
-  }
+  log4cxx::helpers::MessageBuffer oss_;
+  lg->forcedLog(log4cxx::Level::getDebug(), oss_.str(oss_ << msg),
+                log4cxx::spi::LocationInfo(fileName, funcName,lineN));
 }
 
-void pzinternal::LogPzInfoImpl(TPZLogger pzlg, std::string msg, const char *fileName, const std::size_t lineN){
+void pzinternal::LogPzInfoImpl(TPZLogger pzlg, std::string msg,
+                               const char *funcName,const char *fileName,
+                               const std::size_t lineN){
   log4cxx::LoggerPtr lg = log4cxx::LoggerPtr(log4cxx::Logger::getLogger(pzlg.fLogName));
-  if (lg->isInfoEnabled()) {
-    std::scoped_lock lock(glogmutex);
-    LOG4CXX_INFO(lg, msg);
-  } else {
-      static bool firstTime{true};
-      if (firstTime) {
-        std::cout << "Please set isInfoEnabled at ";
-        std::cout << fileName << ":" << lineN;
-        std::cout << std::endl;
-        firstTime = false;
-      }
-  }
+  log4cxx::helpers::MessageBuffer oss_;
+  lg->forcedLog(log4cxx::Level::getInfo(), oss_.str(oss_ << msg),
+                log4cxx::spi::LocationInfo(fileName,funcName,lineN));
 }
-void pzinternal::LogPzWarnImpl(TPZLogger pzlg, std::string msg, const char *fileName, const std::size_t lineN){
+void pzinternal::LogPzWarnImpl(TPZLogger pzlg, std::string msg,
+                               const char *funcName, const char *fileName,
+                               const std::size_t lineN){
   log4cxx::LoggerPtr lg = log4cxx::LoggerPtr(log4cxx::Logger::getLogger(pzlg.fLogName));
-  if (lg->isWarnEnabled()) {
-    std::scoped_lock lock(glogmutex);
-    LOG4CXX_WARN(lg, msg);
-  }else {
-    static bool firstTime{true};
-    if (firstTime) {
-      std::cout << "Please set isWarnEnabled at ";
-      std::cout << fileName << ":" << lineN;
-      std::cout << std::endl;
-      firstTime = false;
-    }
-  }
+  log4cxx::helpers::MessageBuffer oss_;
+  lg->forcedLog(log4cxx::Level::getWarn(), oss_.str(oss_ << msg),
+                log4cxx::spi::LocationInfo(fileName, funcName,lineN));
 }
 
-void pzinternal::LogPzErrorImpl(TPZLogger pzlg, std::string msg, const char *fileName, const std::size_t lineN){
+void pzinternal::LogPzErrorImpl(TPZLogger pzlg, std::string msg,
+                                const char *funcName, const char *fileName,
+                                const std::size_t lineN){
   log4cxx::LoggerPtr lg = log4cxx::LoggerPtr(log4cxx::Logger::getLogger(pzlg.fLogName));
-  if (lg->isErrorEnabled()) {
-    std::scoped_lock lock(glogmutex);
-    LOG4CXX_ERROR(lg, msg);
-    DebugStop();
-  }else {
-    static bool firstTime{true};
-    if (firstTime) {
-      std::cout << "Please set isErrorEnabled at ";
-      std::cout << fileName << ":" << lineN;
-      std::cout << std::endl;
-      firstTime = false;
-    }
-  }
+  log4cxx::helpers::MessageBuffer oss_;
+  lg->forcedLog(log4cxx::Level::getError(), oss_.str(oss_ << msg),
+                log4cxx::spi::LocationInfo(fileName,funcName,lineN));
 }
 
-void pzinternal::LogPzFatalImpl(TPZLogger pzlg, std::string msg, const char *fileName, const std::size_t lineN){
+void pzinternal::LogPzFatalImpl(TPZLogger pzlg, std::string msg,
+                                const char *funcName, const char *fileName,
+                                const std::size_t lineN) {
   log4cxx::LoggerPtr lg = log4cxx::LoggerPtr(log4cxx::Logger::getLogger(pzlg.fLogName));
-  if (lg->isFatalEnabled()) {
-    std::scoped_lock lock(glogmutex);
-    LOG4CXX_FATAL(lg, msg);
-  }else {
-    static bool firstTime{true};
-    if (firstTime) {
-      std::cout << "Please set isFatalEnabled at ";
-      std::cout << fileName << ":" << lineN;
-      std::cout << std::endl;
-      firstTime = false;
-    }
-  }
+  log4cxx::helpers::MessageBuffer oss_; 
+  lg->forcedLog(::log4cxx::Level::getFatal(), oss_.str(oss_ << msg),
+                log4cxx::spi::LocationInfo(fileName,funcName,lineN));
 }
 
 /**

--- a/Util/pzlog.h
+++ b/Util/pzlog.h
@@ -42,18 +42,23 @@ class TPZLogger;
 
 namespace pzinternal{
 void LogPzDebugImpl(TPZLogger lg, std::string msg,
+                    [[maybe_unused]] const char *funcName,
                     [[maybe_unused]] const char *fileName,
                     [[maybe_unused]] const std::size_t lineN);
 void LogPzInfoImpl(TPZLogger lg, std::string msg,
+                   [[maybe_unused]] const char *funcName,
                    [[maybe_unused]] const char *fileName,
                    [[maybe_unused]] const std::size_t lineN);
 void LogPzWarnImpl(TPZLogger lg, std::string msg,
+                   [[maybe_unused]] const char *funcName,
                    [[maybe_unused]] const char *fileName,
                    [[maybe_unused]] const std::size_t lineN);
 void LogPzErrorImpl(TPZLogger lg, std::string msg,
+                    [[maybe_unused]] const char *funcName,
                     [[maybe_unused]] const char *fileName,
                     [[maybe_unused]] const std::size_t lineN);
 void LogPzFatalImpl(TPZLogger lg, std::string msg,
+                    [[maybe_unused]] const char *funcName,
                     [[maybe_unused]] const char *fileName,
                     [[maybe_unused]] const std::size_t lineN);
 }
@@ -121,18 +126,23 @@ private:
   bool fIsFatalEnabled;
 
   friend void pzinternal::LogPzDebugImpl(TPZLogger lg, std::string msg,
+                                         const char *funcName,
                                          const char *fileName,
                                          const std::size_t lineN);
   friend void pzinternal::LogPzInfoImpl(TPZLogger lg, std::string msg,
+                                        const char *funcName,
                                         const char *fileName,
                                         const std::size_t lineN);
   friend void pzinternal::LogPzWarnImpl(TPZLogger lg, std::string msg,
+                                        const char *funcName,
                                         const char *fileName,
                                         const std::size_t lineN);
   friend void pzinternal::LogPzErrorImpl(TPZLogger lg, std::string msg,
+                                         const char *funcName,
                                          const char *fileName,
                                          const std::size_t lineN);
   friend void pzinternal::LogPzFatalImpl(TPZLogger lg, std::string msg,
+                                         const char *funcName,
                                          const char *fileName,
                                          const std::size_t lineN);
 };
@@ -141,10 +151,11 @@ private:
 
 /// Define log for debug
 #define LOGPZ_DEBUG(logger, msg) { \
-   if (logger.isDebugEnabled()) {\
+    if (logger.isDebugEnabled()) {  \
       std::stringstream msg_stream; \
       msg_stream << msg; \
-      pzinternal::LogPzDebugImpl(logger, msg_stream.str(),__FILE__,__LINE__); \
+      pzinternal::LogPzDebugImpl(logger, msg_stream.str(),\
+                                 __PRETTY_FUNCTION__,__FILE__,__LINE__); \
    }\
 }
 
@@ -153,7 +164,8 @@ private:
    if (logger.isInfoEnabled()) {\
       std::stringstream msg_stream; \
       msg_stream << msg; \
-      pzinternal::LogPzInfoImpl(logger, msg_stream.str(),__FILE__,__LINE__); \
+      pzinternal::LogPzInfoImpl(logger, msg_stream.str(),\
+                                __PRETTY_FUNCTION__,__FILE__,__LINE__); \
    }\
 }
 
@@ -162,7 +174,8 @@ private:
    if (logger.isWarnEnabled()) {\
       std::stringstream msg_stream; \
       msg_stream << msg; \
-      pzinternal::LogPzWarnImpl(logger, msg_stream.str(),__FILE__,__LINE__); \
+      pzinternal::LogPzWarnImpl(logger, msg_stream.str(),\
+                                __PRETTY_FUNCTION__,__FILE__,__LINE__); \
    }\
 }
 
@@ -171,7 +184,8 @@ private:
    if (logger.isErrorEnabled()) {\
       std::stringstream msg_stream; \
       msg_stream << msg; \
-      pzinternal::LogPzErrorImpl(logger, msg_stream.str(),__FILE__,__LINE__); \
+      pzinternal::LogPzErrorImpl(logger, msg_stream.str(),\
+                                 __PRETTY_FUNCTION__,__FILE__,__LINE__); \
    }\
 }
 /// Define log for fatal errors
@@ -179,7 +193,8 @@ private:
    if (logger.isFatalEnabled()) {\
       std::stringstream msg_stream; \
       msg_stream << msg; \
-      pzinternal::LogPzFatalImpl(logger, msg_stream.str(),__FILE__,__LINE__); \
+      pzinternal::LogPzFatalImpl(logger, msg_stream.str(),\
+                                 __PRETTY_FUNCTION__,__FILE__,__LINE__); \
    }\
 }
 


### PR DESCRIPTION
Instead of using the `LOG4CXX_(DEBUG|INFO|WARN|ERROR)` macros on `pzlog.cpp`, their
content was expanded so we recover the information previously given by the 
`LOGCXX_LOCATION` macro.