### PR TITLE
Including SBFEM-Hdiv code in RefactorGeom

### DIFF
--- a/Mesh/CMakeLists.txt
+++ b/Mesh/CMakeLists.txt
@@ -113,8 +113,22 @@ set(sources
 )
 
 if(USING_MKL)
-  list(APPEND headers TPZSBFemElementGroup.h TPZSBFemVolume.h)
-  list(APPEND sources TPZSBFemElementGroup.cpp TPZSBFemVolume.cpp)
+  list(APPEND headers
+    TPZSBFemElementGroup.h
+    TPZSBFemMultiphysicsElGroup.h
+    TPZSBFemVolume.h
+	  TPZSBFemVolumeHdiv.h
+	  TPZSBFemVolumeL2.h
+	  TPZSBFemVolumeMultiphysics.h
+    TPZCompElHDivSBFem.h)
+  list(APPEND sources
+    TPZSBFemElementGroup.cpp
+    TPZSBFemMultiphysicsElGroup.cpp
+    TPZSBFemVolume.cpp
+	  TPZSBFemVolumeHdiv.cpp
+	  TPZSBFemVolumeL2.cpp
+	  TPZSBFemVolumeMultiphysics.cpp
+    TPZCompElHDivSBFem.cpp)
 endif()
 
   

--- a/Mesh/TPZCompElHDivCollapsed.h
+++ b/Mesh/TPZCompElHDivCollapsed.h
@@ -20,9 +20,10 @@
 template<class TSHAPE>
 class TPZCompElHDivCollapsed : public TPZCompElHDiv<TSHAPE> {
 	
+protected:
     /// vector which defines whether the normal is outward or not
     TPZCompElHDivBound2<TSHAPE> fBottom,fTop;
-protected:
+    
     /** @brief To append vectors */
 	void Append(TPZFMatrix<REAL> &u1, TPZFMatrix<REAL> &u2, TPZFMatrix<REAL> &u12);
     template<class TVar>

--- a/Mesh/TPZCompElHDivSBFem.cpp
+++ b/Mesh/TPZCompElHDivSBFem.cpp
@@ -1,0 +1,336 @@
+/**
+ * @file
+ * @brief Contains the implementation of the TPZCompElHDivSBFem methods.
+ */
+
+
+#include "TPZCompElHDivSBFem.h"
+#include "pzgeoel.h"
+#include "TPZMaterial.h"
+#include "pzlog.h"
+#include "TPZShapeDisc.h"
+#include "TPZCompElDisc.h"
+#include "TPZMaterialDataT.h"
+#include "pzelchdiv.h"
+#include "pzvec_extras.h"
+
+
+#ifdef LOG4CXX
+static LoggerPtr logger(Logger::getLogger("pz.mesh.TPZCompElHDivSBFem"));
+#endif
+
+// Initialize with the geometry of the SBFemVolume
+template<class TSHAPE>
+TPZCompElHDivSBFem<TSHAPE>::TPZCompElHDivSBFem(TPZCompMesh &mesh, TPZGeoEl *gel, TPZGeoElSide &gelside, int64_t &index) :
+TPZCompElHDivCollapsed<TSHAPE>(mesh, gel, index), fGelVolSide(gelside)
+{
+}
+
+template<class TSHAPE>
+TPZCompElHDivSBFem<TSHAPE>::TPZCompElHDivSBFem(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
+TPZCompElHDivCollapsed<TSHAPE>(mesh, gel, index), fGelVolSide(0)
+{
+}
+
+template<class TSHAPE>
+TPZCompElHDivSBFem<TSHAPE>::TPZCompElHDivSBFem(TPZCompMesh &mesh, const TPZCompElHDivSBFem<TSHAPE> &copy) :
+TPZCompElHDivCollapsed<TSHAPE>(mesh,copy)
+{
+    fGelVolSide = copy.fGelVolSide;
+}
+
+template<class TSHAPE>
+TPZCompElHDivSBFem<TSHAPE>::TPZCompElHDivSBFem() : TPZCompElHDivCollapsed<TSHAPE>()
+{
+}
+
+template<class TSHAPE>
+TPZCompElHDivSBFem<TSHAPE>::~TPZCompElHDivSBFem()
+{
+}
+
+// Set the GeoElSide for the volumetric SBFEM element
+template<class TSHAPE>
+void TPZCompElHDivSBFem<TSHAPE>::SetGelVolumeSide(TPZGeoElSide &gelside)
+{
+    fGelVolSide = gelside;
+}
+
+// Get the GeoElSide for the volumetric SBFEM element
+template<class TSHAPE>
+TPZGeoElSide & TPZCompElHDivSBFem<TSHAPE>::GetGelVolumeSide()
+{
+    return fGelVolSide;
+}
+
+template<class TSHAPE>
+void TPZCompElHDivSBFem<TSHAPE>::ComputeRequiredData(TPZMaterialDataT<STATE> &data, TPZVec<REAL> &qsi)
+{
+    // Compute data for the 1d functions first
+    bool needssol = data.fNeedsSol;
+    data.fNeedsSol = false;
+    TPZCompElHDivCollapsed<TSHAPE>::ComputeRequiredData(data, qsi);
+    data.fNeedsSol = needssol;
+
+    auto nshape2d = data.phi.Rows();
+    auto nshape1d = 0;
+    for (int i = 0; i < 3; i++)
+    {
+        nshape1d += this->NConnectShapeF(i, this->fPreferredOrder);
+    }
+
+    HDivCollapsedDirections(data, nshape1d);
+
+    data.ComputeFunctionDivergence();
+    
+    int64_t nshape = (nshape2d - nshape1d) / 2;
+    // Adjusting divergence values
+    for (int64_t i = 0; i < nshape1d; i++)
+    {
+        data.divphi(i) = data.dphi(0,i);
+    }
+    for (int64_t i = 0; i < nshape; i++)
+    {
+        data.divphi(i+nshape1d) = 0;
+        data.divphi(i+nshape1d+nshape) = data.phi(i+nshape1d);
+        data.phi(i+nshape1d+nshape) = 0;
+    }
+    
+#ifdef LOG4CXX
+    if (logger->isDebugEnabled())
+    {
+        stringstream sout;
+        sout << "qsi = " << data.xParametric << endl;
+        data.phi.Print("phi = ", sout, EMathematicaInput);
+        LOGPZ_DEBUG(logger,sout.str());
+    }
+#endif
+}
+
+// This function will compute the directions for the HDiv collapsed based on the information of neighbourhood
+template<class TSHAPE>
+void TPZCompElHDivSBFem<TSHAPE>::HDivCollapsedDirections(TPZMaterialDataT<STATE> &data, int64_t nshape1d)
+{
+    // Computing the deformed directions for the 2d functions using the information of the neighbourhood
+    // Inspired in TPZSBFemVolume::ComputeKMatrices
+    auto detjac1d = data.detjac;
+    auto axes1d = data.axes;
+
+    // The Reference element will be the skeleton
+    TPZGeoEl *Ref1D = this->Reference();
+    int dim1 = TSHAPE::Dimension;
+
+    // The Volume element will be the one passed as an argument by the TPZSBFemVolumeHDiv - GEO DO EL 1D
+    // The SBFemVolumeHdiv will compute the Contribute for the SBFemHdiv element
+    // Before that, the material data must be computed (It will call ComputeRequiredData from TPZCompElHDivSBFem)
+    TPZGeoEl * gelvolume = fGelVolSide.Element();
+    int dim2 = gelvolume->Dimension();
+
+    // Find the higher side of the skeleton element
+    TPZGeoElSide SkeletonSide(Ref1D, Ref1D->NSides() - 1);
+
+    // Create a transformation between these sides
+    TPZTransform<REAL> tr(dim2, dim1);
+    tr = SkeletonSide.NeighbourSideTransform(fGelVolSide);
+    TPZTransform<REAL> t2 = gelvolume->SideToSideTransform(fGelVolSide.Side(), gelvolume->NSides() - 1);
+    tr = t2.Multiply(tr);
+
+    // Applying the transformation
+    TPZManVector<REAL, 3> xi(dim1), xiquad(dim2), xivol(dim2);
+    xi = data.xParametric;
+    tr.Apply(xi, xiquad);
+    xivol = xiquad;
+    xivol[dim2 - 1] = -0.5;
+
+    // Computing the data for the volumetric element
+    gelvolume->X(xivol, data.x);
+    gelvolume->Jacobian(xiquad, data.jacobian, data.axes, data.detjac, data.jacinv);
+
+    auto axes = data.axes;
+    if (dim2 == 3) {
+        AdjustAxes3D(axes, data.axes, data.jacobian, data.jacinv, data.detjac);
+    }
+
+    // Adjusting derivatives
+    ExtendShapeFunctions(data, detjac1d);
+
+    auto ndir = data.fDeformedDirections.Cols()-1;
+
+    if (dim2 == 3)
+    {
+        std::cout << "Function not verified for 3D cases yet\n";
+        DebugStop();
+    }
+    
+    TPZFNMatrix<9,REAL> grad(dim2,dim2,0);
+    gelvolume->GradX(xivol,grad);
+    REAL detjac = sqrt(2*data.detjac);
+    
+    TPZFNMatrix<9,REAL> jaccollapsed;
+    data.axes.Resize(data.jacobian.Cols(),3);
+    data.jacobian.Multiply(data.axes,jaccollapsed);
+    TPZFMatrix<REAL> fDeformedDirectionsCopy(data.fDeformedDirections);
+
+    auto signal = 0, signal0 = 0;
+    TPZManVector<REAL,2> signalvec(2,0);
+    for (int i = 0; i < dim2; i++)
+    {
+        signal += -data.axes(1,i);
+    }
+    
+    for (auto j = 0; j < 3; j++)
+    {
+        for (auto i = 0; i < dim2; i++)
+        {
+            data.fDeformedDirections(i,j) = data.fDeformedDirections(i,0);
+        }
+    }
+    for (auto j = 3; j < data.fDeformedDirections.Cols(); j++)
+    {
+        data.fDeformedDirections(2,j) = 0.;
+        for (auto i = 0; i < dim2; i++)
+        {
+            for (int k = 0; k < 3; k++)
+            {
+                data.fDeformedDirections(i,j) = signal*fDeformedDirectionsCopy(k,j)*grad(i,1)*2./fabs(detjac1d);
+            }
+        }
+    }
+}
+
+template <class TSHAPE>
+void TPZCompElHDivSBFem<TSHAPE>::AdjustAxes3D(const TPZFMatrix<REAL> &axes2D, TPZFMatrix<REAL> &axes3D, TPZFMatrix<REAL> &jac3D, TPZFMatrix<REAL> &jacinv3D, REAL detjac)
+{
+    TPZManVector<REAL, 3> ax1(3), ax2(3), ax3(3);
+    for (int i = 0; i < 3; i++) {
+        ax1[i] = axes2D.g(0, i);
+        ax2[i] = axes2D.g(1, i);
+        Cross(ax1, ax2, ax3);
+    }
+    for (int i = 0; i < 3; i++) {
+        axes3D(0, i) = ax1[i];
+        axes3D(1, i) = ax2[i];
+        axes3D(2, i) = ax3[i];
+        if (detjac < 0.) {
+            axes3D(2, i) *= -1.;
+        }
+    }
+    TPZFNMatrix<9, REAL> jacnew(3, 3), axest(3, 3), jacinv(3, 3);
+    axes3D.Transpose(&axest);
+    axes3D.Multiply(jac3D, jacnew);
+    jacinv3D.Multiply(axest, jacinv);
+    jac3D = jacnew;
+    jacinv3D = jacinv;
+#ifdef PZDEBUG
+    // check whether the axes are orthogonal and whether the jacobian is still the inverse of jacinv
+    {
+        TPZFNMatrix<9, REAL> ident1(3, 3, 0.), ident2(3, 3, 0.), identity(3, 3);
+        identity.Identity();
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                for (int k = 0; k < 3; k++) {
+                    ident1(i, j) += axes3D(i, k) * axes3D(j, k);
+                    ident2(i, j) += jac3D(i, k) * jacinv3D(k, j);
+                }
+            }
+        }
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                if (fabs(ident1(i, j) - identity(i, j)) > 1.e-6) {
+                    DebugStop();
+                }
+                if (fabs(ident2(i, j) - identity(i, j)) > 1.e-6) {
+                    DebugStop();
+                }
+            }
+        }
+    }
+#endif
+}
+
+template <class TSHAPE>
+void TPZCompElHDivSBFem<TSHAPE>::ExtendShapeFunctions(TPZMaterialDataT<STATE> &data, REAL detjac1d)
+{
+    int dim = fGelVolSide.Element()->Dimension();
+
+    auto nshape = data.phi.Rows();
+    auto nshape1d = 0;
+    for (int i = 0; i < 3; i++)
+    {
+        nshape1d += this->NConnectShapeF(i, this->fPreferredOrder);
+    }
+
+    int64_t nshape2d = (nshape - nshape1d) / 2;
+    for (int ish = 0; ish < nshape2d; ish++)
+    {
+        for (int d = 0; d < dim - 1; d++)
+        {
+            data.dphi(d, ish + nshape1d) = 0.;
+            data.dphi(d, ish + nshape1d+nshape2d) = data.phi(ish);
+        }
+        data.dphi(dim-1, ish+nshape1d) = - data.phi(ish) / 2.;
+        data.dphi(dim-1, ish+nshape1d+nshape2d) = 0.;
+    }
+   
+    TPZFNMatrix<50,REAL> philoc(data.phi.Rows(),data.phi.Cols()),dphiloc(data.dphi.Rows(),data.dphi.Cols());
+    TPZManVector<int,TSHAPE::NSides> ord;
+    TPZCompElHDivCollapsed<TSHAPE>::fBottom.GetInterpolationOrder(ord);
+
+    int nc = this->Reference()->NCornerNodes();
+    TPZManVector<int64_t,8> id(nc);
+    for (int ic=0; ic<nc; ic++)
+    {
+        id[ic] = this->Reference()->Node(ic).Id();
+    }
+
+    TSHAPE::Shape(data.xParametric, id, ord, philoc, dphiloc);
+
+    TPZManVector<int,9> permutegather(TSHAPE::NSides);
+    int transformid = TSHAPE::GetTransformId(id);
+    TSHAPE::GetSideHDivPermutation(transformid, permutegather);
+    
+    TPZManVector<int64_t,27> FirstIndex(TSHAPE::NSides+1);
+    TPZCompElHDivCollapsed<TSHAPE>::fBottom.FirstShapeIndex(FirstIndex);
+
+    int order = TPZCompElHDivCollapsed<TSHAPE>::fBottom.Connect(0).Order();
+    for (int side=0; side < TSHAPE::NSides; side++)
+    {
+        int ifirst = FirstIndex[side];
+        int kfirst = FirstIndex[permutegather[side]];
+        int nshape = TSHAPE::NConnectShapeF(side,order);
+        for (int i=0; i<nshape; i++)
+        {
+            data.phi(nshape1d + ifirst+i,0) = philoc(kfirst+i,0);
+            for (int d=0; d< TSHAPE::Dimension; d++)
+            {
+                data.dphi(d,nshape1d + ifirst+i) = dphiloc(d,kfirst+i);
+            }
+        }
+    }
+    data.divsol.Resize(1);
+    data.divsol[0].Resize(1,0.);
+    
+
+    TPZInterpolationSpace::Convert2Axes(data.dphi, data.jacinv, data.dphix);
+}
+
+template <class TSHAPE>
+void TPZCompElHDivSBFem<TSHAPE>::ComputeSolution(TPZVec<REAL> &qsi, TPZMaterialDataT<STATE> &data)
+{
+    DebugStop();
+}
+
+#include "pzshapetriang.h"
+#include "pzshapepoint.h"
+#include "pzshapelinear.h"
+#include "pzshapequad.h"
+
+using namespace pzshape;
+
+template class TPZRestoreClass< TPZCompElHDivSBFem<TPZShapeLinear>>;
+template class TPZRestoreClass< TPZCompElHDivSBFem<TPZShapeTriang>>;
+template class TPZRestoreClass< TPZCompElHDivSBFem<TPZShapeQuad>>;
+
+template class TPZCompElHDivSBFem<TPZShapeTriang>;
+template class TPZCompElHDivSBFem<TPZShapeLinear>;
+template class TPZCompElHDivSBFem<TPZShapeQuad>;

--- a/Mesh/TPZCompElHDivSBFem.h
+++ b/Mesh/TPZCompElHDivSBFem.h
@@ -1,0 +1,79 @@
+/**
+ * @file
+ * @brief Contains declaration of TPZCompElHDivCollapsed class which implements a generic computational element (HDiv scope).
+ */
+
+#pragma once
+
+#include "pzelchdiv.h"
+#include "pzelchdivbound2.h"
+#include "TPZCompElHDivCollapsed.h"
+
+/**
+ * @brief This class implements a "generic" computational element of an HDiv space. \ref CompElement "Computational Element"
+ * @addtogroup CompElement
+ * @{
+ */
+/** 
+ * By varying the classes passed as template arguments, the complete family of computational elements are implemented
+ */
+template<class TSHAPE>
+class TPZCompElHDivSBFem : public TPZCompElHDivCollapsed<TSHAPE> {
+
+    /// geometric element representing the collapsed volume
+    TPZGeoElSide fGelVolSide;
+
+    /// vector which defines whether the normal is outward or not
+    TPZManVector<int, TSHAPE::NFacets> fSideOrient;
+    
+public:
+	    
+	TPZCompElHDivSBFem(TPZCompMesh &mesh, TPZGeoEl *gel, TPZGeoElSide &gelside, int64_t &index);
+
+	TPZCompElHDivSBFem(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+	
+	TPZCompElHDivSBFem(TPZCompMesh &mesh, const TPZCompElHDivSBFem<TSHAPE> &copy);
+	
+	TPZCompElHDivSBFem();
+	
+	virtual ~TPZCompElHDivSBFem();
+	
+	virtual TPZCompEl *Clone(TPZCompMesh &mesh) const  override {
+		return new TPZCompElHDivSBFem<TSHAPE> (mesh, *this);
+	}
+
+    /** @brief Returns the unique identifier for reading/writing objects to streams */
+    int ClassId() const override;
+
+    void SetGelVolumeSide(TPZGeoElSide &gelside);
+
+    TPZGeoElSide & GetGelVolumeSide();
+
+    virtual void ComputeRequiredData(TPZMaterialDataT<STATE> &data, TPZVec<REAL> &qsi) override;
+
+    void ComputeDeformedDirections(TPZMaterialDataT<STATE> &data);
+
+    void HDivCollapsedDirections(TPZMaterialDataT<STATE> &data, int64_t nshape1d);
+
+    void AdjustAxes3D(const TPZFMatrix<REAL> &axes2D, TPZFMatrix<REAL> &axes3D, TPZFMatrix<REAL> &jac3D, TPZFMatrix<REAL> &jacinv3D, REAL detjac);
+
+    void ExtendShapeFunctions(TPZMaterialDataT<STATE> &data2d, REAL nshape1d);
+
+    virtual void ComputeSolution(TPZVec<REAL> &qsi, TPZMaterialDataT<STATE> &data);
+
+};
+
+template<class TSHAPE>
+int TPZCompElHDivSBFem<TSHAPE>::ClassId() const{
+    return Hash("TPZCompElHDivSBFem") ^ TPZIntelGen<TSHAPE>::ClassId() << 1;
+}
+
+#include "pzcmesh.h"
+
+
+/** @brief Creates computational linear element for HDiv approximate space */
+TPZCompEl *CreateHDivColapsedLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+/** @brief Creates computational quadrilateral element for HDiv approximate space */
+TPZCompEl *CreateHDivColapsedQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+/** @brief Creates computational triangular element for HDiv approximate space */
+TPZCompEl *CreateHDivColapsedTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);

