### PR TITLE
Dot product fix

### DIFF
--- a/Matrix/pzfmatrix.cpp
+++ b/Matrix/pzfmatrix.cpp
@@ -2077,16 +2077,16 @@ int TPZFMatrix<TVar>::Subst_Diag( TPZFMatrix<TVar>* b ) const
 
 /** @brief Implement dot product for matrices */
 template<class TVar>
-RTVar Dot(const TPZFMatrix<TVar> &A, const TPZFMatrix<TVar> &B) {
+TVar Dot(const TPZFMatrix<TVar> &A, const TPZFMatrix<TVar> &B) {
     int64_t size = (A.Rows())*A.Cols();
-    RTVar result = 0.;
+    TVar result = 0.;
     if(!size) return result;
     const TVar *fpA = &A.g(0,0), *fpB = &B.g(0,0);
     const TVar *fpLast = fpA+size;
     while(fpA < fpLast)
     {
         if constexpr (is_complex<TVar>::value){
-            result += (*fpA++ * std::conj(*fpB++)).real();
+            result += *fpA++ * std::conj(*fpB++);
         }
         else{
             result += (*fpA++ * *fpB++);
@@ -2097,13 +2097,13 @@ RTVar Dot(const TPZFMatrix<TVar> &A, const TPZFMatrix<TVar> &B) {
 }
 
 template
-float Dot(const TPZFMatrix< std::complex<float> > &A, const TPZFMatrix< std::complex<float> > &B);
+std::complex<float> Dot(const TPZFMatrix< std::complex<float> > &A, const TPZFMatrix< std::complex<float> > &B);
 
 template
-double Dot(const TPZFMatrix< std::complex<double> > &A, const TPZFMatrix< std::complex<double> > &B);
+std::complex<double> Dot(const TPZFMatrix< std::complex<double> > &A, const TPZFMatrix< std::complex<double> > &B);
 
 template
-long double Dot(const TPZFMatrix< std::complex<long double> > &A, const TPZFMatrix< std::complex<long double> > &B);
+std::complex<long double> Dot(const TPZFMatrix< std::complex<long double> > &A, const TPZFMatrix< std::complex<long double> > &B);
 
 template
 long double Dot(const TPZFMatrix<long double> &A, const TPZFMatrix<long double> &B);

--- a/Matrix/pzfmatrix.h
+++ b/Matrix/pzfmatrix.h
@@ -41,7 +41,7 @@ template <class TVar> class TPZVerySparseMatrix;
 
 /** @brief Returns a dot product to matrices */
 template<class TVar>
-RTVar Dot(const TPZFMatrix<TVar> &A,const TPZFMatrix<TVar> &B);
+TVar Dot(const TPZFMatrix<TVar> &A,const TPZFMatrix<TVar> &B);
 
 /** @brief Returns the norm of the matrix A */
 template<class TVar>
@@ -730,15 +730,15 @@ inline long double Norm(const TPZFMatrix<long double> &A) {
 }
 
 inline float Norm(const TPZFMatrix< std::complex <float> > &A) {
-    return sqrt(Dot(A,A));
+    return sqrt(Dot(A,A).real());
 }
 
 inline double Norm(const TPZFMatrix< std::complex <double> > &A) {
-    return sqrt(Dot(A,A));
+    return sqrt(Dot(A,A).real());
 }
 
 inline long double Norm(const TPZFMatrix< std::complex <long double> > &A) {
-    return sqrt(Dot(A,A));
+    return sqrt(Dot(A,A).real());
 }
 
 inline float Norm(const TPZFMatrix< Fad <float> > &A) {

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -33,7 +33,7 @@ class TPZMatrix: public TPZBaseMatrix
 
 {
 public:
-    
+  using Type = TVar;
 	/** @brief Default constructor */
 	TPZMatrix() = default;
 	/**@brief Copy constructor */


### PR DESCRIPTION
The dot product of two complex matrices was being calculated as the real part of  `a . std::conj(b)`, which is not correct.

Unit tests were created and the code was then fixed (which required adjustments w.r.t. how the norm is calculated using the dot product). 

Also, an attribute

`TPZMatrix<T>::Type = T` was created.  