### PR TITLE
New way of handling log4cxx config file overwriting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ if(USING_LOG4CXX)
   include(cmake/EnableLog4cxx.cmake)
   enable_log4cxx(pz)
   set(PZ_LOG ON) # Will add a define PZ_LOG on pz_config.h
-  set(PZ_LOG4CXX_CONFIG_FILE ${PROJECT_SOURCE_DIR}/Util/log4cxx.cfg) #specify where log4cxx config is found
+  set(PZ_LOG4CXX_CONFIG_FILE ${PROJECT_BINARY_DIR}/Util/log4cxx.cfg) #specify where log4cxx config is found
 else()
   set(PZ_LOG OFF)
 endif()

--- a/Util/CMakeLists.txt
+++ b/Util/CMakeLists.txt
@@ -88,9 +88,23 @@ set(sources
     )
 
 install(FILES ${public_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Util)
+
 if(USING_LOG4CXX)
-    install(FILES log4cxx.cfg DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Util)
+    set(inputPath ${CMAKE_CURRENT_SOURCE_DIR}/log4cxx.cfg)
+    set(outputPath ${CMAKE_CURRENT_BINARY_DIR}/log4cxx.cfg)
+
+    add_custom_command(
+        OUTPUT ${outputPath}
+        DEPENDS ${inputPath}
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/log4cxx_config_backup_gen.cmake
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${inputPath} ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    add_custom_target(log4cxx-config DEPENDS ${outputPath})
+    add_dependencies(pz log4cxx-config)
+
+    install(FILES ${outputPath} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Util)
 endif()
+
 target_sources(pz PRIVATE ${headers} ${sources})
 add_subdirectory(Hash)
 #for doxygen

--- a/cmake/log4cxx_config_backup_gen.cmake
+++ b/cmake/log4cxx_config_backup_gen.cmake
@@ -1,0 +1,5 @@
+set(outputPath log4cxx.cfg)
+if(EXISTS ${outputPath})
+    message(WARNING "Existing log4cxx config file found and renamed to 'log4cxx-backup.cfg'!")
+    file(RENAME ${outputPath} log4cxx-backup.cfg)
+endif()


### PR DESCRIPTION
This PR implements the following behaviour regarding `log4cxx.cfg` file:

- Built NeoPZ no longer uses the config file from the source directory but rather a copy located in the build directory;
- The build directory file is installed in opposition to the source file. This means one can customize the `log4cxx.cfg` file located in the *build* directory, without changing the status of the repository.
- The config files of the build and install directories are overwritten *only* if the source file is updated. In that case, we warn the user and generate a backup of the previous file in the build directory. 