--- a/Mesh/TPZSBFemMultiphysicsElGroup.cpp
+++ b/Mesh/TPZSBFemMultiphysicsElGroup.cpp
@@ -1,0 +1,850 @@
+//
+//  TPZSBFemElementGroup.cpp
+//  PZ
+//
+//  Created by Karolinne Coelho on 22/01/2021.
+//
+//
+#include "TPZSBFemMultiphysicsElGroup.h"
+#include "TPZMultiphysicsCompMesh.h"
+#include "TPZSBFemVolumeMultiphysics.h"
+#include "TPZMaterialDataT.h"
+#include "TPZGeoLinear.h"
+
+#ifdef USING_MKL
+#include <mkl.h>
+#elif MACOSX
+#include <Accelerate/Accelerate.h>
+#endif
+
+#ifdef LOG4CXX
+static LoggerPtr logger(Logger::getLogger("sbfemmultiphysicselgroup"));
+static LoggerPtr loggercoef(Logger::getLogger("sbfemmultiphysicscoefmatrices"));
+static LoggerPtr loggereigensystem(Logger::getLogger("sbfemmultiphysicseigensystem"));
+static LoggerPtr loggerlocalstiff(Logger::getLogger("loggerlocalstiff"));
+static LoggerPtr loggerfulleigensys(Logger::getLogger("sbfemmultiphysicsfulleigensys"));
+static LoggerPtr loggersbfemcondensed(Logger::getLogger("sbfemcondensed"));
+static LoggerPtr loggerflux(Logger::getLogger("sbfemfluxhdiv"));
+#endif
+
+void TPZSBFemMultiphysicsElGroup::AddElement(TPZCompEl *cel)
+{
+    std::set<int64_t> connects;
+    for (auto ic : fConnectIndexes)
+    {
+        connects.insert(ic);
+    }
+    
+    auto celvol = dynamic_cast<TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad> *>(cel);
+    TPZCompEl *celskeleton = Mesh()->Element(celvol->SkeletonIndex());
+
+    auto nc = celskeleton->NConnects();
+    for (int ic=0; ic<nc; ic++)
+    {
+        connects.insert(celskeleton->ConnectIndex(ic));
+    }
+
+    nc = connects.size();
+    if (nc != fConnectIndexes.size())
+    {
+        fConnectIndexes.Resize(nc, 0);
+        auto it = connects.begin();
+        for (int ic = 0; it != connects.end(); it++,ic++)
+        {
+            fConnectIndexes[ic] = *it;
+        }
+    }
+    TPZElementGroup::AddElement(cel);
+}
+
+void TPZSBFemMultiphysicsElGroup::Print(std::ostream &out) const
+{
+    out << __PRETTY_FUNCTION__ << std::endl;
+    TPZElementGroup::Print(out);
+
+    out << "Element indexes of the volume elements ";
+    for (auto cel : fElGroup)
+    {
+        out << cel->Index() << " ";
+    }
+    out << std::endl;
+    out << "Indices of the associated computational skeleton elements\n";
+    for (auto cel : fElGroup)
+    {
+        auto vol = dynamic_cast<TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad> *>(cel);
+        if(!vol) DebugStop();
+        out << vol->SkeletonIndex() << " ";
+    }
+    out << std::endl;
+    out << "Connect indexes \n";
+    int nc = NConnects();
+    for (int ic=0; ic<nc; ic++)
+    {
+        out << ConnectIndex(ic) << " ";
+    }
+    out << std::endl;
+    out << "Connect indexes of the contained elements\n";
+    for (auto cel : fElGroup)
+    {
+        int nc = cel->NConnects();
+        for (int ic=0; ic<nc; ic++)
+        {
+            out << cel->ConnectIndex(ic) << " ";
+        }
+        out << std::endl;
+    }
+    out << "Connect indexes of the condensed element \n";
+    nc = fCondEl->NConnects();
+    for (int ic=0; ic<nc; ic++)
+    {
+        out << fCondEl->ConnectIndex(ic) << " ";
+    }
+    out << std::endl;
+    
+    out << "End of " << __PRETTY_FUNCTION__ << std::endl;
+}
+
+
+void TPZSBFemMultiphysicsElGroup::GroupandCondense(set<int> & condensedmatid)
+{
+#ifdef PZDEBUG
+    if (fElGroup.size() == 0 || condensedmatid.size() == 0) DebugStop();
+#endif
+    int64_t index;
+    fCondensedEls = new TPZElementGroup(*Mesh(), index);
+
+    for (auto celvol : fElGroup)
+    {
+        if (!celvol) continue;
+
+        auto sbfemvol = dynamic_cast<TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad> * >(celvol);
+
+#ifdef PZDEBUG
+        if (!sbfemvol) DebugStop();
+#endif
+
+        for (auto cel : sbfemvol->SBFemElementVec())
+        {
+            if (!cel) DebugStop(); 
+            auto matid = cel->Reference()->MaterialId();
+            auto it = condensedmatid.find(matid);
+
+            if (it == condensedmatid.end()) continue;
+            
+            fCondensedEls->AddElement(cel);
+        }
+    }
+    
+    // Updating NElConnected()
+    // fDifPressure and fAverPressure must have NElConnected = 2, and the others = 1
+    {
+        for(auto cel : fElGroup)
+        {
+            auto sbfem = dynamic_cast<TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad> *>(cel);
+            if(!sbfem) DebugStop();
+
+            auto elvec = sbfem->SBFemElementVec();
+
+            for (auto el : elvec)
+            {
+                if ( !el || !(el->Reference()) ) DebugStop();
+            
+                auto matid = el->Reference()->MaterialId();
+                auto it = condensedmatid.find(matid);
+
+                // If it is a condensed element, NElConnected = 1
+                if (it != condensedmatid.end() && *(condensedmatid.begin()) != matid)
+                {
+                    auto nconcel = el->NConnects();
+                    for (auto ic = 0; ic < nconcel; ic++)
+                    {
+                        el->Connect(ic).ResetElConnected();
+                        el->Connect(ic).IncrementElConnected();
+                    }
+                } 
+                // Not condensed elements are: fDifPressure and fAverPressure
+            }
+        }
+    }
+
+    bool keepmatrix = true;
+    fCondEl = new TPZCondensedCompEl(fCondensedEls, keepmatrix);
+
+    AdjustConnectivities();
+
+    SetLocalIndices(index);
+}
+
+void TPZSBFemMultiphysicsElGroup::CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef)
+{
+    TPZElementMatrixT<STATE> E0, E1, E2;
+    ComputeMatrices(E0, E1, E2);
+    
+    InitializeElementMatrix(ek, ef);
+
+    int n = E0.fMat.Rows();
+    auto dim = Mesh()->Dimension();
+    
+    TPZFMatrix<STATE> E0Inv(E0.fMat);
+
+    TPZVec<int> pivot(E0Inv.Rows(),0);
+    int nwork = 4*n*n + 2*n;
+    TPZVec<STATE> work(2*nwork,0.);
+    int info=0;
+#ifdef STATEdouble
+    dgetrf_(&n, &n, &E0Inv(0,0), &n, &pivot[0], &info);
+#endif
+#ifdef STATEfloat
+    sgetrf_(&n, &n, &E0Inv(0,0), &n, &pivot[0], &info);
+#endif
+    if (info != 0) {
+        DebugStop();
+    }
+#ifdef STATEdouble
+    dgetri_(&n, &E0Inv(0,0), &n, &pivot[0], &work[0], &nwork, &info);
+#endif
+#ifdef STATEfloat
+    sgetri_(&n, &E0Inv(0,0), &n, &pivot[0], &work[0], &nwork, &info);
+#endif
+    if (info != 0) {
+        DebugStop();
+    }
+    
+    TPZFMatrix<STATE> globmat(2*n,2*n,0.);
+    
+#ifdef STATEdouble
+    cblas_dgemm(CblasColMajor, CblasNoTrans, CblasTrans, n, n, n, 1., &E0Inv(0,0), n, &E1.fMat(0,0), n, 0., &globmat(0,0), 2*n);
+#elif defined STATEfloat
+    cblas_sgemm(CblasColMajor, CblasNoTrans, CblasTrans, n, n, n, 1., &E0Inv(0,0), n, &E1.fMat(0,0), n, 0., &globmat(0,0), 2*n);
+#else
+    cout << "SBFem does not execute for this configuration\n";
+    DebugStop();
+#endif
+    
+    for (int i=0; i<n; i++) {
+        for (int j=0; j<n; j++) {
+            globmat(i,j+n) = -E0Inv(i,j);
+        }
+    }
+#ifdef STATEdouble
+    cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, n, n, n, 1., &E1.fMat(0,0), n, &globmat(0,0), 2*n, 0., &globmat(n,0), 2*n);
+#elif defined STATEfloat
+    cblas_sgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, n, n, n, 1., &E1.fMat(0,0), n, &globmat(0,0), 2*n, 0., &globmat(n,0), 2*n);
+#else
+    cout << "SBFem does not execute for this configuration\n";
+    DebugStop();
+#endif
+    for (int i=0; i<n; i++) {
+        for (int j=0; j<n; j++) {
+            globmat(i+n,j) -= E2.fMat(i,j);
+        }
+    }
+
+#ifdef STATEdouble
+    cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, n, n, n, -1., &E1.fMat(0,0), n, &E0Inv(0,0), n, 0., &globmat(n,n), 2*n);
+#elif defined STATEfloat
+    cblas_sgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, n, n, n, -1., &E1.fMat(0,0), n, &E0Inv(0,0), n, 0., &globmat(n,n), 2*n);
+#else
+    cout << "SBFem does not execute for this configuration\n";
+    DebugStop();
+#endif
+
+    for (int i=0; i<n; i++) {
+        globmat(i,i) -= (dim-2)*0.5;
+        globmat(i+n,i+n) += (dim-2)*0.5;
+    }
+    
+    
+    static pthread_mutex_t mutex_serial = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_lock(&mutex_serial);
+
+    TPZFMatrix<STATE> globmatkeep(globmat);
+    TPZFNMatrix<100,complex<double> > eigenVectors;
+    TPZManVector<complex<double> > eigenvalues;
+    globmatkeep.SolveEigenProblem(eigenvalues, eigenVectors);
+    // this->SolveEigenProblemSBFEM(globmatkeep, eigenvalues, eigenVectors);
+#ifdef LOG4CXX
+    if (loggerfulleigensys->isDebugEnabled())
+    {
+        stringstream sout;
+        EigenVectorsReal(eigenVectors).Print("eigvecfull = ", sout, EMathematicaInput);
+        EigenvaluesReal(eigenvalues).Print(sout);
+        LOGPZ_DEBUG(loggerfulleigensys, sout.str())
+    }
+#endif
+    
+    pthread_mutex_unlock(&mutex_serial);
+        
+    TPZFMatrix<std::complex<double>> QVectors(n,n,0.);
+    fPhi.Resize(n, n);
+    TPZManVector<std::complex<double>> eigvalsel(n,0);
+    TPZFMatrix<std::complex<double> > eigvecsel(2*n,n,0.),eigvalmat(1,n,0.);
+    int count = 0;
+    for (int i=0; i<2*n; i++) {
+        if (eigenvalues[i].real() < -1.e-6) {
+            for (int j=0; j<n; j++) {
+                QVectors(j,count) = eigenVectors(j+n,i);
+                eigvecsel(j,count) = eigenVectors(j,i);
+                eigvecsel(j+n,count) = eigenVectors(j+n,i);
+                fPhi(j,count) = eigenVectors(j,i);
+            }
+            eigvalsel[count] = eigenvalues[i].real();
+            eigvalmat(0,count) = eigenvalues[i];
+            count++;
+        }
+    }
+    fPhiQ = QVectors;
+
+    if (dim == 2)
+    {
+        int nstate = Connect(0).NState();
+        if (nstate != 2 && nstate != 1) {
+            DebugStop();
+        }
+        if(count != n-nstate) {
+            DebugStop();
+        }
+        int ncon = fCondEl->NConnects();
+        int eq=0;
+        std::set<int64_t> cornercon;
+        BuildCornerConnectList(cornercon);
+        for (int ic=ncon/2; ic<ncon; ic++) {
+            int64_t conindex = fCondEl->ConnectIndex(ic);
+            if (cornercon.find(conindex) != cornercon.end())
+            {
+                fPhi(eq,count) = 1;
+                eigvecsel(eq,count) = 1;
+                if (nstate == 2)
+                {
+                    fPhi(eq+1,count+1) = 1;
+                    eigvecsel(eq+1,count+1) = 1;
+                }
+            }
+            eq += fCondEl->Connect(ic).NShape()*fCondEl->Connect(ic).NState();
+        }
+    }
+    if(dim==3 && count != n)
+    {
+        DebugStop();
+    }
+    fEigenvalues = eigvalsel;
+        
+    TPZFMatrix<std::complex<double> > phicopy(fPhi);
+    fPhiInverse.Redim(n, n);
+    fPhiInverse.Identity();
+    
+    try
+    {
+        TPZVec<int> pivot;
+        phicopy.Decompose_LU(pivot);
+        phicopy.Substitution(&fPhiInverse, pivot);
+    }
+    catch(...)
+    {
+        exit(-1);
+    }
+
+    TPZFMatrix<std::complex<double>> ekloc;
+    QVectors.Multiply(fPhiInverse, ekloc);
+#ifdef PZDEBUG
+    cout << eigenvalues << "\n";
+#endif
+
+    ek.fMat.Resize(ekloc.Rows(),ekloc.Cols());
+    
+    TPZFMatrix<double> ekimag(ekloc.Rows(),ekloc.Cols());
+    for (int i=0; i<ekloc.Rows(); i++) {
+        for (int j=0; j<ekloc.Cols(); j++) {
+            ek.fMat(i,j) = ekloc(i,j).real();
+            ekimag(i,j) = ekloc(i,j).imag();
+        }
+    }
+
+#ifdef LOG4CXX
+    if (loggereigensystem->isDebugEnabled())
+    {
+        std::stringstream sout;
+        // sout << fLocalindices << endl;
+        ek.fMat.Print("ekloc = ", sout, EMathematicaInput);
+        // globmatkeep.Print("matrix = ", sout, EMathematicaInput);
+        // eigvecsel.Print("eigvec =", sout, EMathematicaInput);
+        eigvalmat.Print("lambda =", sout, EMathematicaInput);
+        fPhi.Print("phi = ", sout, EMathematicaInput);
+        fPhiInverse.Print("phiinv = ", sout, EMathematicaInput);
+        QVectors.Print("qvec = ", sout, EMathematicaInput);
+        LOGPZ_DEBUG(loggereigensystem, sout.str())
+    }
+#endif
+    
+    for (auto cel : fElGroup)
+    {
+        auto sbfem = dynamic_cast<TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad>*>(cel);
+#ifdef PZDEBUG
+        if (!sbfem) {
+            DebugStop();
+        }
+#endif
+        sbfem->SetPhiEigVal(fPhi, fEigenvalues);
+    }
+
+    // FLUX
+    TPZFMatrix<double> k01 = fCondEl->Matrix().K01();
+    n = fPhi.Rows();
+
+    TPZFMatrix<std::complex<double>> fPhiD(2*n, 2*n,0.);
+    for (int i = 0; i < n; i++)
+    {
+        for (int j = 0; j < n; j++)
+        {
+            fPhiD(i,j) = fPhi(i,j);
+            fPhiD(i+n,j+n) = fPhi(i,j);
+        }
+    }
+
+    TPZFMatrix<std::complex<double>> tempcomplex(k01.Rows(),k01.Cols(),0.);
+    for (auto i = 0; i < k01.Rows(); i++)
+    {
+        for (auto j = 0; j < k01.Cols(); j++)
+        {
+            tempcomplex(i,j) = k01(i,j);
+        }   
+    }
+    
+    tempcomplex.Multiply(fPhiD, fPhiFlux);
+    
+    for (auto cel : fElGroup)
+    {
+        auto sbfem = dynamic_cast<TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad> *>(cel);
+#ifdef PZDEBUG
+        if (!sbfem) {
+            DebugStop();
+        }
+#endif
+        sbfem->SetPhiFlux(fPhiFlux, fEigenvalues);
+    }
+
+#ifdef LOG4CXX  
+    if (loggerflux->isDebugEnabled())
+    {
+        stringstream sout;
+        k01.Print("k01 = ", sout, EMathematicaInput);
+        fPhiD.Print("phid = ", sout, EMathematicaInput);
+        fPhiFlux.Print("fPhiFlux = ", sout, EMathematicaInput);
+        LOGPZ_DEBUG(loggerflux, sout.str())
+    }
+#endif
+
+}
+
+void TPZSBFemMultiphysicsElGroup::ComputeMatrices(TPZElementMatrixT<STATE> &E0, TPZElementMatrixT<STATE> &E1, TPZElementMatrixT<STATE> &E2)
+{
+    TPZElementMatrixT<STATE> ek(Mesh(),TPZElementMatrixT<STATE>::EK);
+    TPZElementMatrixT<STATE> ef(Mesh(),TPZElementMatrixT<STATE>::EF);
+    fCondEl->CalcStiff(ek,ef);
+
+    int n = ek.fMat.Rows()/2;
+    
+    E0.fMat.Resize(n,n);
+    E1.fMat.Resize(n,n);
+    E2.fMat.Resize(n,n);
+
+    for (int i = 0; i < n; i++)
+    {
+        for (int j = 0; j < n; j++)
+        {
+            E0.fMat(i,j) = ek.fMat(i,j);
+            E1.fMat(i,j) = ek.fMat(i+n,j);
+            E2.fMat(i,j) = ek.fMat(i+n,j+n);
+        }
+    }
+
+#ifdef LOG4CXX
+    if (logger->isDebugEnabled())
+    {
+        std::stringstream sout;
+        fCondEl->Print(sout);
+        LOGPZ_DEBUG(logger,sout.str())
+    }
+    if (loggercoef->isDebugEnabled())
+    {
+        std::stringstream out;
+        E0.fMat.Print("E0pz = ", out, EMathematicaInput);
+        E1.fMat.Print("E1pz = ", out, EMathematicaInput);
+        E2.fMat.Print("E2pz = ", out, EMathematicaInput);
+        LOGPZ_DEBUG(loggercoef,out.str())
+    }
+#endif
+}
+
+void TPZSBFemMultiphysicsElGroup::InitializeElementMatrix(TPZElementMatrixT<STATE> &ek, TPZElementMatrixT<STATE> &ef) const
+{
+	const int ncon = fCondEl->NConnects();
+	int numeq = 0;
+	ef.fBlock.SetNBlocks(ncon);
+	ek.fBlock.SetNBlocks(ncon);
+    
+    for (int ic=0; ic<ncon; ic++)
+    {
+        TPZConnect &c = Connect(ic);
+        int blsize = c.NShape()*c.NState();
+        numeq += blsize;
+        ef.fBlock.Set(ic, blsize);
+        ek.fBlock.Set(ic, blsize);
+    }
+    const int numloadcases = 1;
+    ef.fMesh = Mesh();
+    ef.fType = TPZElementMatrix::EF;
+	ef.fMat.Redim(numeq,numloadcases);
+	ef.fConnect.Resize(ncon);
+
+    ek.fMesh = Mesh();
+    ek.fType = TPZElementMatrix::EK;
+	ek.fMat.Redim(numeq,numeq);
+	ek.fConnect.Resize(ncon);
+
+	for(int i=0; i<ncon; i++)
+    {
+		(ef.fConnect)[i] = ConnectIndex(i);
+		(ek.fConnect)[i] = ConnectIndex(i);
+	}
+    std::map<int64_t,TPZOneShapeRestraint>::const_iterator it;
+    for (it = fRestraints.begin(); it != fRestraints.end(); it++) 
+    {
+        ef.fOneRestraints.push_back(it->second);
+        ek.fOneRestraints.push_back(it->second);
+    }
+}//void
+
+void TPZSBFemMultiphysicsElGroup::LoadSolution()
+{
+    int ndofs = fPhiInverse.Cols();
+    int ncoef = fPhiInverse.Rows();
+    
+    TPZFNMatrix<100, std::complex<double>> uh_local(ncoef, fMesh->Solution().Cols(),0.);
+    fCoef.Resize(ncoef,fMesh->Solution().Cols());
+    
+    TPZFMatrix<STATE> &meshSol = fMesh->Solution();
+
+    int count = 0;
+    int nc = fCondEl->NConnects();
+    for (int ic=nc/2; ic<nc; ic++)
+    {
+        TPZConnect &c = fCondEl->Connect(ic);
+        int nshape = c.NShape();
+        int nstate = c.NState();
+        int blsize = nshape*nstate;
+        int64_t seqnum = c.SequenceNumber();
+        int64_t pos = fMesh->Block().Position(seqnum);
+        for (int seq=0; seq < blsize; seq++) {
+            for (int c=0; c<uh_local.Cols(); c++)
+            {
+                uh_local(count+seq,c) = meshSol(pos+seq,c);
+            }
+        }
+        count += blsize;
+    }
+    fPhiInverse.Multiply(uh_local, fCoef);
+
+    count = 0;
+    TPZFMatrix<std::complex<double>> diageigval(ndofs,ndofs);
+    for (int i = 0; i < ndofs; i++)
+    {
+        diageigval(i,i) = -fEigenvalues[i];
+    }
+
+    auto duh_local = fCoef;
+    TPZFMatrix<std::complex<double>> temp;
+    diageigval.Multiply(fCoef, temp);
+    fPhi.Multiply(temp, duh_local);
+
+    for (int ic=0; ic<nc/2; ic++)
+    {
+        TPZConnect &c = fCondEl->Connect(ic);
+        int nshape = c.NShape();
+        int nstate = c.NState();
+        int blsize = nshape*nstate;
+        int64_t seqnum = c.SequenceNumber();
+        int64_t pos = fMesh->Block().Position(seqnum);
+        for (int seq=0; seq < blsize; seq++) {
+            for (int c=0; c<uh_local.Cols(); c++)
+            {
+                meshSol(pos+seq,c) = duh_local(count+seq,c).real();
+            }
+        }
+        count += blsize;
+    }
+
+    fPhiInverse.Multiply(duh_local, fCoefD);
+
+    for (auto cel : fElGroup)
+    {
+        auto sbfem = dynamic_cast<TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad> *>(cel);
+#ifdef PZDEBUG
+        if (!sbfem) {
+            DebugStop();
+        }
+#endif
+        sbfem->LoadCoef(fCoef, fCoefD); // first coef is related to the average pressure, and the second is the dif pressure
+    }
+
+    fCondEl->LoadSolution();
+    
+#ifdef LOG4CXX
+    if (loggereigensystem->isDebugEnabled())
+    {
+        std::stringstream sout;
+        Mesh()->Solution().Print("uh = ", sout, EMathematicaInput);
+        uh_local.Print("uh = ", sout, EMathematicaInput);
+        fCoef.Print("fcoef = ", sout, EMathematicaInput);
+        fCoefD.Print("fcoefd = ", sout, EMathematicaInput);
+        LOGPZ_DEBUG(loggereigensystem,sout.str())
+    }
+#endif
+}
+
+void TPZSBFemMultiphysicsElGroup::AdjustConnectivities()
+{
+    // Permuting the condensed element's connectivity
+    auto ncon = fCondEl->NConnects();
+    auto ncontot = this->NConnects();
+
+    TPZManVector<int64_t> perm(ncon), indexes(ncontot);
+    int posdif = 0;
+    int posaver = ncon/2;
+    
+    for (auto cel : fElGroup)
+    {
+        auto sbfem  = dynamic_cast<TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad> *>(cel);
+        auto elvec = sbfem->SBFemElementVec();
+        // Adjusting connectivity - dif pressure        
+        {
+            auto celloc = elvec[0];
+
+            auto nconlocal = celloc->NConnects();
+            for (int ic = 0; ic < nconlocal; ic++)
+            {
+                perm[posdif+ic] = celloc->ConnectIndex(ic);
+            }
+            posdif += nconlocal;
+        }
+        // Adjusting connectivity - average pressure
+        {
+            auto celloc = elvec[6];
+
+            auto nconlocal = celloc->NConnects();
+            for (int ic = 0; ic < nconlocal; ic++)
+            {
+                perm[posaver+ic] = celloc->ConnectIndex(ic);
+            }
+            posaver += nconlocal;
+        }
+    }
+    fCondEl->PermuteActiveConnects(perm);
+    
+    for (int64_t i = 0; i < fCondEl->NConnects()/2; i++)
+    {
+        auto &c = fCondEl->Connect(i);
+        c.SetCondensed(true);
+    }
+
+    auto nconelgr = this->NConnects();
+    auto notcondensed = nconelgr - ncon;
+    TPZManVector<int64_t> connectsids(nconelgr);
+    for (auto i = 0; i < notcondensed; i++)
+    {
+        connectsids[i] = this->ConnectIndex(i);
+    }
+    auto pos = nconelgr - ncon;
+    for (auto i = 0; i < ncon; i++)
+    {
+        connectsids[i+pos] = fCondEl->ConnectIndex(i);
+    }
+    fCondensedEls->ReorderConnects(connectsids);
+
+
+    for (auto i = 0; i < ncon/2; i++)
+    {
+        connectsids[i+ncon/2] = fCondEl->ConnectIndex(i);
+    }
+    for (auto i = ncon/2; i < ncon; i++)
+    {
+        connectsids[i-ncon/2] = fCondEl->ConnectIndex(i);
+    }
+    for (auto i = ncon; i < nconelgr; i++)
+    {
+        connectsids[i] = this->ConnectIndex(i-ncon);
+    }
+    
+    this->ReorderConnects(connectsids);
+
+#ifdef LOG4CXX
+    if (loggersbfemcondensed->isDebugEnabled())
+    {
+        stringstream sout;
+        fCondEl->Print(sout);
+        LOGPZ_DEBUG(loggersbfemcondensed, sout.str());
+    }
+#endif
+}
+
+void TPZSBFemMultiphysicsElGroup::SetLocalIndices(int64_t index)
+{
+    int nc = fCondEl->NConnects();
+    TPZManVector<int, 10> firsteqcond(nc + 1, 0);
+    for (int ic = 0; ic < nc; ic++)
+    {
+        TPZConnect &c = fCondEl->Connect(ic);
+        firsteqcond[ic + 1] = firsteqcond[ic] + c.NShape() * c.NState();
+    }
+    auto numeqcondensed = *max_element(firsteqcond.begin(), firsteqcond.end());
+
+    std::map<int64_t, int> globtolocal;
+    nc = this->NConnects();
+    TPZManVector<int, 10> firsteq(nc + 1, 0);
+    for (int ic = 0; ic < nc; ic++)
+    {
+        globtolocal[this->ConnectIndex(ic)] = ic;
+        TPZConnect &c = this->Connect(ic);
+        firsteq[ic + 1] = firsteq[ic] + c.NShape() * c.NState();
+    }
+
+    for (auto cel : fElGroup)
+    {
+        auto sbfem  = dynamic_cast<TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad> *>(cel);
+        auto elvec = sbfem->SBFemElementVec();
+        TPZCompEl *celskeleton = elvec[6];
+
+        // Determining the number of equations for each element:
+        int neq = 0;
+        auto ncskeleton = celskeleton->NConnects();
+        for (int ic = 0; ic < ncskeleton; ic++)
+        {
+            TPZConnect &c = celskeleton->Connect(ic);
+            neq += c.NShape() * c.NState();
+        }
+
+        // LOCAL INDICES PRESSURE
+        TPZManVector<int64_t> localindices(neq);
+        int count = 0;
+        for (int ic = 0; ic < celskeleton->NConnects(); ic++)
+        {
+            int64_t cindex = celskeleton->ConnectIndex(ic);
+#ifdef PZDEBUG
+            if (globtolocal.find(cindex) == globtolocal.end()) DebugStop();
+#endif
+            int locfirst = firsteq[globtolocal[cindex]];
+            TPZConnect &c = celskeleton->Connect(ic);
+            int neq = c.NShape() * c.NState();
+            for (int eq = 0; eq < neq; eq++)
+            {
+                localindices[count++] = locfirst + eq;
+            }
+        }
+
+        if (sbfem->Element(6)->Reference()->NodeIndex(0) != sbfem->Element(5)->Reference()->NodeIndex(0))
+        {
+// #ifdef PZDEBUG
+//             cout << "Inverting local indices for subelement " << sbfem->Reference()->Index() << endl ;
+// #endif
+            TPZManVector<int64_t> localindicescopy(localindices);
+            localindices[0] = localindicescopy[1];
+            localindices[1] = localindicescopy[0];
+        }
+
+        // LOCAL INDICES FLUX
+        int neqflux = 0;
+        TPZCompEl *celflux = elvec[1];
+        auto ncflux = celflux->NConnects();
+        for (int ic = 0; ic < ncflux; ic++)
+        {
+            TPZConnect &c = celflux->Connect(ic);
+            neqflux += c.NShape() * c.NState();
+        }
+        int neqint = 0;
+        TPZCompEl *celinternal = elvec[3];
+        auto ncint = celinternal->NConnects() - ncskeleton - 2*ncflux;
+        for (int ic = 0; ic < ncint; ic++)
+        {
+            TPZConnect &c = celinternal->Connect(ic);
+            neqint += c.NShape() * c.NState();
+        }
+        
+        TPZManVector<int64_t> localindicesflux(neqflux);
+        count = 0;
+        for (int ic = 0; ic < ncflux; ic++)
+        {
+            int64_t cindex = celflux->ConnectIndex(ic);
+#ifdef PZDEBUG
+            if (globtolocal.find(cindex) == globtolocal.end()) DebugStop();
+#endif
+            TPZConnect &c = celflux->Connect(ic);
+            int neqflux = c.NShape() * c.NState();
+            int locfirst = firsteq[globtolocal[cindex]];
+            for (int eq = 0; eq < neqflux; eq++)
+            {
+                localindicesflux[count++] = locfirst + eq;
+            }
+        }
+        for (int id = 0; id < localindicesflux.size(); id++)
+        {
+            localindicesflux[id] -= numeqcondensed;
+        }
+        
+        TPZManVector<int64_t> localindicesint(neqint);
+        count = 0;
+        for (int ic = 0; ic < ncint; ic++)
+        {
+            int64_t cindex = celinternal->ConnectIndex(ic);
+#ifdef PZDEBUG
+            if (globtolocal.find(cindex) == globtolocal.end()) DebugStop();
+#endif
+            TPZConnect &c = celinternal->Connect(ic);
+            int neqint = c.NShape() * c.NState();
+            int locfirst = firsteq[globtolocal[cindex]];
+            for (int eq = 0; eq < neqint; eq++)
+            {
+                localindicesint[count++] = locfirst + eq;
+            }
+        }
+        for (int id = 0; id < localindicesint.size(); id++)
+        {
+            localindicesint[id] -= numeqcondensed;
+        }
+
+        sbfem->SetLocalIndices(localindices,localindicesint,localindicesflux);
+    }
+}
+
+/*
+
+Helpful doc to understand connectivity in SBFEMMultiphysics approach:
+
+ORDER CONNECTS INSIDE A TPZSBFemVolumeHdiv
+fElGroup[0]: 36 37 38 -> fDifPressure
+fElGroup[1]: 3 -> fFluxLeft
+fElGroup[2]: 3 36 37 38 -> fInterface
+fElGroup[3]: 0 1 2 3 4 | 24 25 26 -> fFlux | fInternalPressure
+fElGroup[4]: 4 -> fFluxRight
+fElGroup[5]: 4 48 49 50 -> fInterface
+fElGroup[6]: 48 49 50 -> fSkeleton (External Pressure)
+
+Material IDs:
+fSkeleton = 6
+fInterface = 7 
+fRightFlux = 8
+fInternal = 9
+fLeftFlux = 10
+fDifPressure = 11
+
+ORDER CONNECTS INSIDE A TPZSBFemMultiphysicsElGroup
+48 49 50 51 52 53 54 55 56 57 58 59 -> fSkeleton
+36 37 38 39 40 41 42 43 44 45 46 47 -> fDifPressure
+0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 -> fFlux
+24 25 26 27 28 29 30 31 32 33 34 35 -> fInternalPressure
+
+ORDER CONNECTS INSIDE THE TPZCondensedCompEl (fCondEl)
+36 37 38 39 40 41 42 43 44 45 46 47 -> fDifPressure
+48 49 50 51 52 53 54 55 56 57 58 59 -> fSkeleton
+Note: it is different from the order of TPZSBFemMultiphysicsElGroup. Here, 1st we have the fDifPressure 1st.
+
+*/

