### PR TITLE
TPZGeoElRefPattern::SetRefPattern check fixed

### DIFF
--- a/Mesh/tpzgeoelrefpattern.h
+++ b/Mesh/tpzgeoelrefpattern.h
@@ -521,8 +521,7 @@ void TPZGeoElRefPattern<TGeo>::SetRefPattern (TPZAutoPointer<TPZRefPattern> refp
 	}
 #endif
 	
-	if(fRefPattern == refpat)
-	{
+	if(fRefPattern && (*fRefPattern == *refpat)){//they are the same refinement pattern
 		return;
 	}
 	else if(this->HasSubElement())

--- a/Refine/TPZRefPattern.cpp
+++ b/Refine/TPZRefPattern.cpp
@@ -88,14 +88,14 @@ TPZRefPattern::TPZRefPattern(const std::string &file ) : fSideRefPattern(0), fId
      */
 }
 
-int TPZRefPattern::operator==(const TPZAutoPointer<TPZRefPattern> compare) const
+int TPZRefPattern::operator==(const TPZRefPattern& compare) const
 {
-	if(fRefPatternMesh.NNodes() != compare->fRefPatternMesh.NNodes() || fRefPatternMesh.NElements() != compare->fRefPatternMesh.NElements())
+	if(fRefPatternMesh.NNodes() != compare.fRefPatternMesh.NNodes() || fRefPatternMesh.NElements() != compare.fRefPatternMesh.NElements())
 	{
 		return 0;
 	}
 	TPZGeoEl *father = fRefPatternMesh.ElementVec()[0];
-	TPZGeoEl *compfather = compare->fRefPatternMesh.ElementVec()[0];
+	TPZGeoEl *compfather = compare.fRefPatternMesh.ElementVec()[0];
 	if(father->Type() != compfather->Type())
 	{
 		return 0;
@@ -121,7 +121,7 @@ int TPZRefPattern::operator==(const TPZAutoPointer<TPZRefPattern> compare) const
 		for(jn = 0; jn < nnodes; jn++){
 			int j;
 			for(j = 0; j < 3; j++){
-				coordcompare[j] = compare->fRefPatternMesh.NodeVec()[jn].Coord(j);
+				coordcompare[j] = compare.fRefPatternMesh.NodeVec()[jn].Coord(j);
 			}
 
 			for(j=0 ; j<dim; j++){
@@ -165,7 +165,7 @@ int TPZRefPattern::operator==(const TPZAutoPointer<TPZRefPattern> compare) const
 				continue;
 			}
 			std::set<int> compnodeset;
-			TPZGeoEl *jgel = compare->fRefPatternMesh.ElementVec()[jel];
+			TPZGeoEl *jgel = compare.fRefPatternMesh.ElementVec()[jel];
 			int jnnode = jgel->NNodes();
 
 			int jn;

--- a/Refine/TPZRefPattern.h
+++ b/Refine/TPZRefPattern.h
@@ -294,7 +294,7 @@ public:
      */
     TPZRefPattern(const TPZRefPattern &copy, const TPZPermutation &permute);
 
-    int operator==(const TPZAutoPointer<TPZRefPattern> compare) const;
+    int operator==(const TPZRefPattern &compare) const;
 
 	virtual ~TPZRefPattern() = default;
 


### PR DESCRIPTION
When setting a (non-null) refinement pattern in an element which already had
an associated pattern, a check is performed to ensure we are not setting the
same pattern again.

The `if` condition was not working as described, instead, it would evaluate
to true if both refinement patterns (new and current) were non-null.