--- a/Mesh/TPZSBFemMultiphysicsElGroup.h
+++ b/Mesh/TPZSBFemMultiphysicsElGroup.h
@@ -1,0 +1,138 @@
+//
+//  TPZSBFemElementGroup.hpp
+//  PZ
+//
+//  Created by Karolinne Coelho on 22/01/21.
+//
+//
+
+#pragma once
+
+#include <stdio.h>
+#include "TPZSBFemElementGroup.h"
+#include "pzcondensedcompel.h"
+
+using namespace std;
+
+class TPZSBFemMultiphysicsElGroup : public TPZSBFemElementGroup
+{
+    
+private:
+    
+    TPZElementGroup * fCondensedEls;
+
+    TPZCondensedCompEl * fCondEl;
+    
+    /// Matrix of eigenvectors which compose the stiffness matrix
+    TPZFMatrix<std::complex<double>> fPhi;
+    
+    /// Matrix of eigenvectors which compose the stiffness matrix
+    TPZFMatrix<std::complex<double>> fPhiQ;
+    
+    /// Matrix of eigenvectors which compose the stiffness matrix for the flux
+    TPZFMatrix<std::complex<double>> fPhiFlux;
+    
+    /// Inverse of the eigenvector matrix (transfers eigenvector coeficients to side shape coeficients)
+    TPZFMatrix<std::complex<double>> fPhiInverse;
+    
+    /// Vector of eigenvalues of the SBFem analyis
+    TPZManVector<std::complex<double>> fEigenvalues;
+    
+    /// Multiplying coefficients of each eigenvector
+    TPZFMatrix<std::complex<double>> fCoef;
+    
+    /// Multiplying coefficients of each eigenvector
+    TPZFMatrix<std::complex<double>> fCoefD;
+    
+    TPZManVector<int64_t> fLocalindices;
+
+public:
+    
+    TPZSBFemMultiphysicsElGroup() : TPZSBFemElementGroup()
+    {
+        
+    }
+    
+    /// constructor
+    TPZSBFemMultiphysicsElGroup(TPZCompMesh &mesh, int64_t &index) : TPZSBFemElementGroup(mesh,index)
+    { 
+    }
+
+    TPZCondensedCompEl * CondensedCompEl()
+    {
+        return fCondEl;
+    }
+
+    void AddElement(TPZCompEl *cel) override;
+
+    virtual void Print(std::ostream &out) const override;
+
+    void GroupandCondense(set<int> & matidscondensed);
+
+
+    void ComputeMatrices(TPZElementMatrixT<STATE> &E0, TPZElementMatrixT<STATE> &E1, TPZElementMatrixT<STATE> &E2);
+    
+    /**
+     * @brief Computes the element stifness matrix and right hand side
+     * @param ek element stiffness matrix
+     * @param ef element load vector
+     */
+    virtual void CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef) override;
+
+
+    void ComputeMatrices(TPZElementMatrix &E0, TPZElementMatrix &E1, TPZElementMatrix &E2);
+
+
+    virtual void BuildCornerConnectList(std::set<int64_t> &connectindexes) const override
+    {
+        for (auto sbfemvol : fElGroup)
+        {
+            sbfemvol->BuildCornerConnectList(connectindexes);
+        }
+    }
+
+    void InitializeElementMatrix(TPZElementMatrixT<STATE> &ek, TPZElementMatrixT<STATE> &ef) const;
+
+    void LoadSolution() override;
+
+    void LoadFlux();
+    
+    TPZFMatrix<std::complex<double>> &PhiInverse()
+    {
+        return fPhiInverse;
+    }
+
+    void AdjustConnectivities();
+
+    void SetLocalIndices(int64_t index);
+    
+    void SetLocalIndicesFlux(int64_t index);
+
+    TPZManVector<double> EigenvaluesReal(TPZManVector<complex<double> > & eigenvalues)
+    {
+        int64_t nel = eigenvalues.NElements();
+        TPZManVector<double> eig(nel);
+        for(int64_t el=0; el<nel; el++)
+        {
+            eig[el] = eigenvalues[el].real();
+        }
+        return eig;
+    }
+
+    TPZFMatrix<double> EigenVectorsReal(TPZFMatrix<std::complex<double>> &eigvec)
+    {
+        auto nrows = eigvec.Rows();
+        auto ncols = eigvec.Cols();
+        TPZFMatrix<double> eig(nrows,ncols);
+
+        for (auto ir = 0; ir < nrows; ir++)
+        {
+            for (auto ic = 0; ic < ncols; ic++)
+            {
+                eig(ir,ic) = eigvec(ir,ic).real();
+            }
+        }
+        
+        return eig;
+    }
+};

--- a/Mesh/TPZSBFemVolume.h
+++ b/Mesh/TPZSBFemVolume.h
@@ -17,7 +17,7 @@
 
 class TPZSBFemVolume : public TPZInterpolationSpace
 {
-    
+protected:
     /// index of element group
     int64_t fElementGroupIndex = -1;
     

--- a/Mesh/TPZSBFemVolumeHdiv.cpp
+++ b/Mesh/TPZSBFemVolumeHdiv.cpp
@@ -1,0 +1,272 @@
+
+//
+//  TPZSBFemVolumeHdiv.cpp
+//  PZ
+//
+//  Created by Karolinne Coelho on 25/01/2021.
+//
+//
+
+#include "TPZSBFemVolumeHdiv.h"
+#include "pzgeoelside.h"
+#include "TPZSBFemElementGroup.h"
+#include "pzintel.h"
+#include "TPZMatCombinedSpaces.h"
+#include "TPZMatErrorCombinedSpaces.h"
+#include "pzelmat.h"
+#include "TPZBndCondT.h"
+#include "pzcmesh.h"
+#include "TPZGeoLinear.h"
+#include "pzmultiphysicscompel.h"
+#include "pzgraphelq2dd.h"
+#include "pzgraphelq3dd.h"
+#include "tpzgraphelprismmapped.h"
+
+// #ifdef LOG4CXX
+// static LoggerPtr logger(Logger::getLogger("pz.mesh.sbfemvolume"));
+// #endif
+
+TPZSBFemVolumeHdiv::TPZSBFemVolumeHdiv(TPZCompMesh & mesh, TPZGeoEl * gel, int64_t & index) : TPZInterpolationSpace(mesh, gel, index), fElementGroupIndex(-1), fSkeleton(-1)
+{
+    fElementVec1D.Resize(3);
+}
+
+TPZCompEl * TPZSBFemVolumeHdiv::Clone(TPZCompMesh &mesh) const
+{
+    // till I remember how this works
+    DebugStop();
+    return 0;
+}
+
+void TPZSBFemVolumeHdiv::AddElement1D(TPZCompEl * cel, int localindex)
+{
+    fElementVec1D[localindex] = cel;
+    auto ncon = fConnectIndexes.size();
+    auto nconcel = cel->NConnects();
+    
+    fConnectIndexes.Resize(ncon+nconcel);
+    for (auto i = 0; i < nconcel; i++)
+    {
+        fConnectIndexes[i+ncon] = cel->ConnectIndex(i);
+    }
+}
+
+void TPZSBFemVolumeHdiv::SetPhiFlux(TPZFMatrix<std::complex<double>> &phiflux, TPZManVector<std::complex<double>> &eigval)
+{        
+    fEigenvalues = eigval;
+    int nrow = fLocalIndicesFluxInt.size();
+    fPhiFluxInt.Resize(nrow, phiflux.Cols());
+    for (int i = 0; i < nrow; i++)
+    {
+        for (int j = 0; j < phiflux.Cols(); j++)
+        {
+            fPhiFluxInt(i, j) = phiflux(fLocalIndicesFluxInt[i], j);
+        }
+    }    
+
+    nrow = fLocalIndicesFlux.size();
+    fPhiFlux.Resize(nrow, phiflux.Cols());
+    for (int i = 0; i < nrow; i++)
+    {
+        for (int j = 0; j < phiflux.Cols(); j++)
+        {
+            fPhiFlux(i, j) = phiflux(fLocalIndicesFlux[i], j);
+        }
+    }
+}
+
+void TPZSBFemVolumeHdiv::SetLocalIndicesFlux(TPZManVector<int64_t> &localindicesfluxint, TPZManVector<int64_t> &localindicesflux)
+{
+    fLocalIndicesFluxInt = localindicesfluxint;
+    fLocalIndicesFlux = localindicesflux;
+}
+
+void TPZSBFemVolumeHdiv::LoadCoef(TPZFMatrix<std::complex<double>> &coef, TPZFMatrix<std::complex<double>> &coefd)
+{
+    fCoeficients = coef;
+    fCoeficientsD = coefd;
+}
+
+void TPZSBFemVolumeHdiv::ReallyComputeSolution(TPZMaterialDataT<STATE> & data)
+{
+    TPZCompMesh *cmesh = this->Mesh();
+    data.sol.Resize(fCoeficients.Cols());
+    data.dsol.Resize(fCoeficients.Cols());
+
+    TPZManVector<REAL> qsi = data.xParametric;
+
+    TPZGeoEl *Ref2D = this->Reference();
+    TPZMaterial *mat2d = cmesh->FindMaterial(Ref2D->MaterialId());
+    int dim = Ref2D->Dimension();
+
+    REAL sbfemparam = (1. - qsi[dim - 1]) / 2.;
+    if (IsZero(sbfemparam)) {
+        for (int i = 0; i < dim - 1; i++) {
+            qsi[i] = 0.;
+        }
+        if (dim == 2) {
+            sbfemparam = 1.e-6;
+            qsi[dim - 1] = 1. - 2.e-6;
+        } else {
+            sbfemparam = 1.e-4;
+            qsi[dim - 1] = 1. - 2.e-4;
+        }
+    }
+    
+    auto CFlux = dynamic_cast<TPZCompElHDivSBFem<pzshape::TPZShapeLinear> *> (fElementVec1D[1]);
+#ifdef PZDEBUG
+    if (!CFlux) DebugStop();
+#endif
+    
+    TPZMaterialDataT<STATE> data2d;
+
+    TPZManVector<REAL, 3> qsilow(qsi);
+    qsilow.Resize(dim - 1);
+
+    TPZGeoEl *Ref1D = CFlux->Reference();
+
+    Ref1D->Jacobian(qsilow, data.jacobian, data.axes, data.detjac, data.jacinv);
+    Ref2D->Jacobian(qsi, data2d.jacobian, data2d.axes, data2d.detjac, data2d.jacinv);
+    auto axes = data2d.axes;
+
+    CFlux->ComputeRequiredData(data, qsilow);
+
+    // TPZVec<TPZTransform<> > trvec;
+    // CFlux->AffineTransform(trvec);
+
+    // TPZManVector<REAL> locpt(CFlux->Reference()->Dimension());
+    // trvec[CFlux->Index()].Apply(qsilow, locpt);
+    // ComputeRequiredData(data,locpt);
+
+    int nshape = fPhiFlux.Rows() + fPhiFluxInt.Rows();
+    int nstate = mat2d->NStateVariables();
+    
+    data.divsol.Resize(data.sol.size());
+    
+    for (int s = 0; s < data.sol.size(); s++)
+    {
+        TPZManVector<std::complex<double>, 10> uh_xi(nshape, 0.), Duh_xi(nshape, 0.);
+        int nphixiint = fPhiFluxInt.Rows();
+        int nphixiext = fPhiFlux.Rows();
+        int numeig = fEigenvalues.size();
+        std::complex<double> xiexp;
+        for (int c = 0; c < numeig; c++) {
+            if (IsZero(fEigenvalues[c] + 1. + 0.5 * (dim - 2))) {
+                xiexp = 1;
+            } else {
+                xiexp = pow(sbfemparam, -fEigenvalues[c] -1. - 0.5 * (dim - 2));
+            }
+            for (int i = 0; i < nphixiint; i++) {
+                uh_xi[i] += fPhiFluxInt(i, c) * xiexp * fCoeficientsD(c, s);
+            }
+            for (int i = 0; i < nphixiext; i++) {
+                uh_xi[i+nphixiint] +=  fPhiFlux(i, c) * xiexp * fCoeficientsD(c, s);    
+            }
+        }
+        for (int c = numeig; c < 2*numeig; c++) {
+            if (IsZero(fEigenvalues[c-numeig] + 1. + 0.5 * (dim - 2))) { 
+                xiexp = 1;
+            } else {
+                xiexp = pow(sbfemparam, -fEigenvalues[c-numeig] -1. - 0.5 * (dim - 2));
+            }
+            for (int i = 0; i < nphixiint; i++) {
+                uh_xi[i] += fPhiFluxInt(i, c) * xiexp * fCoeficients(c-numeig, s);
+            }
+            for (int i = 0; i < nphixiext; i++) {
+                uh_xi[i+nphixiint] += fPhiFlux(i, c) * xiexp * fCoeficients(c-numeig, s);
+            }
+        }
+
+        data.sol[s].Resize(3);
+        data.sol[s].Fill(0.);
+
+        auto multiphysicsel = dynamic_cast<TPZMultiphysicsElement * >(CFlux);
+        auto collapsedel = dynamic_cast<TPZCompElHDivSBFem<pzshape::TPZShapeLinear> * >(fElementVec1D[1]);
+
+        int ishape = 0;
+        for (int ic = 0; ic < collapsedel->NConnects()-1; ic++)
+        {
+            auto nshape = collapsedel->NConnectShapeF(ic, collapsedel->GetPreferredOrder());
+            for (int is = 0; is < nshape; is++)
+            {
+                for (int istate = 0; istate < nstate; istate++)
+                {
+                    for (int d = 0; d < dim; d++)
+                    {
+                        int id = (ishape + is)* nstate + istate;
+                        data.sol[s][d] += data.phi(id) * data.fDeformedDirections(d,ic) * uh_xi[id].real();
+                    }
+                }
+            }
+            ishape += nshape;
+        }
+        {
+            data.dsol[s].Redim(dim*nstate, dim);
+            data.divsol[s].Resize(nstate);
+            data.divsol[s].Fill(0.);
+        }
+    }
+}
+
+int TPZSBFemVolumeHdiv::NShapeF() const
+{
+    int nc = fElementVec1D[1]->NConnects();
+    int nshape = 0;
+    for (int ic=0; ic<nc; ic++) {
+        TPZConnect &c = Connect(ic);
+        nshape += c.NShape();
+    }
+    return nshape;
+}
+
+int TPZSBFemVolumeHdiv::NConnectShapeF(int icon, int order) const
+{
+    DebugStop();
+    return 0;
+}
+
+TPZIntPoints & TPZSBFemVolumeHdiv::GetIntegrationRule()
+{
+    if(!fIntRule) InitializeIntegrationRule();
+    return *fIntRule;
+}
+
+const TPZIntPoints & TPZSBFemVolumeHdiv::GetIntegrationRule() const
+{
+    if(!fIntRule) DebugStop();
+    return *fIntRule;
+}
+
+void TPZSBFemVolumeHdiv::SetPreferredOrder ( int order )
+{
+    fPreferredOrder = order;
+}
+
+void TPZSBFemVolumeHdiv::BuildCornerConnectList(std::set<int64_t> &connectindexes) const
+{
+    fElementVec1D[1]->BuildCornerConnectList(connectindexes);
+}
+
+int TPZSBFemVolumeHdiv::Dimension() const
+{
+    return Reference()->Dimension();
+}
+
+int64_t TPZSBFemVolumeHdiv::ConnectIndex(int i) const
+{
+    if (i > fConnectIndexes.size())
+    {
+        DebugStop();
+    }        
+    return fConnectIndexes[i];
+}
+
+int TPZSBFemVolumeHdiv::NConnects() const
+{
+    return fConnectIndexes.size();   
+}
+
+TPZCompEl * CreateSBFemFluxCompEl(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index)
+{
+    return new TPZSBFemVolumeHdiv(mesh, gel, index);    
+}

--- a/Mesh/TPZSBFemVolumeHdiv.h
+++ b/Mesh/TPZSBFemVolumeHdiv.h
@@ -1,0 +1,180 @@
+//
+//  TPZSBFemVolumeHdiv.hpp
+//  PZ
+//
+//  Created by Karolinne Coelho on 25/01/2021.
+//
+//
+
+#pragma once
+
+#include <stdio.h>
+#include "pzcompel.h"
+#include "pzelmat.h"
+#include "TPZSBFemVolume.h"
+#include "TPZCompElHDivSBFem.h"
+#include "TPZMultiphysicsCompMesh.h"
+#include "TPZSBFemMultiphysicsElGroup.h"
+#include "pzmultiphysicselement.h"
+#include "pzmultiphysicscompel.h"
+#include "pzgeoquad.h"
+
+#include "pzshapelinear.h"
+#include "pzshapetriang.h"
+#include "pzshapequad.h"
+#include "pzelchdiv.h"
+
+#include "pzgraphelq2dd.h"
+#include "pzgraphelq3dd.h"
+#include "tpzgraphelprismmapped.h"
+
+using namespace std;
+using namespace pzshape;
+
+class TPZSBFemVolumeHdiv : public TPZInterpolationSpace
+{
+    /// index of element group
+    int64_t fElementGroupIndex = -1;
+
+    int fSkeleton = -1;
+
+    TPZCompEl *fElementGroup = 0;
+
+	/** @brief List of pointers to computational elements */
+    // Order of the elements: fLeftFlux, fRightFlux, fSkeleton
+	TPZManVector<TPZCompEl* ,3> fElementVec1D;
+    	
+	/** @brief Indexes of the connects of the element */
+	TPZVec<int64_t> fConnectIndexes;
+    
+    /// pointer to the integration rule
+    TPZIntPoints *fIntRule = 0;
+    
+    /// vector of local indices of multipliers in the group
+    TPZManVector<int64_t> fLocalIndicesFluxInt;
+    
+    /// vector of local indices of multipliers in the group
+    TPZManVector<int64_t> fLocalIndicesFlux;
+    
+    /// Section of the phi vector associated with this volume element
+    TPZFNMatrix<30,std::complex<double>> fPhiFluxInt;
+    
+    /// Section of the phi vector associated with this volume element
+    TPZFNMatrix<30,std::complex<double>> fPhiFlux;
+    
+    /// Eigenvlues associated with the internal shape functions
+    TPZManVector<std::complex<double>> fEigenvalues;
+    
+    /// Multiplier coeficients associated with the solution
+    TPZFNMatrix<30, std::complex<double>> fCoeficients;
+    TPZFNMatrix<30, std::complex<double>> fCoeficientsD;
+
+public:
+    
+    TPZSBFemVolumeHdiv(TPZCompMesh & mesh, TPZGeoEl * gel, int64_t & index);
+    
+    virtual ~TPZSBFemVolumeHdiv()
+    {
+    }
+
+    /** @brief Method for creating a copy of the element */
+    virtual TPZCompEl *Clone(TPZCompMesh &mesh) const override;
+
+    void AddElement1D(TPZCompEl * cel, int localindex);
+
+    void SetPhiFlux(TPZFMatrix<std::complex<double>> &phiflux, TPZManVector<std::complex<double>> &eigval);
+
+    void SetLocalIndicesFlux(TPZManVector<int64_t> &localindicesfluxint, TPZManVector<int64_t> &localindicesflux);
+
+    void LoadCoef(TPZFMatrix<std::complex<double>> &coef, TPZFMatrix<std::complex<double>> &coefd);
+
+    int NShapeF() const override;
+
+    virtual int NConnectShapeF(int icon, int order) const override;
+
+    /** @brief Returns a reference to an integration rule suitable for integrating the interior of the element */
+    virtual const TPZIntPoints &GetIntegrationRule() const override;
+    
+    /** @brief Returns a reference to an integration rule suitable for integrating the interior of the element */
+    virtual TPZIntPoints &GetIntegrationRule() override;
+
+    virtual void SetPreferredOrder ( int order ) override;
+
+    virtual void BuildCornerConnectList(std::set<int64_t> &connectindexes) const override;
+
+    virtual int Dimension() const override;
+
+    virtual int64_t ConnectIndex(int i) const override;
+
+    virtual int NConnects() const override;
+
+    virtual void ReallyComputeSolution(TPZMaterialDataT<STATE> & data) override;
+
+    void InitMaterialData(TPZMaterialData & data) override
+    {
+        auto datat = dynamic_cast<TPZMaterialDataT<STATE>*>(&data);
+        InitMaterialDataT(*datat);
+    }
+
+    void InitMaterialDataT(TPZMaterialDataT<STATE> &data)
+    {
+        auto collapsedcompel = dynamic_cast<TPZCompElHDivSBFem<pzshape::TPZShapeLinear>*>(fElementVec1D[1]);
+        collapsedcompel->InitMaterialData(data);
+    }
+
+    virtual void ComputeRequiredData(TPZMaterialDataT<STATE> &data, TPZVec<REAL> &qsi) override
+    {
+//         TPZManVector<REAL, 3> qsilow(qsi);
+//         qsilow.Resize(this->Reference()->Dimension() - 1);
+
+//         auto collapsedcompel = dynamic_cast<TPZCompElHDivSBFem<pzshape::TPZShapeLinear>*>(fElementVec1D[1]);
+// #ifdef PZDEBUG  
+//         if (!collapsedcompel) DebugStop();
+// #endif
+        
+//         collapsedcompel->ComputeRequiredData(data, qsilow);
+
+        data.xParametric = qsi;
+//         if (data.fNeedsSol)
+//         {
+            ReallyComputeSolution(data);
+        // }
+    };
+
+    void Shape(TPZVec<REAL> &qsi,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphidxi) override
+    {
+        DebugStop();
+    };
+
+    virtual TPZCompEl *ClonePatchEl(TPZCompMesh &mesh,
+                                    std::map<int64_t,int64_t> & gl2lcConMap,
+                                    std::map<int64_t,int64_t> & gl2lcElMap) const override
+    {
+        DebugStop();
+        return 0;
+    };
+
+    virtual void SetConnectIndex(int inode, int64_t index) override
+    {
+        DebugStop();
+    };
+
+    virtual int NSideConnects(int iside) const override
+    {
+        DebugStop();
+        return 0;
+    };
+
+    virtual int SideConnectLocId(int icon,int is) const override
+    {
+        DebugStop();
+        return 0;
+    };
+
+	virtual void PRefine ( int order ) override
+    {
+        DebugStop();
+    };
+};
+
+TPZCompEl * CreateSBFemFluxCompEl(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);

--- a/Mesh/TPZSBFemVolumeL2.cpp
+++ b/Mesh/TPZSBFemVolumeL2.cpp
@@ -1,0 +1,180 @@
+
+//
+//  TPZSBFemVolumeL2.cpp
+//  PZ
+//
+//  Created by Karolinne Coelho on 25/01/2021.
+//
+//
+
+#include "TPZSBFemVolumeL2.h"
+#include "pzgeoelside.h"
+#include "TPZSBFemElementGroup.h"
+#include "pzintel.h"
+#include "TPZMatSingleSpace.h"
+#include "TPZMatErrorSingleSpace.h"
+#include "pzelmat.h"
+#include "TPZBndCondT.h"
+#include "pzcmesh.h"
+#include "TPZGeoLinear.h"
+#include "pzgraphelq2dd.h"
+#include "pzgraphelq3dd.h"
+#include "tpzgraphelprismmapped.h"
+
+// #ifdef LOG4CXX
+// static LoggerPtr logger(Logger::getLogger("pz.mesh.sbfemvolume"));
+// #endif
+
+TPZSBFemVolumeL2::TPZSBFemVolumeL2(TPZCompMesh & mesh, TPZGeoEl * gel, int64_t & index) : TPZSBFemVolume(mesh, gel, index)
+{
+    fElementVec1D.Resize(3);
+}
+
+void TPZSBFemVolumeL2::LoadCoef(TPZFMatrix<std::complex<double>> &coef, TPZFMatrix<std::complex<double>> &coefd)
+{
+    fCoeficients = coef;
+    fCoeficientsD = coefd;
+}
+
+void TPZSBFemVolumeL2::SetElementGroupIndex(int64_t index)
+{
+    fElementGroupIndex = index;
+    TPZCompEl *celgr = Mesh()->Element(index);
+    fElementGroup = celgr;
+}
+
+/**
+ * @brief Computes solution and its derivatives in the local coordinate qsi.
+ * @param qsi master element coordinate
+ * @param sol finite element solution
+ * @param dsol solution derivatives
+ * @param axes axes associated with the derivative of the solution
+ */
+void TPZSBFemVolumeL2::ReallyComputeSolution(TPZMaterialDataT<STATE> & data)
+{
+    TPZVec<REAL> &qsi = data.xParametric;
+    TPZSolVec<STATE> &sol = data.sol;
+    TPZGradSolVec<STATE> &dsol = data.dsol;
+    TPZFMatrix<REAL> &axes = data.axes;
+
+    TPZCompMesh *cmesh = this->Mesh();
+    data.sol.Resize(fCoeficients.Cols());
+    data.dsol.Resize(fCoeficients.Cols());
+
+    TPZGeoEl *Ref2D = this->Reference();
+    int matid = Ref2D->MaterialId();
+    TPZMaterial *mat2d = cmesh->FindMaterial(matid);
+
+    int dim = Ref2D->Dimension();
+    REAL sbfemparam = (1. - qsi[dim - 1]) / 2.;
+    if (sbfemparam < 0.) {
+        std::cout << "sbfemparam " << sbfemparam << std::endl;
+        sbfemparam = 0.;
+    }
+    if (IsZero(sbfemparam)) {
+        for (int i = 0; i < dim - 1; i++) {
+            qsi[i] = 0.;
+        }
+        if (dim == 2) {
+            sbfemparam = 1.e-6;
+            qsi[dim - 1] = 1. - 2.e-6;
+        } else {
+            sbfemparam = 1.e-4;
+            qsi[dim - 1] = 1. - 2.e-4;
+        }
+    }
+
+    auto CSkeleton = dynamic_cast<TPZInterpolationSpace *> (fElementVec1D[2]);
+
+    TPZMaterialDataT<STATE> data1d, data2d;
+    // compute the lower dimensional shape functions
+    TPZManVector<REAL, 3> qsilow(qsi);
+    qsilow.Resize(dim - 1);
+
+    TPZGeoEl *Ref1D = CSkeleton->Reference();
+
+    CSkeleton->InitMaterialData(data1d);
+    CSkeleton->ComputeRequiredData(data1d, qsilow);
+
+    Ref1D->Jacobian(qsilow, data1d.jacobian, data1d.axes, data1d.detjac, data1d.jacinv);
+    Ref2D->Jacobian(qsi, data2d.jacobian, data2d.axes, data2d.detjac, data2d.jacinv);
+    axes = data2d.axes;
+
+    int nshape = data1d.phi.Rows();
+    int nstate = mat2d->NStateVariables();
+#ifdef PZDEBUG
+    if (fPhi.Cols() != fCoeficients.Rows()) {
+        DebugStop();
+    }
+#endif
+
+    for (int s = 0; s < sol.size(); s++) {
+        TPZManVector<std::complex<double>, 10> uh_xi(fPhi.Rows(), 0.), Duh_xi(fPhi.Rows(), 0.);
+        int nphixi = fPhi.Rows();
+        int numeig = fPhi.Cols();
+        for (int c = 0; c < numeig; c++) {
+            std::complex<double> xiexp;
+            std::complex<double> xiexpm1;
+            if (IsZero(fEigenvalues[c] + 0.5 * (dim - 2))) {
+                xiexp = 1;
+                xiexpm1 = 0;
+            } else if (IsZero(fEigenvalues[c] + 1. + 0.5 * (dim - 2))) {
+                xiexp = sbfemparam;
+                xiexpm1 = 1;
+            } else {
+                xiexp = pow(sbfemparam, -fEigenvalues[c] - 0.5 * (dim - 2));
+                xiexpm1 = pow(sbfemparam, -fEigenvalues[c] - 1. - 0.5 * (dim - 2));
+            }
+            for (int i = 0; i < nphixi; i++) {
+                uh_xi[i] += fCoeficients(c, s) * xiexp * fPhi(i, c);
+                Duh_xi[i] += -fCoeficients(c, s)*(fEigenvalues[c] + 0.5 * (dim - 2)) * xiexpm1 * fPhi(i, c);
+            }
+        }
+        
+#ifdef LOG4CXX2
+        if (s == 0 && logger->isDebugEnabled()) {
+            std::stringstream sout;
+            sout << "uh_xi " << uh_xi << std::endl;
+            sout << "Duh_xi " << Duh_xi << std::endl;
+            data1d.phi.Print(sout);
+            LOGPZ_DEBUG(logger, sout.str())
+        }
+#endif
+        
+        data.sol[s].Resize(nstate);
+        data.sol[s].Fill(0.);
+        TPZFNMatrix<9, STATE> dsollow(dim - 1, nstate, 0.), dsolxieta(dim, nstate, 0.);
+        TPZManVector<STATE, 3> dsolxi(nstate, 0.);
+        for (int ishape = 0; ishape < nshape; ishape++) {
+            for (int istate = 0; istate < nstate; istate++) {
+                sol[s][istate] += data1d.phi(ishape) * uh_xi[ishape * nstate + istate].real();
+                dsolxi[istate] += data1d.phi(ishape) * Duh_xi[ishape * nstate + istate].real();
+                for (int d = 0; d < dim - 1; d++) {
+                    dsollow(d, istate) += data1d.dphi(d, ishape) * uh_xi[ishape * nstate + istate].real();
+                }
+            }
+        }
+        for (int istate = 0; istate < nstate; istate++) {
+            for (int d = 0; d < dim - 1; d++) {
+                dsolxieta(d, istate) = dsollow(d, istate);
+            }
+            dsolxieta(dim - 1, istate) = -dsolxi[istate] / 2.;
+        }
+        data.dsol[s].Resize(dim, nstate);
+        data.dsol[s].Zero();
+        for (int istate = 0; istate < nstate; istate++) {
+            for (int d1 = 0; d1 < dim; d1++) {
+                for (int d2 = 0; d2 < dim; d2++) {
+                    data.dsol[s](d1, istate) += data2d.jacinv(d2, d1) * dsolxieta(d2, istate);
+                }
+            }
+        }
+    }
+}
+
+#include "pzaxestools.h"
+
+TPZCompEl * CreateSBFemPressureCompEl(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index)
+{
+    return new TPZSBFemVolumeL2(mesh, gel, index);    
+}

--- a/Mesh/TPZSBFemVolumeL2.h
+++ b/Mesh/TPZSBFemVolumeL2.h
@@ -1,0 +1,209 @@
+//
+//  TPZSBFemVolumeL2.hpp
+//  PZ
+//
+//  Created by Karolinne Coelho on 25/01/2021.
+//
+//
+
+#pragma once
+
+#include <stdio.h>
+#include "pzcompel.h"
+#include "pzelmat.h"
+#include "TPZSBFemVolume.h"
+#include "TPZCompElHDivSBFem.h"
+#include "TPZMultiphysicsCompMesh.h"
+#include "TPZSBFemMultiphysicsElGroup.h"
+#include "pzmultiphysicselement.h"
+#include "pzmultiphysicscompel.h"
+#include "pzgeoquad.h"
+#include "TPZGeoLinear.h"
+
+#include "pzshapelinear.h"
+#include "pzshapetriang.h"
+#include "pzshapequad.h"
+#include "pzelchdiv.h"
+
+#include "pzgraphelq2dd.h"
+#include "pzgraphelq3dd.h"
+#include "tpzgraphelprismmapped.h"
+
+using namespace std;
+using namespace pzshape;
+
+class TPZSBFemVolumeL2 : public TPZSBFemVolume
+{
+    // TPZSBFemVolume has the fSkeleton data
+
+	/** @brief List of pointers to computational elements */
+    // Order of the elements: fDifPressure, fInternal, fSkeleton
+	TPZManVector<TPZCompEl* ,3> fElementVec1D;
+    
+    /// vector of local indices of the internal pressure
+    TPZManVector<int64_t> fLocalIndicesInt;
+    
+    /// Section of the phi vector associated the internal pressure
+    TPZFNMatrix<30,std::complex<double>> fPhiInt;
+    
+    /// Multiplier coeficients associated with the internal pressure
+    TPZFNMatrix<30, std::complex<double>> fCoeficientsInt;
+    
+    /// vector of local indices of the internal pressure
+    TPZManVector<int64_t> fLocalIndicesDifPr;
+    
+    /// Section of the phi vector associated the internal pressure
+    TPZFNMatrix<30,std::complex<double>> fPhiDifPr;
+    
+    /// Multiplier coeficients associated with the internal pressure
+    TPZFNMatrix<30, std::complex<double>> fCoeficients;
+    TPZFNMatrix<30, std::complex<double>> fCoeficientsD;
+
+	/// Indexes of the connects of all pressure elements
+	TPZVec<int64_t> fConnectIndexes;
+
+public:
+    
+    TPZSBFemVolumeL2(TPZCompMesh & mesh, TPZGeoEl * gel, int64_t & index);
+    
+    virtual ~TPZSBFemVolumeL2()
+    {
+        // Reference()->ResetReference();
+    }
+
+    void SetLocalIndices(TPZManVector<int64_t> &localindices)
+    {
+        fLocalIndices = localindices;
+    }
+
+
+    void InitMaterialData(TPZMaterialData & data) override
+    {
+        TPZSBFemVolume::InitMaterialData(data);
+    }
+
+    virtual void ComputeRequiredData(TPZMaterialDataT<STATE> &data, TPZVec<REAL> &qsi) override
+    {
+        // auto CSkeleton = dynamic_cast<TPZInterpolationSpace *> (fElementVec1D[2]);
+
+        // // compute the lower dimensional shape functions
+        // TPZManVector<REAL, 3> qsilow(qsi);
+        // qsilow.Resize(this->Reference()->Dimension() - 1);
+        // CSkeleton->ComputeRequiredData(data, qsilow);
+
+        // auto Ref2D = this->Reference();
+        // TPZMaterialDataT<STATE> data2d;
+        // Ref2D->Jacobian(qsi, data2d.jacobian, data2d.axes, data2d.detjac, data2d.jacinv);
+        // data.axes = data2d.axes;
+
+        // data.xParametric = qsi;
+
+        data.xParametric = qsi;
+        // if (data.fNeedsSol)
+        // {
+            ReallyComputeSolution(data);
+        // }
+    }
+
+    void LoadCoef(TPZFMatrix<std::complex<double>> &coef, TPZFMatrix<std::complex<double>> &coefd);
+
+    virtual void ReallyComputeSolution(TPZMaterialDataT<STATE> & data) override;
+
+    void AddElement1D(TPZCompEl * cel, int localindex)
+    {
+        fElementVec1D[localindex] = cel;
+        auto ncon = fConnectIndexes.size();
+        auto nconcel =cel->NConnects();
+        fConnectIndexes.Resize(ncon+nconcel);
+        for (auto i = 0; i < nconcel; i++)
+        {
+            fConnectIndexes[i+ncon] = cel->ConnectIndex(i);
+        }
+    }
+
+    void SetElementGroupIndex(int64_t index);
+
+    void SetPhiEigVal(TPZFMatrix<std::complex<double>> &phi, TPZManVector<std::complex<double>> &eigval)
+    {
+        fEigenvalues = eigval;
+        
+        int nrow = fLocalIndices.size();
+        fPhi.Resize(nrow, phi.Cols());
+        for (int i = 0; i < nrow; i++) {
+            for (int j = 0; j < phi.Cols(); j++) {
+                fPhi(i, j) = phi(fLocalIndices[i], j);
+            }
+        }
+    };
+
+    /** @brief Returns the number of nodes of the element */
+    virtual int NConnects() const override
+    {
+        return fConnectIndexes.size();   
+    }
+
+    virtual int64_t ConnectIndex(int i) const override
+    {
+        if (i > fConnectIndexes.size())
+        {
+            DebugStop();
+        }        
+        return fConnectIndexes[i];
+    }
+
+    virtual int Dimension() const override
+    {
+        TPZGeoEl *reference = Reference();
+        return reference->Dimension();
+    }
+
+    virtual void CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef) override
+    {
+        DebugStop();
+    }
+
+    virtual void BuildCornerConnectList(std::set<int64_t> &connectindexes) const override
+    {
+        fElementVec1D[2]->BuildCornerConnectList(connectindexes);
+    }
+
+    virtual int NSideConnects(int iside) const override
+    {
+        DebugStop();
+        return 0;
+    }
+
+    virtual int SideConnectLocId(int icon,int is) const override
+    {
+        DebugStop();
+        return 0;
+    }
+
+    virtual int NShapeF() const override
+    {
+        int nc = fElementVec1D[2]->NConnects();
+        int nshape = 0;
+        for (int ic=0; ic<nc; ic++) {
+            TPZConnect &c = Connect(ic);
+            nshape += c.NShape();
+        }
+        return nshape;
+    }
+
+    virtual TPZCompEl *Element(int elindex)
+    {
+        return fElementVec1D[elindex];
+    }
+
+    virtual TPZManVector<TPZCompEl *,3> & ElementVec()
+    {
+        return fElementVec1D;
+    }
+
+    virtual void SetConnectIndexes(TPZVec<int64_t> &indexes)
+    {
+        fConnectIndexes = indexes;
+    }
+};
+
+TPZCompEl * CreateSBFemPressureCompEl(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);

--- a/Mesh/TPZSBFemVolumeMultiphysics.cpp
+++ b/Mesh/TPZSBFemVolumeMultiphysics.cpp
@@ -1,0 +1,591 @@
+
+//
+//  TPZSBFemVolumeMultiphysics.cpp
+//  PZ
+//
+//  Created by Karolinne Coelho on 25/01/2021.
+//
+//
+
+#include "TPZSBFemVolumeL2.h"
+#include "TPZSBFemVolumeHdiv.h"
+#include "TPZSBFemVolumeMultiphysics.h"
+#include "pzgeoelside.h"
+#include "TPZSBFemElementGroup.h"
+#include "pzintel.h"
+#include "TPZMatCombinedSpaces.h"
+#include "TPZMatErrorCombinedSpaces.h"
+#include "pzelmat.h"
+#include "TPZBndCondT.h"
+#include "TPZNullMaterialCS.h"
+#include "pzcmesh.h"
+#include "pzmultiphysicscompel.h"
+#include "pzgraphelq2dd.h"
+#include "pzgraphelq3dd.h"
+#include "tpzgraphelprismmapped.h"
+
+#include "pzgeopoint.h"
+#include "pzgeoquad.h"
+#include "pzgeotriangle.h"
+#include "pzgeotetrahedra.h"
+#include "pzgeoprism.h"
+#include "TPZGeoCube.h"
+#include "TPZGeoLinear.h"
+#include "pzgeopyramid.h"
+
+#ifdef LOG4CXX
+static LoggerPtr logger(Logger::getLogger("pz.mesh.sbfemvolume"));
+#endif
+
+template<class TGeometry>
+TPZSBFemVolumeMultiphysics<TGeometry>::TPZSBFemVolumeMultiphysics(TPZCompMesh & mesh, TPZGeoEl * gel, int64_t & index) : TPZMultiphysicsCompEl<TGeometry>(mesh, gel, index)
+{
+    fElementVec1D.Resize(7);
+}
+
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::AddElement1D(TPZCompEl * cel, int localindex)
+{
+    fElementVec1D[localindex] = cel;
+    auto ncon = fConnectIndexes.size();
+    auto nconcel =cel->NConnects();
+    fConnectIndexes.Resize(ncon+nconcel);
+    for (auto i = 0; i < nconcel; i++)
+    {
+        fConnectIndexes[i+ncon] = cel->ConnectIndex(i);
+    }
+}
+
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::AddElement(TPZCompEl *cel, int64_t meshindex)
+{
+    if (fElementVec.size() <= meshindex) 
+    {
+        fElementVec.resize(meshindex+1);
+        TPZMultiphysicsElement::fActiveApproxSpace.Resize(meshindex+1, 1);
+    }
+    if (cel)
+    {
+        TPZGeoEl *gel = cel->Reference();
+        TPZCompElSide celside(cel,gel->NSides()-1);
+        fElementVec[meshindex] = celside;
+    }
+    else
+    {
+        fElementVec[meshindex] = TPZCompElSide();
+    }
+}
+
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::SetElementGroupIndex(int64_t index)
+{
+    fElementGroupIndex = index;
+    TPZCompEl *celgr = this->Mesh()->Element(index);
+    fElementGroup = celgr;
+}
+
+template<class TGeometry>
+TPZCompEl * TPZSBFemVolumeMultiphysics<TGeometry>::Element(int64_t elindex)
+{
+    return fElementVec[elindex].Element();
+}
+
+template<class TGeometry>
+TPZCompEl * TPZSBFemVolumeMultiphysics<TGeometry>::ReferredElement(int64_t mesh)
+{
+#ifdef PZDEBUG
+    if (fElementVec.size() <= mesh) {
+        PZError << "Error at " << __PRETTY_FUNCTION__ << " index does not exist!\n";
+        DebugStop();
+    };
+#endif
+    return fElementVec[mesh].Element();
+}
+
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::SetSkeleton(int64_t skeleton)
+{
+    fSkeleton = skeleton;
+}
+
+template<class TGeometry>
+int64_t TPZSBFemVolumeMultiphysics<TGeometry>::SkeletonIndex()
+{
+    return fSkeleton;
+}
+
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::LoadCoef(TPZFMatrix<std::complex<double>> &coef, TPZFMatrix<std::complex<double>> &coefd)
+{
+    auto sbfemflux = dynamic_cast<TPZSBFemVolumeHdiv * >(fElementVec[0].Element());
+#ifdef PZDEBUG
+    if(!sbfemflux) DebugStop();
+#endif
+    sbfemflux->LoadCoef(coef, coefd);
+
+    auto sbfeml2 = dynamic_cast<TPZSBFemVolumeL2 * >(fElementVec[1].Element());
+#ifdef PZDEBUG
+    if(!sbfeml2) DebugStop();
+#endif
+    sbfeml2->LoadCoef(coef, coefd);
+    
+}
+
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::SetLocalIndices(TPZManVector<int64_t> &localindices, TPZManVector<int64_t> &localindicesint, TPZManVector<int64_t> &localindicesflux)
+{
+    auto sbfemflux = dynamic_cast<TPZSBFemVolumeHdiv * >(fElementVec[0].Element());
+#ifdef PZDEBUG
+    if(!sbfemflux) DebugStop();
+#endif
+    sbfemflux->SetLocalIndicesFlux(localindicesint,localindicesflux);
+
+    auto sbfeml2 = dynamic_cast<TPZSBFemVolumeL2 * >(fElementVec[1].Element());
+#ifdef PZDEBUG
+    if(!sbfeml2) DebugStop();
+#endif
+    sbfeml2->SetLocalIndices(localindices);
+}
+
+template<class TGeometry>
+int TPZSBFemVolumeMultiphysics<TGeometry>::NConnects() const
+{
+    return fConnectIndexes.size();   
+}
+
+template<class TGeometry>
+int64_t TPZSBFemVolumeMultiphysics<TGeometry>::ConnectIndex(int i) const
+{
+    if (i > fConnectIndexes.size())
+    {
+        DebugStop();
+    }        
+    return fConnectIndexes[i];
+}
+
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::CreateGraphicalElement(TPZGraphMesh &graphmesh, int dimension)
+{
+    TPZGeoEl *ref = this->Reference();
+    if (ref->Dimension() != dimension) {
+        return;
+    }
+    MElementType ty = ref->Type();
+    if (ty == EQuadrilateral) {
+        new TPZGraphElQ2dd(this, &graphmesh);
+    } else if (ty == ECube) {
+        new TPZGraphElQ3dd(this, &graphmesh);
+    } else if (ty == EPrisma) {
+        new TPZGraphElPrismMapped(this, &graphmesh);
+    } else {
+        DebugStop();
+    }
+}
+
+template<class TGeometry>
+TPZIntPoints & TPZSBFemVolumeMultiphysics<TGeometry>::GetIntegrationRule() const
+{
+    if(!fIntRule) DebugStop();
+    return *fIntRule;
+}
+
+template<class TGeometry>
+TPZIntPoints & TPZSBFemVolumeMultiphysics<TGeometry>::GetIntegrationRule()
+{
+    if(!fIntRule) InitializeIntegrationRule();
+    return *fIntRule;
+}
+
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::BuildCornerConnectList(std::set<int64_t> &connectindexes) const
+{
+    auto celskeleton = fElementVec1D[6];
+    celskeleton->BuildCornerConnectList(connectindexes);
+}
+
+template<class TGeometry>
+TPZCompEl * TPZSBFemVolumeMultiphysics<TGeometry>::Element(int elindex)
+{
+    return fElementVec1D[elindex];
+}
+
+template<class TGeometry>
+TPZManVector<TPZCompEl * ,7> & TPZSBFemVolumeMultiphysics<TGeometry>::SBFemElementVec()
+{
+    return fElementVec1D;
+}
+
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::SetPhiEigVal(TPZFMatrix<std::complex<double>> &phi, TPZManVector<std::complex<double>> &eigval)
+{
+    fEigenvalues = eigval;
+    
+    // int nrow = fLocalIndices.size();
+    // fPhi.Resize(nrow, phi.Cols());
+    // for (int i = 0; i < nrow; i++) {
+    //     for (int j = 0; j < phi.Cols(); j++) {
+    //         fPhi(i, j) = phi(fLocalIndices[i], j);
+    //     }
+    // }
+    
+
+    auto sbfeml2 = dynamic_cast<TPZSBFemVolumeL2 * >(fElementVec[1].Element());
+#ifdef PZDEBUG
+    if(!sbfeml2) DebugStop();
+#endif
+    sbfeml2->SetPhiEigVal(phi, eigval);
+}
+
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::SetPhiFlux(TPZFMatrix<std::complex<double>> &phiflux, TPZManVector<std::complex<double>> &eigval)
+{
+    auto sbfemhdiv = dynamic_cast<TPZSBFemVolumeHdiv * >(fElementVec[0].Element());
+#ifdef PZDEBUG
+    if(!sbfemhdiv) DebugStop();
+#endif
+    sbfemhdiv->SetPhiFlux(phiflux, eigval);
+}
+
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::AffineTransform(TPZVec<TPZTransform<> > &trVec) const
+{
+    int64_t nel;
+    int side, dim, dimmf;
+    nel=fElementVec.size();
+    trVec.Resize(nel);
+    TPZGeoEl *gelmf = this->Reference();
+    dimmf = gelmf->Dimension();
+    side = gelmf->NSides()-1;
+    TPZGeoEl  *geoel;
+    for (int64_t i = 0; i<nel; i++) {
+        if (!fElementVec[i]) {
+            continue;
+        }
+        geoel = fElementVec[i].Element()->Reference();
+        dim =  geoel->Dimension();
+        if (dim == dimmf) {
+            TPZTransform<> tr(dim);
+            TPZGeoElSide gelside(geoel,geoel->NSides()-1);
+            TPZGeoElSide gelmfside(gelmf,side);
+            if (gelside.NeighbourExists(gelmfside))
+            {
+                trVec[i] = tr;
+                gelmfside.SideTransform3(gelside, trVec[i]);
+            }
+            else
+            {
+                trVec[i] = gelmf->BuildTransform2(side, geoel, tr);
+            }
+        }
+        else
+        {
+            TPZTransform<> LocalTransf(dimmf);
+            TPZGeoElSide thisgeoside(gelmf,gelmf->NSides()-1);
+            TPZGeoElSide neighgeoside = fElementVec[i].Reference();
+            thisgeoside.SideTransform3(neighgeoside, LocalTransf);
+            TPZGeoElSide highdim(neighgeoside.Element(), neighgeoside.Element()->NSides()-1);
+            trVec[i] = neighgeoside.SideToSideTransform(highdim).Multiply(LocalTransf);
+            
+        }
+    }
+}
+
+/**
+ * @brief Computes solution and its derivatives in the local coordinate qsi.
+ * @param qsi master element coordinate
+ * @param sol finite element solution
+ * @param dsol solution derivatives
+ * @param axes axes associated with the derivative of the solution
+*/
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::Solution(TPZVec<REAL> &qsi,int var,TPZVec<STATE> &sol)
+{
+    if (var >= 99) {
+        TPZCompEl::Solution(qsi, var, sol);
+        return;
+    }
+    
+    auto *material =
+        dynamic_cast<TPZMatCombinedSpacesT<STATE>*>(this->Material());
+    if(!material){
+        sol.Resize(0);
+        return;
+    }
+
+    TPZGeoEl *Ref2D = this->Reference();
+    int matid = Ref2D->MaterialId();
+    auto *mat2d =
+        dynamic_cast<TPZMatCombinedSpacesT<STATE>*>(this->Mesh()->FindMaterial(matid));
+    TPZMaterialDataT<STATE> data2d;
+    
+    TPZManVector<TPZTransform<> > trvec;
+    AffineTransform(trvec);
+    
+    TPZManVector<REAL,3> myqsi(qsi);
+    myqsi.resize(qsi.size());
+    
+    int64_t nref = fElementVec.size();
+    TPZManVector<TPZMaterialDataT<STATE>,2> datavec;
+    datavec.resize(nref);
+    InitMaterialData(datavec);
+    material->FillDataRequirements(datavec);
+    for (int64_t iref = 0; iref<nref; iref++)
+    {
+        TPZInterpolationSpace *msp  = dynamic_cast <TPZInterpolationSpace *>(fElementVec[iref].Element());
+        if(!msp) continue;
+        trvec[iref].Apply(qsi, myqsi);
+        datavec[iref].p = msp->MaxOrder();
+        
+        TPZMaterialData::MShapeFunctionType shapetype = datavec[iref].fShapeType;
+        msp->ComputeRequiredData(datavec[iref], myqsi);
+        constexpr bool hasPhi{true};
+        msp->ComputeSolution(myqsi, datavec[iref],hasPhi);
+        
+        datavec[iref].x.Resize(3);
+        msp->Reference()->X(myqsi, datavec[iref].x);
+    }
+    
+    material->Solution(datavec, var, sol);
+    for (int64_t iref = 0; iref<nref; iref++)
+    {
+        
+        TPZInterpolationSpace *msp  = dynamic_cast <TPZInterpolationSpace *>(fElementVec[iref].Element());
+        if(!msp) continue;
+        msp->CleanupMaterialData(datavec[iref]);
+    }
+}
+
+#include "pzaxestools.h"
+
+template <class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::InitMaterialData(TPZVec<TPZMaterialDataT<STATE> > &dataVec, TPZVec<int64_t> *indices)
+{
+    int64_t nref = this->fElementVec.size();
+    
+#ifdef PZDEBUG
+    if (nref != dataVec.size()) {
+        PZError << "Error at " << __PRETTY_FUNCTION__ << " The number of materials can not be different from the size of the fElementVec !\n";
+        DebugStop();
+    }
+#endif
+    if(indices){
+        int64_t nindices = indices->size();
+        TPZVec<int> nshape(nindices);
+        for (int64_t iref = 0; iref <nindices; iref++) {
+            int64_t indiciref = indices->operator[](iref);
+            if(fElementVec[indiciref])
+            {
+                dataVec[indiciref].gelElId = fElementVec[indiciref].Element()->Reference()->Id();
+            }
+            TPZInterpolationSpace *msp  = dynamic_cast <TPZInterpolationSpace *>(fElementVec[indiciref].Element());
+            if (!msp) {
+                continue;
+            }
+            // precisa comentar essa parte se for calcular os vetores no pontos de integracao.
+            msp->InitMaterialData(dataVec[indiciref]);
+        }
+    }else{
+        TPZVec<int> nshape(nref);
+        for (int64_t iref = 0; iref < nref; iref++)
+        {
+            if(fElementVec[iref])
+            {
+                dataVec[iref].gelElId = fElementVec[iref].Element()->Reference()->Id();
+            }
+            TPZInterpolationSpace *msp  = dynamic_cast <TPZInterpolationSpace *>(fElementVec[iref].Element());
+            if (!msp) {
+                continue;
+            }
+            // precisa comentar essa parte se for calcular os vetores no pontos de integracao.
+            msp->InitMaterialData(dataVec[iref]);
+        }
+    }
+    
+    int n_active_approx_spaces = TPZMultiphysicsElement::fActiveApproxSpace.size();
+    if (n_active_approx_spaces == 0) { /// it preserves the integrity for old version of multiphycis codes.
+        TPZMultiphysicsElement::fActiveApproxSpace.Resize(nref, 1);
+    }
+    
+    for (int64_t iref = 0; iref < nref; iref++) {
+        dataVec[iref].fActiveApproxSpace = TPZMultiphysicsElement::fActiveApproxSpace[iref];
+    }
+    auto * mat =
+        dynamic_cast<TPZMatCombinedSpacesT<STATE>*>(this->Material());
+    mat->FillDataRequirements(dataVec);
+    
+}
+
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::ComputeRequiredData(TPZVec<TPZMaterialDataT<STATE>> &dataVec,TPZVec<REAL> &qsi)
+{
+    if(dataVec.size())
+    {
+        for (int i = 0; i < 2; i++)        
+        {
+            auto sbfemvol = dynamic_cast<TPZInterpolationSpace *>(fElementVec[i].Element());
+            if (!sbfemvol)
+            {
+                DebugStop();
+            }
+            
+            sbfemvol->Reference()->X(qsi, dataVec[i].x);        
+
+            TPZVec<TPZTransform<> > trvec;
+            AffineTransform(trvec);
+            TPZManVector<REAL> locpt(sbfemvol->Reference()->Dimension());
+            trvec[i].Apply(qsi, locpt);
+
+            sbfemvol->ComputeRequiredData(dataVec[i],locpt);
+        }
+    }
+    else
+        DebugStop();
+}
+
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::EvaluateError(TPZVec<REAL> &errors,bool store_error)
+{
+    auto *nullmat = dynamic_cast<TPZNullMaterialCS<STATE> *>(this->Material());
+    if(nullmat) return;
+
+    auto *mat = dynamic_cast<TPZMatCombinedSpacesT<STATE>*>(this->Material());
+    auto *matError = dynamic_cast<TPZMatErrorCombinedSpaces<STATE>*>(mat);
+
+    if (!matError || !(matError->HasExactSol()))
+    {
+        PZError<<__PRETTY_FUNCTION__;
+        PZError<<" the material has no associated exact solution\n";
+        PZError<<"Aborting...";
+        DebugStop();
+    }
+    if (dynamic_cast<TPZBndCond *> (matError)) return;
+
+    int problemdimension = this->Mesh()->Dimension();
+    TPZGeoEl *ref = this->Reference();
+    if (ref->Dimension() < problemdimension) return;
+
+    int NErrors = matError->NEvalErrors();
+    errors.Resize(NErrors);
+    errors.Fill(0.);
+
+    int dim = Dimension();
+    TPZAutoPointer<TPZIntPoints> intrule = ref->CreateSideIntegrationRule(ref->NSides() - 1, 5);
+    int maxIntOrder = intrule->GetMaxOrder();
+    TPZManVector<int, 3> prevorder(dim), maxorder(dim, maxIntOrder);
+    intrule->GetOrder(prevorder);
+    intrule->SetOrder(maxorder);
+
+    int ndof = this->Material()->NStateVariables();
+    TPZManVector<STATE, 10> u_exact(ndof);
+    TPZFNMatrix<90, STATE> du_exact(dim, ndof);
+
+    TPZManVector<REAL, 10> intpoint(problemdimension), values(NErrors);
+    values.Fill(0.0);
+    REAL weight;
+    TPZManVector<STATE, 9> flux_el(0, 0.);
+
+    TPZManVector<TPZMaterialDataT<STATE>,2> datavec(2);
+    InitMaterialData(datavec);
+
+    const int64_t nref = fElementVec.size();
+    int iactive = -1;
+    for (unsigned int i = 0; i < nref; ++i) {
+        if (datavec[i].fShapeType != TPZMaterialData::EEmpty) {
+            datavec[i].fNeedsSol = true;
+            iactive = i;
+        }
+    }
+    if (iactive == -1) DebugStop();
+
+    int nintpoints = intrule->NPoints();
+    TPZFNMatrix<9, REAL> jac, axe, jacInv;
+    REAL detJac;
+
+    for (int nint = 0; nint < nintpoints; nint++)
+    {
+        intrule->Point(nint, intpoint, weight);
+
+        ref->Jacobian(intpoint, jac, axe, detJac, jacInv);
+        ComputeRequiredData(datavec, intpoint);
+        
+        weight *= fabs(detJac);
+        matError->Errors(datavec, values);
+
+        for (int ier = 0; ier < NErrors; ier++)
+        {
+            errors[ier] += values[ier] * weight;
+        }
+    }
+    //Norma sobre o elemento
+    for (int ier = 0; ier < NErrors; ier++) {
+        errors[ier] = sqrt(errors[ier]);
+    }//for ier
+
+    if (store_error) {
+        int64_t index = TPZMultiphysicsElement::Index();
+        TPZFMatrix<STATE> &elvals = this->Mesh()->ElementSolution();
+        if (elvals.Cols() < NErrors) {
+            std::cout << "The element solution of the mesh should be resized before EvaluateError\n";
+            DebugStop();
+        }
+        for (int ier = 0; ier < NErrors; ier++) {
+            elvals(index, ier) = errors[ier];
+        }
+    }
+    intrule->SetOrder(prevorder);
+
+}
+
+template<class TGeometry>
+void TPZSBFemVolumeMultiphysics<TGeometry>::InitializeIntegrationRule()
+{
+    if (fIntRule) {
+        DebugStop();
+    }
+    int nsides = this->Reference()->NSides();
+    fIntRule = this->Reference()->CreateSideIntegrationRule(nsides-1, 1);
+}
+
+template<class TGeometry>
+int TPZSBFemVolumeMultiphysics<TGeometry>::Dimension() const
+{
+    return this->Reference()->Dimension();
+}
+
+template<class TGeometry>
+int TPZSBFemVolumeMultiphysics<TGeometry>::NShapeF() const
+{
+    int nc = fElementVec1D[6]->NConnects();
+    int nshape = 0;
+    for (int ic=0; ic<nc; ic++) {
+        TPZConnect &c = fElementVec1D[6]->Connect(ic);
+        nshape += c.NShape();
+    }
+    return nshape;
+}
+
+TPZCompEl * CreateSBFemMultiphysicsLinearEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index)
+{
+    return new TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoLinear>(mesh, gel, index);    
+}
+
+TPZCompEl * CreateSBFemMultiphysicsQuadEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index)
+{
+    return new TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad>(mesh, gel, index);    
+}
+
+TPZCompEl * CreateSBFemMultiphysicsCubeEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index)
+{
+    return new TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoCube>(mesh, gel, index);    
+}
+
+TPZCompEl * CreateSBFemMultiphysicsPrismaEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index)
+{
+    return new TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoPrism>(mesh, gel, index);    
+}
+
+template class TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoPoint>;
+template class TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoLinear>;
+template class TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad>;
+template class TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoCube>;
+template class TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoPrism>;

--- a/Mesh/TPZSBFemVolumeMultiphysics.h
+++ b/Mesh/TPZSBFemVolumeMultiphysics.h
@@ -1,0 +1,178 @@
+//
+//  TPZSBFemVolumeMultiphysics.hpp
+//  PZ
+//
+//  Created by Karolinne Coelho on 25/01/2021.
+//
+//
+
+#pragma once
+
+#include <stdio.h>
+#include "pzcompel.h"
+#include "pzelmat.h"
+#include "TPZSBFemVolume.h"
+#include "TPZCompElHDivSBFem.h"
+#include "TPZMultiphysicsCompMesh.h"
+#include "TPZSBFemMultiphysicsElGroup.h"
+#include "pzmultiphysicselement.h"
+#include "pzmultiphysicscompel.h"
+#include "pzgeoquad.h"
+
+#include "pzshapelinear.h"
+#include "pzshapetriang.h"
+#include "pzshapequad.h"
+#include "pzelchdiv.h"
+
+#include "pzgraphelq2dd.h"
+#include "pzgraphelq3dd.h"
+#include "tpzgraphelprismmapped.h"
+
+using namespace std;
+
+template <class TGeometry>
+class TPZSBFemVolumeMultiphysics : public TPZMultiphysicsCompEl<TGeometry>
+{
+    /// index of element group
+    int64_t fElementGroupIndex = -1;
+
+    int fSkeleton = -1;
+
+    TPZCompEl *fElementGroup = 0;
+
+	TPZManVector<TPZCompElSide ,5> fElementVec;
+
+	/** @brief List of pointers to computational elements */
+    // Order of the elements: fDifPressure, fInterface, fLeftFlux, fRightFlux, fAverPressure, fInterface, fSkeleton
+	TPZManVector<TPZCompEl* ,7> fElementVec1D;
+    	
+	/** @brief Indexes of the connects of the element */
+	TPZVec<int64_t> fConnectIndexes;
+    
+    /// pointer to the integration rule
+    TPZIntPoints *fIntRule = 0;
+    
+    /// vector of local indices of multipliers in the group
+    TPZManVector<int64_t> fLocalIndices;
+    
+    /// Section of the phi vector associated with this volume element
+    TPZFNMatrix<30,std::complex<double>> fPhi;
+    
+    /// Eigenvlues associated with the internal shape functions
+    TPZManVector<std::complex<double>> fEigenvalues;
+
+public:
+    
+    TPZSBFemVolumeMultiphysics(TPZCompMesh & mesh, TPZGeoEl * gel, int64_t & index);
+    
+    virtual ~TPZSBFemVolumeMultiphysics()
+    {
+    }
+
+    void AddElement1D(TPZCompEl * cel, int localindex);
+
+    virtual void AddElement(TPZCompEl *cel, int64_t meshindex) override;
+
+    virtual TPZManVector<TPZCompElSide,5> &ElementVec() override { return fElementVec; }
+
+    virtual TPZCompEl *Element(int64_t elindex) override;
+
+    /**@brief Returns referred element of this*/
+	virtual TPZCompEl *ReferredElement(int64_t mesh) override;
+
+    void SetSkeleton(int64_t skeleton);
+    
+    int64_t SkeletonIndex();
+    
+    void LoadCoef(TPZFMatrix<std::complex<double>> &coef, TPZFMatrix<std::complex<double>> &coefd);
+
+    void AffineTransform(TPZVec<TPZTransform<> > &trVec) const override;
+
+    void SetElementGroupIndex(int64_t index);
+
+    /** @brief Returns the number of nodes of the element */
+    virtual int NConnects() const override;
+
+    virtual int64_t ConnectIndex(int i) const override;
+
+    virtual int Dimension() const override;
+
+    virtual void CreateGraphicalElement(TPZGraphMesh &graphmesh, int dimension) override;
+
+    void EvaluateError(TPZVec<REAL> &errors,bool store_error) override;
+
+    virtual TPZIntPoints & GetIntegrationRule() const override;
+
+    virtual TPZIntPoints & GetIntegrationRule() override;
+
+    void InitializeIntegrationRule() override;
+
+    virtual void BuildCornerConnectList(std::set<int64_t> &connectindexes) const override;
+
+    virtual int NShapeF() const;
+
+    virtual TPZCompEl *Element(int elindex);
+
+    TPZManVector<TPZCompEl * ,7> & SBFemElementVec();
+
+    void SetPhiEigVal(TPZFMatrix<std::complex<double>> &phi, TPZManVector<std::complex<double>> &eigval);
+
+    void SetPhiFlux(TPZFMatrix<std::complex<double>> &phiflux, TPZManVector<std::complex<double>> &eigval);
+
+    //@{
+	/**
+	 * @brief Post processing method which computes the solution for the var post processed variable.
+	 * @param qsi coordinate of the point in master element space where the solution will be evaluated
+	 * @param var variable which will be computed
+	 * @param sol (output) solution computed at the given point
+	 * @see TPZMaterial::VariableIndex
+	 * @see TPZMaterial::NSolutionVariables
+	 * @see TPZMaterial::Solution
+	 */
+	/** The var index is obtained by calling the TPZMaterial::VariableIndex method with a post processing name */
+	virtual void Solution(TPZVec<REAL> &qsi,int var,TPZVec<STATE> &sol) override;
+
+	void InitMaterialData(TPZVec<TPZMaterialDataT<STATE>> &dataVec, TPZVec<int64_t> *indices = 0) override;
+
+    void ComputeRequiredData(TPZVec<TPZMaterialDataT<STATE>> &dataVec,TPZVec<REAL> &qsi);
+
+    void SetLocalIndices(TPZManVector<int64_t> &localindices, TPZManVector<int64_t> &localindicesint, TPZManVector<int64_t> &localindicesflux);
+
+    virtual void SetConnectIndexes(TPZVec<int64_t> &indexes) override
+    {
+        fConnectIndexes = indexes;
+    }
+
+    /** @brief Method for creating a copy of the element */
+    virtual TPZCompEl *Clone(TPZCompMesh &mesh) const override
+    {
+        DebugStop();
+        return 0;
+    }
+
+    virtual TPZCompEl *ClonePatchEl(TPZCompMesh &mesh,
+                                    std::map<int64_t,int64_t> & gl2lcConMap,
+                                    std::map<int64_t,int64_t> & gl2lcElMap) const override
+    {
+        DebugStop();
+        return 0;
+    }
+
+    virtual void CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElementMatrixT<STATE> &ef) override
+    {
+        DebugStop();
+    }
+
+    virtual void SetConnectIndex(int inode, int64_t index) override
+    {
+        DebugStop();
+    }
+};
+
+TPZCompEl * CreateSBFemMultiphysicsLinearEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
+
+TPZCompEl * CreateSBFemMultiphysicsQuadEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
+
+TPZCompEl * CreateSBFemMultiphysicsCubeEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
+
+TPZCompEl * CreateSBFemMultiphysicsPrismaEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);

--- a/Mesh/pzcondensedcompel.cpp
+++ b/Mesh/pzcondensedcompel.cpp
@@ -776,3 +776,28 @@ void TPZCondensedCompEl::BuildCornerConnectList(std::set<int64_t> &connectindexe
 int TPZCondensedCompEl::ClassId() const{
     return Hash("TPZCondensedCompEl") ^ TPZCompEl::ClassId() << 1;
 }
+
+void TPZCondensedCompEl::PermuteActiveConnects(TPZManVector<int64_t> &perm)
+{
+    auto ncon = NConnects();
+    auto nint = fNumInternalEqs;
+    for (int64_t ic = 0; ic < ncon; ic++)
+    {
+        fActiveConnectIndexes[ic] = perm[ic];
+    }
+    
+    if (fKeepMatrix == false)
+    {
+        nint = 0;
+    }
+	TPZAutoPointer<TPZMatrix<STATE> > k00 = new TPZFMatrix<STATE>(nint, nint, 0.);
+    TPZStepSolver<STATE> *step = new TPZStepSolver<STATE>(k00);
+    step->SetDirect(ELU);
+    TPZAutoPointer<TPZMatrixSolver<STATE> > autostep = step;
+    
+    fCondensed.SetSolver(autostep);
+    if(fKeepMatrix == true)
+    {
+        fCondensed.Redim(fNumTotalEqs,fNumInternalEqs);
+    }
+}

--- a/Mesh/pzcondensedcompel.h
+++ b/Mesh/pzcondensedcompel.h
@@ -222,6 +222,8 @@ public:
 		return 0;
     }
 
+    void PermuteActiveConnects(TPZManVector<int64_t> &perm);
+
 virtual int ClassId() const override;
 
 

--- a/Mesh/pzcreateapproxspace.cpp
+++ b/Mesh/pzcreateapproxspace.cpp
@@ -536,6 +536,7 @@ void TPZCreateApproximationSpace::SetAllCreateFunctionsHCurl(int dimension){
 #if defined(USING_MKL) && defined(USING_LAPACK) && !defined(STATE_COMPLEX)
 
 #include "TPZSBFemVolume.h"
+#include "TPZSBFemVolumeMultiphysics.h"
 
 void TPZCreateApproximationSpace::SetAllCreateFunctionsSBFem(int dimension){
     
@@ -563,6 +564,37 @@ void TPZCreateApproximationSpace::SetAllCreateFunctionsSBFem(int dimension){
             fp[EPiramide] = CreateNoElement;
             fp[EPrisma] = CreateSBFemCompEl;
             fp[ECube] = CreateSBFemCompEl;
+            break;
+        default:
+            DebugStop();
+            break;
+    }
+}
+void TPZCreateApproximationSpace::SetAllCreateFunctionsSBFemMultiphysics(int dimension){
+    fStyle = EMultiphysicsSBFem;
+    switch (dimension) {
+        case 1:
+            DebugStop();
+            break;
+        case 2:
+            fp[EPoint] = CreateMultiphysicsPointEl;
+            fp[EOned] = CreateMultiphysicsLinearEl;
+            fp[ETriangle] = CreateMultiphysicsTriangleEl;
+            fp[EQuadrilateral] = CreateSBFemMultiphysicsQuadEl; // SBFem
+            fp[ETetraedro] = CreateNoElement;
+            fp[EPiramide] = CreateNoElement;
+            fp[EPrisma] = CreateNoElement;
+            fp[ECube] = CreateNoElement;
+            break;
+        case 3:
+            fp[EPoint] = CreateNoElement;
+            fp[EOned] = CreateNoElement;
+            fp[ETriangle] = CreateNoElement;
+            fp[EQuadrilateral] = CreateNoElement;
+            fp[ETetraedro] = CreateNoElement;
+            fp[EPiramide] = CreateNoElement;
+            fp[EPrisma] = CreateSBFemMultiphysicsPrismaEl;
+            fp[ECube] = CreateSBFemMultiphysicsCubeEl;
             break;
         default:
             DebugStop();

--- a/Mesh/pzcreateapproxspace.h
+++ b/Mesh/pzcreateapproxspace.h
@@ -40,7 +40,7 @@ class TPZCreateApproximationSpace : public TPZSavable {
     
 public:
     
-    enum MApproximationStyle {ENone,EContinuous,EDiscontinuous,EHDiv,EHCurl, EMultiphysics, ESBFem, ECustom};
+    enum MApproximationStyle {ENone,EContinuous,EDiscontinuous,EHDiv,EHCurl, EMultiphysics, EMultiphysicsSBFem, ESBFem, ECustom};
 private:
     /// approximation space style last used
     MApproximationStyle fStyle = ENone;
@@ -101,12 +101,16 @@ public:
     /** @brief Create SBFem approximation space. Depends on MKL. */
     void SetAllCreateFunctionsSBFem(int meshdim);
 
+    void SetAllCreateFunctionsSBFemMultiphysics(int meshdim);
+
 #ifndef STATE_COMPLEX
     /** @brief Create an approximation space with HDivxL2 elements */
 	void SetAllCreateFunctionsHDivPressure(int meshdim);
 #endif
     /** @brief Create approximation spaces corresponding to the space defined by cel */
 	void SetAllCreateFunctions(TPZCompEl &cel, TPZCompMesh *mesh);
+    /** @brief Create an approximation space based on SBFem multiphysics elements */
+	void SetAllCreateFunctionsSBFemMultiphysicElem();
     /** @brief Create an approximation space based on multiphysics elements */
 	void SetAllCreateFunctionsMultiphysicElem();
     /** @brief Create an approximation space based on multiphysics elements with memory*/	

--- a/Mesh/pzelementgroup.cpp
+++ b/Mesh/pzelementgroup.cpp
@@ -139,6 +139,17 @@ void TPZElementGroup::ReorderConnects()
     for(int ic=0; ic<nc; ic++) fConnectIndexes[ic] = orderedindexes[ic].second;
 }
 
+void TPZElementGroup::ReorderConnects(TPZManVector<int64_t> &connects)
+{
+    int64_t nc = connects.size();
+
+    // TPZManVector<std::pair<int,int64_t>, 100 > orderedindexes(connects.size());
+    for (int ic=0; ic<nc; ic++)
+    {
+        fConnectIndexes[ic] = connects[ic];
+    }
+}
+
 
 /**
  * @brief Method for creating a copy of the element in a patch mesh

--- a/Mesh/pzelementgroup.h
+++ b/Mesh/pzelementgroup.h
@@ -87,6 +87,8 @@ public:
 
     /// Reorder the connects in increasing number of elements connected
     void ReorderConnects();
+
+    void ReorderConnects(TPZManVector<int64_t> &connects);
     
     const TPZVec<TPZCompEl *> &GetElGroup(){
         return fElGroup;

--- a/Pre/CMakeLists.txt
+++ b/Pre/CMakeLists.txt
@@ -60,8 +60,8 @@ set(sources
     )
 
 if (USING_MKL)
-    list(APPEND headers TPZBuildSBFem.h)
-    list(APPEND sources TPZBuildSBFem.cpp)
+	list(APPEND headers TPZBuildSBFem.h TPZBuildSBFemMultiphysics.h)
+	list(APPEND sources TPZBuildSBFem.cpp TPZBuildSBFemMultiphysics.cpp)
 endif()
 
 install(FILES ${headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Pre)

--- a/Pre/TPZBuildSBFem.h
+++ b/Pre/TPZBuildSBFem.h
@@ -18,6 +18,7 @@
 
 class TPZBuildSBFem
 {
+protected:
     /// geometric mesh
     TPZAutoPointer<TPZGeoMesh> fGMesh;
     

--- a/Pre/TPZBuildSBFemMultiphysics.cpp
+++ b/Pre/TPZBuildSBFemMultiphysics.cpp
@@ -1,0 +1,1076 @@
+//
+//  TPZBuildSBFemMultiphysics.cpp
+//  PZ
+//
+//  Created by Karolinne Coelho on 18/01/21.
+//
+//
+
+#include "TPZBuildSBFemMultiphysics.h"
+
+#include "TPZCompElHDivSBFem.h"
+#include "TPZNullMaterial.h"
+#include "TPZNullMaterialCS.h"
+#include "TPZBndCondBase.h"
+#include "TPZLagrangeMultiplierCS.h"
+#include "pzgeoelbc.h"
+#include "pzshapelinear.h"
+#include "pzshapetriang.h"
+#include "pzshapequad.h"
+#include "TPZVTKGeoMesh.h"
+
+#include "tpzgeoblend.h"
+#include "TPZGeoLinear.h"
+#include "tpzgeoelrefpattern.h"
+
+#include "TPZSBFemMultiphysicsElGroup.h"
+#include "TPZSBFemVolumeL2.h"
+#include "TPZSBFemVolumeHdiv.h"
+#include "TPZSBFemVolumeMultiphysics.h"
+
+#include "pzcondensedcompel.h"
+#include "pzgeoelbc.h"
+
+#ifdef LOG4CXX
+static LoggerPtr logger(Logger::getLogger("pz.mesh.tpzbuildsbfem"));
+static LoggerPtr loggersbfemhdivgeom(Logger::getLogger("buildsbfemhdivgeom"));
+static LoggerPtr loggercmesh(Logger::getLogger("cmeshsbfemhdiv"));
+#endif
+
+// This function will create both TPZSBFemVolumeMultiphysics (and its atomic elements) and TPZSBFemMultiphysicsElGroup.
+// Sequence of the method:
+// 1. Define geometry with the external dim-1 elements and collapsed element;
+// 2. Update atomic meshes (cmeshflux and cmeshpressure);
+// 3. Update Multiphysics mesh;
+// 4. Create interface elements;
+// 5. Create TPZSBFemVolumeMultiphysics objects based on the multiphysics elements;
+// 6. Update the multiphysics mesh to contemplate only the SBFem elements (ignore FE els);
+// 7. Define SBFemMultiphysicsElGroups as a group of TPZSBFemVolumeMultiphysics;
+// 8. Condense the DOFs of the SBFemMultiphysicsElGroups.
+void TPZBuildSBFemMultiphysics::BuildMultiphysicsCompMesh(TPZMultiphysicsCompMesh & cmeshm)
+{
+    TPZManVector<TPZCompMesh*, 2> cmeshvec = cmeshm.MeshVector();
+
+    // The flux cmesh must have:
+    // 1. Material ID defined in the map EGroup -> EMatVol
+    auto cmeshflux = cmeshvec[0];    
+
+    // The pressure cmesh must have:
+    // 1. Material ID defining the map EGroup -> EMatVol.
+    // 2. The Material ID related to the Skeleton - a Neumann BC - external average pressure.
+    // 3. The boundary conditions.
+    // All these materials must be defined in the cmeshm too.
+    auto cmeshpressure = cmeshvec[1];
+
+    // ********** CREATING THE GEOMETRY
+    // Skeleton Elements + Collapsed Elements + External elements:
+
+    // Before calling this function the Skeleton elements has been already created
+    // So I just need to create the collapsed and external elements
+
+    // Creating dim-1 elements CompEls - Skeleton
+    int dim = cmeshm.Dimension();
+    fGMesh->SetName("gmesh with collapsed els");
+    cmeshpressure->SetName("cmesh pressure");
+
+    set<int> matids1d;
+    for (auto gel : fGMesh->ElementVec())
+    {
+        if (!gel) continue;
+        if (gel->Dimension() == fGMesh->Dimension()-1)
+        {
+            matids1d.insert(gel->MaterialId());
+        }
+    }
+    cmeshpressure->ApproxSpace().CreateDisconnectedElements(true);
+    cmeshpressure->AutoBuild(matids1d);
+
+    // Creating volumetric collapsed elements
+    set<int> matidstarget; // matid of the collapsed element (output parameter)
+    // The updated mesh will be fGMesh
+    // But the comp mesh used must be cmeshpressure because the connectivity of the multiphysics mesh
+    // hasn't been updated yet.
+    CreateCollapsedGeoEls(*cmeshpressure, matidstarget, matids1d);
+
+    // Creating dim-1 elements: External flux and external pressure.
+    CreateExternalElements(fGMesh, matidstarget, matids1d);
+
+    // ********** CREATING THE COMPUTATIONAL MESH
+    // At this point the code created all geometric elements needed for ther SBFEM simulation and it's stored in fGMesh
+    // Here it's created the SBFemVolumeHdiv elements -> CompElHdivElement -> Adjust connectivities
+    // But firstly the atomic meshes must be properly created
+    CreateCompElPressure(*cmeshpressure, matids1d);
+    // Adding the volumetric elements
+    CreateSBFemVolumePressure(*cmeshpressure, matids1d, matidstarget);
+    cmeshpressure->LoadReferences();
+
+    CreateCompElFlux(*cmeshflux, matidstarget, matids1d);
+    // Adding the volumetric elements
+    CreateSBFemVolumeFlux(*cmeshflux, matids1d, matidstarget);
+    cmeshflux->LoadReferences();
+
+    // Then, creating the multiphysics mesh
+    // Next method will setup the multiphysics mesh
+    // Deleting the Hdiv elements existing in the mesh.
+    // The elements must be specified as TPZCompElHDivSBFem elements
+    CreateSBFemMultiphysicsMesh(cmeshm,matidstarget);
+    cmeshm.ApproxSpace().SetAllCreateFunctionsSBFemMultiphysics(dim);
+    cmeshm.SetName("multiphysicssbfem");
+    TPZManVector<int> active(2,1);
+    cmeshm.BuildMultiphysicsSpace(active, cmeshvec);
+    cmeshm.LoadReferences();
+    cmeshm.CleanUpUnconnectedNodes();
+    {
+        ofstream sout("cmeshmultiphysics.txt");
+        cmeshm.Print(sout);
+    }
+    
+    // Adding the interface elements
+    AddInterfaceElements(cmeshm, matids1d);
+    {
+        ofstream sout("cmeshmultiphysics.txt");
+        cmeshm.Print(sout);
+    }
+
+    // Creating the SBFEMVolumeHdiv elements
+    CreateSBFemMultiphysicsVol(cmeshm, matids1d, matidstarget);
+
+    // Based on the multiphysics mesh, create SBFemElementGroups
+    // The SBFemMultiphysicsElGroups = Group of collapsed flux elements + pressure compels
+    // Then, condense the flux into the pressures.
+    CreateSBFemMultiphysicsElGroups(cmeshm, matidstarget);
+    cmeshm.ExpandSolution();
+    cmeshm.ComputeNodElCon();
+    cmeshm.CleanUpUnconnectedNodes();
+    
+    GroupandCondense(cmeshm);
+    cmeshm.ExpandSolution();
+    cmeshm.ComputeNodElCon();
+    cmeshm.CleanUpUnconnectedNodes();
+
+#ifdef PZDEBUG
+    {
+        ofstream mout("cmeshmultiphysicscondensed.txt");
+        cmeshm.Print(mout);
+    }
+#endif
+
+    auto nel = cmeshm.NElements();
+    for (int64_t el = 0; el<nel; el++) {
+        TPZCompEl *cel = cmeshm.Element(el);
+        if (!cel)
+        {
+            continue;
+        }
+        auto sbfemgr = dynamic_cast<TPZSBFemMultiphysicsElGroup * >(cel);
+        if (sbfemgr)
+        {
+            continue;
+        }
+        if (cel->Reference())
+        {
+            auto matid = cel->Reference()->MaterialId();
+            auto it = matids1d.find(matid);
+            if (it != matids1d.end())
+            {
+                continue;
+            }
+        }
+        cmeshm.ElementVec()[el] = 0;
+    }
+#ifdef LOG4CXX
+    if (loggercmesh->isDebugEnabled())
+    {
+        stringstream sout;
+        cmeshm.Print(sout);
+        sout << "flux\n";
+        cmeshflux->Print(sout);
+        sout << "pressure\n";
+        ofstream pout("cmeshpressure.txt");
+        cmeshpressure->Print(sout);
+    }
+#endif
+}
+
+// Creates geometric collapsed elements
+void TPZBuildSBFemMultiphysics::CreateCollapsedGeoEls(TPZCompMesh & cmeshpressure, set<int> & matidstarget, set<int> & matids1d)
+{
+    // all computational elements for internal DOFs have been loaded for flux and pressure meshes
+    set<int> matids;
+    for (auto it = fMatIdTranslation.begin(); it!= fMatIdTranslation.end(); it++)
+    {
+        int64_t mat = it->second;
+        if (cmeshpressure.FindMaterial(mat))
+        {
+            matids.insert(it->first);
+            matidstarget.insert(it->second);
+        }
+    }
+
+    // Creating geometric collapsed elements for the multiphysics mesh based on the pressure mesh
+    auto gmeshpressure = cmeshpressure.Reference();
+    auto dim = gmeshpressure->Dimension();
+
+    for (auto gelpressure : gmeshpressure->ElementVec())
+    {
+        if (!gelpressure || gelpressure->HasSubElement())
+        {
+            continue;
+        }
+        // we create SBFemVolume elements by partitioning the volume elements
+        auto el = gelpressure->Index();
+        if (gelpressure->Dimension() != dim || fElementPartition[el] == -1)
+        {
+            continue;
+        }
+        // I am searching elements with dim dimension and with FE matids
+        // to transform it in collapsed elements with matidtargets
+        if (matids.find(gelpressure->MaterialId()) == matids.end())
+        {
+            continue;
+        }
+        int nsides = gelpressure->NSides();
+        for (int is = 0; is<nsides; is++)
+        {
+            if (gelpressure->SideDimension(is) != dim-1)
+            {
+                continue;
+            }
+            // TPZStack<TPZCompElSide> celstack;
+            TPZGeoElSide gelside(gelpressure,is);
+
+            auto subgelside = gelside.Neighbour();
+            auto it = matids1d.find(subgelside.Element()->MaterialId());
+            while (subgelside != gelside)
+            {
+                if (it != matids1d.end()) break;
+                subgelside = subgelside.Neighbour();
+                it = matids1d.find(subgelside.Element()->MaterialId());
+            }
+            
+            // Creating Duffy elements:
+            {
+                int64_t index;
+                if (subgelside.Dimension() != dim-1)
+                {
+                    continue;
+                }
+                auto nnodes = subgelside.NSideNodes();
+                TPZManVector<int64_t,8> Nodes(nnodes*2,-1);
+                for (int in=0; in<nnodes; in++)
+                {
+                    Nodes[in] = subgelside.SideNodeIndex(in); // Boundary nodes
+                }
+                int elpartition = fElementPartition[el];
+                for (int in=nnodes; in < 2*nnodes; in++)
+                {
+                    Nodes[in] = fPartitionCenterNode[elpartition]; // Scaling center nodes
+                }
+                auto matid = fMatIdTranslation[gelpressure->MaterialId()];
+
+                // Then, the collapsed volumetric elements will be created in the multiphysics gmesh
+                if (subgelside.IsLinearMapping())
+                {
+                    switch(nnodes)
+                    {
+                        case 2:
+                            fGMesh->CreateGeoElement(EQuadrilateral, Nodes, matid, index);
+                            break;
+                        case 4:
+                            fGMesh->CreateGeoElement(ECube, Nodes, matid, index);
+                            DebugStop();
+                            break;
+                        case 3:
+                            fGMesh->CreateGeoElement(EPrisma, Nodes, matid, index);
+                            DebugStop();
+                            break;
+                        default:
+                            std::cout << "Don't understand the number of nodes per side : nnodes " << nnodes << std::endl;
+                            DebugStop();
+                    }
+                    
+                }
+                else
+                {
+                    int64_t elementid = fGMesh->NElements()+1;
+                    switch(nnodes)
+                    {
+                        case 2:
+                            new TPZGeoElRefPattern< pzgeom::TPZGeoBlend<pzgeom::TPZGeoQuad> > (Nodes, matid, *fGMesh,index);
+                            break;
+                        case 4:
+                            new TPZGeoElRefPattern< pzgeom::TPZGeoBlend<pzgeom::TPZGeoCube> > (Nodes, matid, *fGMesh,index);
+                            break;
+                        case 3:
+                            fGMesh->CreateGeoElement(EPrisma, Nodes, matid, index);
+                            break;
+                        default:
+                            std::cout << "Don't understand the number of nodes per side : nnodes " << nnodes << std::endl;
+                            DebugStop();
+                    }
+                }
+                auto gel = fGMesh->ElementVec()[index];
+                TPZVec<REAL> qsi(3,0);
+                TPZFMatrix<REAL> jacobian, axes, jacinv;
+                REAL detjac = 0;
+                gel->JacobianXYZ(qsi, jacobian, axes, detjac, jacinv);
+                if (detjac < 0)
+                {
+                    cout << "The element " << index << " is not countclockwise\n";
+                    TPZManVector<int64_t> nodescopy(Nodes);
+                    gel->SetNodeIndex(0,Nodes[1]);
+                    gel->SetNodeIndex(1,Nodes[0]);
+                }
+                
+                if (index >= fElementPartition.size())
+                {
+                    fElementPartition.resize(index+1);
+                }
+                fElementPartition[index] = elpartition;
+            }
+        }
+    }
+    fGMesh->ResetConnectivities();
+    fGMesh->BuildConnectivity();
+
+#ifdef PZDEBUG
+    {
+        ofstream gout("gmeshwithvol.txt");
+        fGMesh->Print(gout);
+    }
+#endif
+}
+
+// The order is: fDifPressure - fFluxRight - fFluxLeft - fAverPressure - fSkeleton
+// fSkeleton is the internal flux and pressures.
+void TPZBuildSBFemMultiphysics::CreateExternalElements(TPZAutoPointer<TPZGeoMesh> & gmesh, set<int> & matidtarget, set<int> &matids1d)
+{
+    auto nelpartitions = fElementPartition.size();
+    fElementPartition.Resize(nelpartitions*6);
+    for (auto gel : gmesh->ElementVec())
+    {
+        if (!gel) continue;
+        // matidtarget contains the material id of the collapsed elements
+        auto it = matidtarget.find(gel->MaterialId());
+        if (it == matidtarget.end()) continue;
+
+        auto idcollapsed = fElementPartition[gel->Index()];
+
+        // getting the side in which the 1d elements will be constructed as neighbours
+        auto iside = GetSideCollapsedEl(gel);
+
+        TPZGeoElBC(gel, iside, fRightFlux);
+        fElementPartition[gmesh->NElements()-1] = idcollapsed;
+        
+        TPZGeoElBC(gel, iside, fInternal);
+        fElementPartition[gmesh->NElements()-1] = idcollapsed;
+
+        TPZGeoElBC(gel, iside, fLeftFlux);
+        fElementPartition[gmesh->NElements()-1] = idcollapsed;
+
+        TPZGeoElBC(gel, iside, fDifPressure);
+        fElementPartition[gmesh->NElements()-1] = idcollapsed;
+        
+        TPZGeoElSide gelside(gel,iside);
+        auto gelsideskeleton = gelside.HasNeighbour(matids1d);
+
+        for (int i = 0; i < 2; i++)
+        {
+            gmesh->ElementVec()[gmesh->NElements()-1]->SetNodeIndex(0,gelsideskeleton.Element()->NodeIndex(0));
+            gmesh->ElementVec()[gmesh->NElements()-1]->SetNodeIndex(1,gelsideskeleton.Element()->NodeIndex(1));
+        }
+    }
+}
+
+void TPZBuildSBFemMultiphysics::CreateCompElPressure(TPZCompMesh &cmeshpressure, set<int> & matids1d)
+{
+    // getting the materials
+    cmeshpressure.SetReference(fGMesh);
+    auto matvec = cmeshpressure.MaterialVec();
+    map<int, TPZMaterial*> matveccopy;
+    for (auto const& [key, val] : matvec)
+    {
+        auto valbndcnd = dynamic_cast<TPZMaterial *>(val);
+        if(!valbndcnd)
+        {
+            matveccopy[key] = val->NewMaterial();
+        } else 
+        {
+            map<int, TPZMaterial*> bnd;
+            valbndcnd->Clone(bnd);
+            for (auto const& [keybnd, valbnd] : bnd)
+            {
+                matveccopy[keybnd] = valbnd;
+            }
+        }
+    }
+
+    auto dim = cmeshpressure.Dimension()-1; // materials with dim-1 dimensional elements
+    auto nstate = cmeshpressure.MaterialVec().begin()->second->NStateVariables();
+    auto matext = cmeshpressure.MaterialVec().begin()->second;
+    auto POrder = cmeshpressure.GetDefaultOrder();
+
+    auto matint = matext->NewMaterial();
+    matint->SetId(fInternal);
+
+    cmeshpressure.CleanUp();
+
+    cmeshpressure.SetReference(fGMesh);
+    cmeshpressure.SetDefaultOrder(POrder);
+    cmeshpressure.SetDimModel(dim);
+    cmeshpressure.SetAllCreateFunctionsContinuous();
+    cmeshpressure.ApproxSpace().CreateDisconnectedElements(true);
+
+    for (auto const& [key, val] : matveccopy)
+    {
+        cmeshpressure.InsertMaterialObject(val);
+    }
+    cmeshpressure.InsertMaterialObject(matint);
+    set<int> matids = {fInternal};
+    cmeshpressure.AutoBuild(matids);
+    
+    auto matleft = new TPZNullMaterial(fDifPressure, dim, nstate);
+    cmeshpressure.InsertMaterialObject(matleft);
+
+    // Pressure mesh will be composed of:
+    // Internal DOFs - Materials already created!
+
+    // 2rd. Dif. pressure
+    matids = {fDifPressure};
+    cmeshpressure.AutoBuild(matids);
+
+    // 3rd. Aver. pressure
+    cmeshpressure.AutoBuild(matids1d); 
+    
+    for(auto newnod : cmeshpressure.ConnectVec())
+    {
+        newnod.SetLagrangeMultiplier(1);
+    }
+
+    cmeshpressure.LoadReferences();
+
+}
+
+void TPZBuildSBFemMultiphysics::CreateSBFemVolumePressure(TPZCompMesh & cmeshpressure, set<int> &matids1d, set<int> & matidtarget)
+{
+    // This for creates the volumetric multiphysics element, working as an AutoBuild()
+    for (auto gelcollapsed : fGMesh->ElementVec())
+    {
+        // Now I'm searching for the collapsed element, in which the matid is in matidtarget.
+        if (!gelcollapsed)
+        {
+            continue;
+        }
+        auto it = matidtarget.find(gelcollapsed->MaterialId());
+        if (it == matidtarget.end())
+        {
+            continue;
+        }
+
+        auto idvol = fElementPartition[gelcollapsed->Index()];
+        if (idvol == -1)
+        {
+            DebugStop();
+        }
+
+        int64_t index;
+        auto cel = CreateSBFemPressureCompEl(cmeshpressure, gelcollapsed, index);
+
+        // Getting the TPZSBFemVolumeHdiv compel
+        auto celsbfem = cmeshpressure.Element(index);
+        auto sbfem = dynamic_cast<TPZSBFemVolumeL2 * >(celsbfem);
+        if(!sbfem)
+        {
+            DebugStop();
+        }
+
+        // Adding multiphysics compels:
+        // The neighbour will be in the surface identified as side. So I get the gelside and search for its neighbour.
+        // I'll include all computational elements related to geo collapsed element
+        auto side = GetSideCollapsedEl(gelcollapsed);
+        TPZGeoElSide gelside(gelcollapsed, side);
+
+        // 1st element will be fDifPressure
+        auto neigh = gelside.Neighbour();
+        auto gel1d = neigh.Element();
+        while (gel1d->MaterialId() != fDifPressure || fElementPartition[gel1d->Index()] != fElementPartition[idvol])
+        {
+            neigh = neigh.Neighbour();
+            gel1d = neigh.Element();
+        }
+        if(!(gel1d->Reference()))
+        {
+            DebugStop();
+        }
+        auto cel1d = gel1d->Reference();
+        sbfem->AddElement1D(cel1d, 0);
+        int count = 1;
+
+        while (gelside != neigh)
+        {
+            neigh = neigh.Neighbour();
+            gel1d = neigh.Element();
+            auto it = matids1d.find(gel1d->MaterialId());
+            if(gel1d->Reference() && (gel1d->MaterialId() == fInternal) )
+            {
+                if(fElementPartition[gel1d->Index()] == idvol)
+                {
+                    cel1d = gel1d->Reference();
+                    sbfem->AddElement1D(cel1d, 1);
+                }
+            }
+            if(gel1d->Reference() && (it != matids1d.end() ) )
+            {
+                cel1d = gel1d->Reference();
+                sbfem->AddElement1D(cel1d, 2);
+                break;
+            }
+        }
+    }
+}
+
+void TPZBuildSBFemMultiphysics::CreateCompElFlux(TPZCompMesh &cmeshflux, set<int> & matidtarget, set<int> & matid1d)
+{
+    // Now creating the material for the external elements:
+    auto dim = cmeshflux.Dimension()-1; // materials with dim-1 dimensional elements
+    auto nstate = cmeshflux.MaterialVec().begin()->second->NStateVariables();
+    auto matext = cmeshflux.MaterialVec().begin()->second;
+    
+    auto matinternal = new TPZNullMaterial(fInternal, dim, nstate);
+    cmeshflux.InsertMaterialObject(matinternal);
+    
+    auto matboundleft = new TPZNullMaterial(fLeftFlux, dim, nstate);
+    cmeshflux.InsertMaterialObject(matboundleft);
+    
+    auto matboundright = new TPZNullMaterial(fRightFlux, dim, nstate);
+    cmeshflux.InsertMaterialObject(matboundright);
+
+    map<int64_t,TPZCompEl *> geltocel;
+
+    fGMesh->ResetReference();
+    int previouspartition = -1;
+    for (auto gelcollapsed : fGMesh->ElementVec())
+    {
+        if (!gelcollapsed) continue;
+        auto it = matidtarget.find(gelcollapsed->MaterialId());
+        if (it == matidtarget.end()) continue;
+
+        int partition = fElementPartition[gelcollapsed->Index()];
+        if (previouspartition != partition)
+        {
+            cmeshflux.Reference()->ResetReference();
+        }
+        
+        auto side = GetSideCollapsedEl(gelcollapsed);
+        TPZGeoElSide gelsidecollapsed(gelcollapsed, side);
+
+        auto gelsideint = gelsidecollapsed.Neighbour();
+        while (gelsideint.Element()->MaterialId() != fInternal)
+        {
+            gelsideint = gelsideint.Neighbour();
+            if (gelsideint == gelsidecollapsed)
+            {
+                DebugStop();
+            }
+        }
+        auto gel1d = gelsideint.Element();
+
+        if(fElementPartition[gel1d->Index()] != fElementPartition[gelcollapsed->Index()])
+        {
+            DebugStop();
+        }
+
+        int64_t index;
+        auto celhdivc = new TPZCompElHDivSBFem<pzshape::TPZShapeLinear>(cmeshflux, gel1d, gelsidecollapsed, index);
+        geltocel[gel1d->Index()] = celhdivc;
+
+        previouspartition = partition;
+    }
+    cmeshflux.ExpandSolution();
+    cmeshflux.Reference()->ResetReference();
+
+    // Now setting the geoelement for the HdivBound
+    for (auto gelleft : fGMesh->ElementVec())
+    {
+        if (!gelleft || gelleft->MaterialId() != fLeftFlux) continue;
+
+        TPZGeoElSide gelsideleft(gelleft, gelleft->NSides()-1);
+
+        auto gelsideinternal = gelsideleft.Neighbour(); // This element if fInternal
+        auto gelsideright = gelsideinternal.Neighbour(); // This element is fRightFlux
+#ifdef PZDEBUG
+        if(gelsideright.Element()->MaterialId() != fRightFlux || gelsideinternal.Element()->MaterialId() != fInternal)
+        {
+            DebugStop();
+        }
+#endif
+
+        auto cel  = geltocel[gelsideinternal.Element()->Index()];
+        TPZCompElHDivSBFem<pzshape::TPZShapeLinear> * celhdivc = dynamic_cast<TPZCompElHDivSBFem<pzshape::TPZShapeLinear> * >(cel);
+#ifdef PZDEBUG
+        if (!celhdivc)
+        {
+            DebugStop();
+        }
+#endif
+        if(fElementPartition[gelleft->Index()] != fElementPartition[gelsideinternal.Element()->Index()])
+        {
+            DebugStop();
+        }
+        if(fElementPartition[gelsideright.Element()->Index()] != fElementPartition[gelsideinternal.Element()->Index()])
+        {
+            DebugStop();
+        }
+
+        int64_t index;
+
+        auto hdivboundleft = new TPZCompElHDivBound2<pzshape::TPZShapeLinear>(cmeshflux,gelsideleft.Element(),index);
+        hdivboundleft->SetConnectIndex(0,celhdivc->ConnectIndex(3));
+        gelsideleft.Element()->ResetReference();
+
+        auto hdivboundright = new TPZCompElHDivBound2<pzshape::TPZShapeLinear>(cmeshflux,gelsideright.Element(),index);
+        hdivboundright->SetConnectIndex(0,celhdivc->ConnectIndex(4));
+        gelsideright.Element()->ResetReference();
+    }
+
+    cmeshflux.LoadReferences();
+    cmeshflux.CleanUpUnconnectedNodes();
+    cmeshflux.ExpandSolution();
+
+#ifdef PZDEBUG
+    ofstream sout("cmeshflux0.txt");
+    cmeshflux.Print(sout);
+    ofstream gout("gmeshflux0.txt");
+    cmeshflux.Reference()->Print(gout);
+#endif
+}
+
+void TPZBuildSBFemMultiphysics::CreateSBFemVolumeFlux(TPZCompMesh & cmesh, set<int> &matids1d, set<int> & matidtarget)
+{
+    // This for creates the volumetric multiphysics element, working as an AutoBuild()
+    for (auto gelcollapsed : fGMesh->ElementVec())
+    {
+        // Now I'm searching for the collapsed element, in which the matid is in matidtarget.
+        if (!gelcollapsed)
+        {
+            continue;
+        }
+        auto it = matidtarget.find(gelcollapsed->MaterialId());
+        if (it == matidtarget.end())
+        {
+            continue;
+        }
+
+        auto idvol = fElementPartition[gelcollapsed->Index()];
+        if (idvol == -1)
+        {
+            DebugStop();
+        }
+
+        int64_t index;
+        auto cel = CreateSBFemFluxCompEl(cmesh, gelcollapsed, index);
+
+        // Getting the TPZSBFemVolumeHdiv compel
+        auto celsbfem = cmesh.Element(index);
+        auto sbfem = dynamic_cast<TPZSBFemVolumeHdiv * >(celsbfem);
+        if(!sbfem)
+        {
+            DebugStop();
+        }
+
+        // Adding multiphysics compels:
+        // The neighbour will be in the surface identified as side. So I get the gelside and search for its neighbour.
+        // I'll include all computational elements related to geo collapsed element
+        auto side = GetSideCollapsedEl(gelcollapsed);
+        TPZGeoElSide gelside(gelcollapsed, side);
+
+        // 1st element will be fDifPressure
+        auto neigh = gelside.Neighbour();
+        auto gel1d = neigh.Element();
+        while (gel1d->MaterialId() != fLeftFlux || fElementPartition[gel1d->Index()] != fElementPartition[idvol])
+        {
+            neigh = neigh.Neighbour();
+            gel1d = neigh.Element();
+        }
+        if(!(gel1d->Reference()))
+        {
+            DebugStop();
+        }
+        auto cel1d = gel1d->Reference();
+        sbfem->AddElement1D(cel1d, 0);
+        int count = 1;
+
+        while (gelside != neigh)
+        {
+            neigh = neigh.Neighbour();
+            gel1d = neigh.Element();
+            if(gel1d->Reference() && (gel1d->MaterialId() == fInternal || gel1d->MaterialId() == fRightFlux))
+            {
+                if(fElementPartition[gel1d->Index()] == idvol)
+                {
+                    cel1d = gel1d->Reference();
+                    sbfem->AddElement1D(cel1d, count);
+                    count++;
+                    if(count == 3) break;
+                }
+            }
+        }
+    }
+}
+
+void TPZBuildSBFemMultiphysics::CreateSBFemMultiphysicsMesh(TPZMultiphysicsCompMesh & cmeshm, set<int> & matidstarget)
+{
+    // The materials for ESkeleton and Emat1 were already created before.
+    auto dim = cmeshm.Dimension();
+    auto id = cmeshm.MaterialVec().begin()->second->Id();
+    auto nstate = cmeshm.MaterialVec().begin()->second->NStateVariables();
+    auto matint = cmeshm.MaterialVec().begin()->second;
+    
+    {
+        auto mat = new TPZNullMaterialCS<STATE>(fDifPressure, dim, nstate);
+        cmeshm.InsertMaterialObject(mat);
+    }
+
+    {
+        auto mat = matint->NewMaterial();
+        mat->SetId(fInternal);
+        cmeshm.InsertMaterialObject(mat);
+    }
+
+    {
+        auto mat = new TPZNullMaterialCS<STATE>(fLeftFlux, dim, nstate);
+        cmeshm.InsertMaterialObject(mat);
+    }
+
+    {
+        auto mat = new TPZNullMaterialCS<STATE>(fRightFlux, dim, nstate);
+        cmeshm.InsertMaterialObject(mat);
+    }
+
+    {
+        auto mat = new TPZLagrangeMultiplierCS<STATE>(fInterface, dim, nstate);
+        cmeshm.InsertMaterialObject(mat);
+    }
+}
+
+// Order of elements to add the interface:
+// 1. fDifPressure
+// 2. fLeftFlux
+// 3. fInternal
+// 4. fRightFlux
+// 5. Skeleton/BC (External average pressure)
+void TPZBuildSBFemMultiphysics::AddInterfaceElements(TPZMultiphysicsCompMesh & cmeshm, set<int> &matids1d)
+{
+    for (auto geldifpr : fGMesh->ElementVec())
+    {
+        if (!geldifpr || geldifpr->MaterialId() != fDifPressure) continue;
+
+        auto side = GetSideSkeletonEl(geldifpr);
+        TPZGeoElSide gelsidedifpr(geldifpr, side);
+
+        auto gelsideleft = gelsidedifpr.Neighbour(); // fLeftFlux
+#ifdef PZDEBUG
+        if(gelsideleft.Element()->MaterialId() != fLeftFlux) DebugStop();
+#endif
+        int64_t index;
+
+        TPZCompElSide celsidedifpr = gelsidedifpr.Reference();
+        TPZCompElSide celsideleft = gelsideleft.Reference();
+#ifdef PZDEBUG
+        if (!celsidedifpr || !celsideleft) DebugStop();
+        if (fElementPartition[gelsidedifpr.Element()->Index()] != fElementPartition[gelsideleft.Element()->Index()])
+        {
+            DebugStop();
+        }
+#endif
+        TPZGeoElBC gelbc(gelsideleft, fInterface);
+        TPZMultiphysicsInterfaceElement *intl = new TPZMultiphysicsInterfaceElement(cmeshm, gelbc.CreatedElement(),index,celsidedifpr,celsideleft);
+        fElementPartition[gelbc.CreatedElement()->Index()] = fElementPartition[gelsidedifpr.Element()->Index()];
+    }
+
+        for (auto gelright : fGMesh->ElementVec())
+    {
+        if (!gelright || gelright->MaterialId() != fRightFlux) continue;
+
+        auto side = GetSideSkeletonEl(gelright);
+        TPZGeoElSide gelsideright(gelright, side);
+
+        auto gelsideaverpr = gelsideright.Neighbour();
+        auto it = matids1d.find(gelsideaverpr.Element()->MaterialId());
+        while (it == matids1d.end())
+        {
+            gelsideaverpr = gelsideaverpr.Neighbour();
+            it = matids1d.find(gelsideaverpr.Element()->MaterialId());
+#ifdef PZDEBUG
+            if (gelsideaverpr.Element() == gelsideright.Element()) DebugStop();
+#endif
+        }
+        int64_t index;
+
+        TPZCompElSide celsideaverpr = gelsideaverpr.Reference();
+        TPZCompElSide celsideright = gelsideright.Reference();
+#ifdef PZDEBUG
+        if (!celsideaverpr || !celsideright)
+        {
+            DebugStop();
+        }
+#endif
+        TPZGeoElBC gelbc(gelsideright, fInterface);
+        auto intr = new TPZMultiphysicsInterfaceElement(cmeshm, gelbc.CreatedElement(),index,celsideright,celsideaverpr);
+        fElementPartition[gelbc.CreatedElement()->Index()] = fElementPartition[gelsideright.Element()->Index()];
+    }
+}
+
+// Here SBFEM Multiphysics Volume elements are created.
+// The Multiphysics element must be fSkeleton
+// But I still need to pass the Volumetric Collapsed element so the TPZSBFemVolumeHdiv class will be able to perform integrations.
+void TPZBuildSBFemMultiphysics::CreateSBFemMultiphysicsVol(TPZMultiphysicsCompMesh & cmeshm, set<int> &matids1d, set<int> & matidtarget)
+{
+    // This for creates the volumetric multiphysics element, working as an AutoBuild()
+    for (auto cel : cmeshm.ElementVec())
+    {
+        // Now I'm searching for the collapsed element, in which the matid is in matidtarget.
+        if (!cel) continue;
+        auto gelcollapsed = cel->Reference();
+        
+        auto it = matidtarget.find(gelcollapsed->MaterialId());
+        if (it == matidtarget.end()) continue;
+
+        auto idvol = fElementPartition[gelcollapsed->Index()];
+        if (idvol == -1) DebugStop();
+
+        // int64_t index;
+
+        // Getting the TPZSBFemVolumeMultiphysics compel
+        // auto celsbfem = cmeshm.Element(index);
+
+        auto sbfem = dynamic_cast<TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad> * >(cel);
+        if(!sbfem) continue;
+
+
+        // Adding multiphysics compels:
+        // The neighbour will be in the surface identified as side. So I get the gelside and search for its neighbour.
+        // I'll include all computational elements related to geo collapsed element
+        auto side = GetSideCollapsedEl(gelcollapsed);
+        TPZGeoElSide gelside(gelcollapsed, side);
+
+        // 1st element will be fDifPressure
+        auto neigh = gelside.Neighbour();
+        auto gel1d = neigh.Element();
+        if(!gel1d || !(gel1d->Reference())) DebugStop();
+        
+        while (gel1d->MaterialId() != fDifPressure || fElementPartition[gel1d->Index()] != fElementPartition[idvol])
+        {
+            neigh = neigh.Neighbour();
+            gel1d = neigh.Element();
+        }
+        auto cel1d = gel1d->Reference();
+        TPZManVector<int64_t> indexes(0);
+        sbfem->SetConnectIndexes(indexes);
+        sbfem->AddElement1D(cel1d, 0);
+        int count = 1;
+
+        while (gelside != neigh)
+        {
+            neigh = neigh.Neighbour();
+            gel1d = neigh.Element();
+            if(gel1d->Reference() && gel1d->Dimension() == fGMesh->Dimension()-1)
+            {
+                if(fElementPartition[gel1d->Index()] == idvol && count != 6)
+                {
+                    cel1d = gel1d->Reference();
+                    sbfem->AddElement1D(cel1d, count);
+                    count++;
+                    if(count == 7) break;
+                }
+                else
+                {
+                    auto it = matids1d.find(gel1d->MaterialId());
+                    if(fElementPartition[gel1d->Index()] == -1 && it != matids1d.end() && count == 6)
+                    {
+                        cel1d = gel1d->Reference();
+                        sbfem->AddElement1D(cel1d, count);
+                        count++;
+                        if(count == 7) break;
+                    }
+                    if(gel1d->MaterialId() == fSkeletonMatId && count == 6)
+                    {
+                        cel1d = gel1d->Reference();
+                        sbfem->AddElement1D(cel1d, count);
+                        count++;
+                        if(count == 7) break;
+                    }
+                }
+            }
+        }
+    }
+    
+}
+
+void TPZBuildSBFemMultiphysics::GroupandCondense(TPZMultiphysicsCompMesh & cmeshm)
+{
+    for (auto cel : cmeshm.ElementVec())
+    {
+        if (!cel)
+        {
+            continue;
+        }
+        auto sbfemgr = dynamic_cast<TPZSBFemMultiphysicsElGroup *>(cel);
+        if (!sbfemgr)
+        {
+            continue;
+        }
+        sbfemgr->GroupandCondense(fCondensedMatids);
+        cmeshm.ComputeNodElCon();
+        cmeshm.CleanUpUnconnectedNodes();
+    }
+}
+
+
+void TPZBuildSBFemMultiphysics::BuildMultiphysicsCompMeshfromSkeleton(TPZCompMesh &cmesh)
+{
+    DebugStop();
+}
+
+
+// ******** UTILITY FUNCTIONS
+
+int TPZBuildSBFemMultiphysics::GetSideSkeletonEl(TPZGeoEl * gel)
+{
+    auto side = -1;
+    switch (gel->Type())
+    {
+    case EOned:
+        side = 2;
+        break;
+    case ETriangle:
+        side = 6;
+        break;
+    case EQuadrilateral:
+        side = 8;
+    default:
+        break;
+    }
+    return side;
+}
+
+int TPZBuildSBFemMultiphysics::GetSideCollapsedEl(TPZGeoEl * gel)
+{
+    auto side = -1;
+    switch (gel->Type())
+    {
+    case EQuadrilateral:
+        side = 4;
+        break;
+    case EPrisma:
+        side = 15;
+        break;
+    case ECube:
+        side = 20;
+        break;
+    default:
+        break;
+    }
+    return side;
+}
+
+void TPZBuildSBFemMultiphysics::CreateSBFemMultiphysicsElGroups(TPZMultiphysicsCompMesh & cmesh, set<int> & matidtarget)
+{
+    int64_t numgroups = fPartitionCenterNode.size();
+    int64_t groupelementindices(numgroups);
+    
+    TPZManVector<int64_t> elementgroupindices(numgroups); 
+    
+    for (int64_t el=0; el<numgroups; el++)
+    {
+        int64_t index;
+        new TPZSBFemMultiphysicsElGroup(cmesh,index);
+        elementgroupindices[el] = index;
+    }
+    int dim = cmesh.Dimension();
+    for (auto cel : cmesh.ElementVec())
+    {
+        if (!cel) continue;
+        
+        auto sbfem = dynamic_cast<TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad> *>(cel);
+        if (sbfem)
+        {
+            TPZGeoEl *gel = sbfem->Reference();
+            if(gel->Dimension() != fGMesh->Reference()->Dimension()) continue;
+            int64_t gelindex = gel->Index();
+
+            int side = GetSideCollapsedEl(gel);
+            TPZGeoElSide gelside(gel,side);
+            int geldim = gel->Dimension();
+            int nsidenodes = gel->NSideNodes(side);
+            TPZManVector<int64_t,8> cornernodes(nsidenodes);
+            for (int node = 0; node<nsidenodes; node++)
+            {
+                cornernodes[node] = gel->SideNodeIndex(side, node);
+            }
+            
+            TPZGeoElSide neighbour = gelside.Neighbour();
+            while (neighbour != gelside) {
+                if(neighbour.Element()->Dimension() == geldim-1 && neighbour.Element()->Reference())
+                {
+                    int nsidenodesneighbour = neighbour.Element()->NCornerNodes();
+                    if (nsidenodesneighbour == nsidenodes)
+                    {
+                        TPZManVector<int64_t,8> neighnodes(nsidenodesneighbour);
+                        for (int i=0; i<nsidenodesneighbour; i++) {
+                            neighnodes[i] = neighbour.Element()->NodeIndex(i);
+                        }
+                        int numequal = 0;
+                        for (int i=0; i<nsidenodesneighbour; i++) {
+                            if (neighnodes[i] == cornernodes[i]) {
+                                numequal++;
+                            }
+                        }
+                        if (numequal == nsidenodesneighbour) {
+                            break;
+                        }
+                    }
+                }
+                neighbour = neighbour.Neighbour();
+            }
+            if (neighbour == gelside) {
+                // we are not handling open sides (yet)
+                DebugStop();
+            }
+            int64_t skelindex = neighbour.Element()->Reference()->Index();
+            sbfem->SetSkeleton(skelindex);
+            
+            int64_t gelgroup = fElementPartition[gelindex];
+            if (gelgroup == -1) {
+                DebugStop();
+            }
+            int64_t celgroupindex = elementgroupindices[gelgroup];
+            auto celgr = cmesh.Element(celgroupindex);
+            auto sbfemgr = dynamic_cast<TPZSBFemMultiphysicsElGroup *>(celgr);
+            if (!sbfemgr) {
+                DebugStop();
+            }
+            sbfemgr->AddElement(sbfem);
+        }
+    }
+    
+    for (auto index : elementgroupindices)
+    {
+        auto cel = cmesh.Element(index);
+        auto sbfemgroup = dynamic_cast<TPZSBFemMultiphysicsElGroup *>(cel);
+        if (!sbfemgroup)
+        {
+            DebugStop();
+        }
+        const TPZVec<TPZCompEl *> &subgr = sbfemgroup->GetElGroup();
+        int64_t nsub = subgr.NElements();
+        for (auto cels : subgr)
+        {
+            auto femvol = dynamic_cast<TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad> *>(cels);
+            if (!femvol) {
+                DebugStop();
+            }
+            femvol->SetElementGroupIndex(index);
+        }
+    }
+}

--- a/Pre/TPZBuildSBFemMultiphysics.h
+++ b/Pre/TPZBuildSBFemMultiphysics.h
@@ -1,0 +1,85 @@
+//
+//  TPZBuildSBFemMultiphysics.h
+//  PZ
+//
+//  Created by Karolinne Coelho on 18/01/21.
+//
+//
+
+#pragma once
+
+#include "TPZBuildSBFem.h"
+#include "TPZMultiphysicsCompMesh.h"
+
+using namespace std;
+
+class TPZBuildSBFemMultiphysics : public TPZBuildSBFem
+{
+    int fDifPressure, fInternal, fLeftFlux, fRightFlux, fInterface;
+
+    set<int> fCondensedMatids;
+
+    map<int64_t,TPZCompEl *> fGeltocel;
+
+    TPZManVector<int64_t> fElGroupIndexes;
+    
+public:
+    
+    /// simple constructor
+    TPZBuildSBFemMultiphysics(TPZAutoPointer<TPZGeoMesh> & gmesh, int skeletonmatid, std::map<int,int> &matidtranslation) : TPZBuildSBFem(gmesh,skeletonmatid, matidtranslation)
+    {
+        // fSkeletonMatId represents the external average pressure;
+        fInterface = fSkeletonMatId+1; //7 
+
+        // fRightFlux represents the external right flux (next to fSkeletonMatId)
+        fRightFlux = fInterface+1; //8
+
+        // fInternal will gather internal flux and pressures (next to fRightFlux)
+        fInternal = fRightFlux+1; //9
+        
+        // fLeftFlux represents the external left flux (next to fInternal)
+        fLeftFlux = fInternal +1; //10
+
+        // fDifPressure represents the differential of the pressure (next to fLeftFlux)
+        fDifPressure = fLeftFlux + 1; //11
+        
+        // Order of the elements, from left to right:
+        // fDifPressure -> fInterface -> fLeftFlux -> fInternal -> fRightFlux -> fInterface -> fSkeletonMatId
+        fCondensedMatids = {fInterface, fLeftFlux, fInternal, fRightFlux};
+    }
+
+    int GetSideSkeletonEl(TPZGeoEl * gel);
+
+    int GetSideCollapsedEl(TPZGeoEl * gel);
+
+    void BuildMultiphysicsCompMesh(TPZMultiphysicsCompMesh &cmesh);
+
+    void CreateExternalElements(TPZAutoPointer<TPZGeoMesh> & gmesh, set<int> & matidtarget, set <int> & matids1d);
+
+    void CreateCollapsedGeoEls(TPZCompMesh & cmeshpressure, set<int> & matidstarget, set<int> & matids1d);
+
+    void CreateCompElPressure(TPZCompMesh &cmeshpressure, set<int> & matids1d);
+
+    void CreateCompElFlux(TPZCompMesh &cmeshflux, set<int> & matidtarget, set<int> & matid1d);
+
+    void CreateSBFemMultiphysicsMesh(TPZMultiphysicsCompMesh & cmeshm, set<int> & matidtarget);
+
+    void AddInterfaceElements(TPZMultiphysicsCompMesh & cmeshm, set<int> &matids1d);
+
+    void CreateSBFemVolumeFlux(TPZCompMesh & cmesh, set<int> &matids1d, set<int> & matidtarget);
+
+    void CreateSBFemVolumePressure(TPZCompMesh & cmesh, set<int> &matids1d, set<int> & matidtarget);
+    
+    void CreateSBFemMultiphysicsVol(TPZMultiphysicsCompMesh & cmeshm, set<int> &matid1d, set<int> & matidtarget);
+
+    void CreateSBFemMultiphysicsElGroups(TPZMultiphysicsCompMesh & cmeshm, set<int> & matidtarget);
+
+    void GroupandCondense(TPZMultiphysicsCompMesh & cmeshm);
+
+    void StandardConfigurationHdiv();
+
+    void AddInternalElements();
+
+// NOT READY YET
+    void BuildMultiphysicsCompMeshfromSkeleton(TPZCompMesh &cmesh);
+};


### PR DESCRIPTION
This PR aims to include the SBFEM-Hdiv code in RefactorGeom. Description of the changes:

**Common files:**
1. TPZCompElHDivCollapsed.h - Defined a variable as protected to be accessible from the derived TPZCompElHDivSBFem class.
2. pzcondensedcompel.h and .cpp - Added the  method `void PermuteActiveConnects(TPZManVector<int64_t> &perm);`.
3. pzcreateapproxspace.h and .cpp - Created the method  `void SetAllCreateFunctionsSBFemMultiphysics(int dimension);` that defines the SBFEM Multiphysics approximation space type `EMultiphysicsSBFem`.
4. pzelementgroup.h and .cpp - Created the method `void ReorderConnects(TPZManVector<int64_t> &connects);`.

**SBFEM new files:**
1. TPZBuildSBFemMultiphysics.h and .cpp - Builds the SBFEM multiphysics mesh.
2. TPZSBFemMultiphysicsElGroup.h and .cpp - The equivalent of the TPZSBFemElementGroup for multiphysics formulation. It is the computational S-element for multiphysics approximation. It computes the SBFEM coefficient matrices, solves the eigenvalue problem, and computes the stiffness matrix.
3. TPZSBFemVolumeMultiphysics.h and .cpp - It contains the Duffy's subpartition of a multiphysics S-element (TPZSBFemMultiphysicsElGroup). Derived from the TPZMultiphysicsCompEl.h, it is composed of the TPZSBFemVolumeHDiv and TPZSBFemVolumeL2 computational elements.
4. TPZSBFemVolumeHDiv.h and .cpp - It contains the Duffy's computational element that approximates the flux using H(div) approximation spaces (defined in TPZCompElHDivSBFem).
5. TPZSBFemVolumeL2.h and .cpp - It contains the Duffy's computational element that approximates the pressure using L2 approximation spaces - derived from the TPZSBFemVolume.h (SBFEM-H1 usual approximation).

**Changes in SBFEM old files:**
1. TPZSBFemVolume.h and TPZBuildSBFem.h - Defined the class variables as protected to be accessible from the derived classes.