### PR TITLE
Created TPZCompElH1

### DIFF
--- a/Mesh/CMakeLists.txt
+++ b/Mesh/CMakeLists.txt
@@ -59,6 +59,7 @@ set(headers
   pzhdivpressurebound.h
   tpzagglomeratemesh.h
   TPZAgglomerateEl.h
+  TPZCompElH1.h
 )
 
 set(sources
@@ -110,6 +111,7 @@ set(sources
   pzhdivpressure.cpp
   pzhdivpressurebound.cpp
   TPZAgglomerateEl.cpp
+  TPZCompElH1.cpp
 )
 
 if(USING_MKL)

--- a/Mesh/TPZCompElH1.cpp
+++ b/Mesh/TPZCompElH1.cpp
@@ -1,0 +1,286 @@
+#include "TPZCompElH1.h"
+#include "pzlog.h"
+#include "pzconnect.h"
+#include "TPZMaterial.h"
+#include "pzcmesh.h"
+
+#ifdef PZ_LOG
+static TPZLogger logger("pz.mesh.tpzintelgen");
+#endif
+
+
+template<class TSHAPE>
+TPZCompElH1<TSHAPE>::TPZCompElH1(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) : TPZRegisterClassId(&TPZCompElH1::ClassId),
+TPZIntelGen<TSHAPE>(mesh,gel,index){
+
+	for(int i=0;i<TSHAPE::NSides;i++) {
+		fConnectIndexes[i] = this->CreateMidSideConnect(i);
+		mesh.ConnectVec()[fConnectIndexes[i]].IncrementElConnected();
+	}
+}
+
+template<class TSHAPE>
+TPZCompElH1<TSHAPE>::TPZCompElH1(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index, int nocreate) : TPZRegisterClassId(&TPZCompElH1::ClassId),
+TPZIntelGen<TSHAPE>(mesh,gel,index)
+{
+	
+}
+
+template<class TSHAPE>
+TPZCompElH1<TSHAPE>::TPZCompElH1(TPZCompMesh &mesh, const TPZCompElH1<TSHAPE> &copy) : TPZRegisterClassId(&TPZCompElH1::ClassId),
+                                                                                       TPZIntelGen<TSHAPE>(mesh,copy){
+	this->fConnectIndexes = copy.fConnectIndexes;
+}
+
+
+template<class TSHAPE>
+TPZCompElH1<TSHAPE>::TPZCompElH1(TPZCompMesh &mesh,
+								 const TPZCompElH1<TSHAPE> &copy,
+								 std::map<int64_t,int64_t> & gl2lcConMap,
+								 std::map<int64_t,int64_t> & gl2lcElMap) :
+TPZRegisterClassId(&TPZCompElH1::ClassId), 
+TPZIntelGen<TSHAPE>(mesh,copy,gl2lcConMap,gl2lcElMap)
+{
+	int i;
+	for(i=0;i<TSHAPE::NSides;i++)
+	{
+		int64_t lcIdx = -1;
+		int64_t glIdx = copy.fConnectIndexes[i];
+		if (gl2lcConMap.find(glIdx) != gl2lcConMap.end()) lcIdx = gl2lcConMap[glIdx];
+		else
+		{
+			std::stringstream sout;
+			sout << "ERROR in : " << __PRETTY_FUNCTION__
+			<< " trying to clone the connect index: " << glIdx
+			<< " wich is not in mapped connect indexes!";
+			LOGPZ_ERROR(logger, sout.str().c_str());
+			fConnectIndexes[i] = -1;
+			return;
+		}
+		fConnectIndexes[i] = lcIdx;
+	}
+  //TODO:NATHANFRAN
+}
+
+template<class TSHAPE>
+TPZCompElH1<TSHAPE>::~TPZCompElH1() {
+    TPZGeoEl *gel = this->Reference();
+    if (gel) {
+        TPZCompEl *cel = gel->Reference();
+        if (cel == this) {
+            this->RemoveSideRestraintsII(this->EDelete);
+        }
+        this->Reference()->ResetReference();
+    }
+    TPZStack<int64_t > connectlist;
+    this->BuildConnectList(connectlist);
+    int64_t nconnects = connectlist.size();
+    for (int ic = 0; ic < nconnects; ic++) {
+        if (connectlist[ic] != -1){
+            this->fMesh->ConnectVec()[connectlist[ic]].DecrementElConnected();
+        }
+    }
+}
+
+
+template<class TSHAPE>
+void TPZCompElH1<TSHAPE>::SetConnectIndex(int i, int64_t connectindex){
+#ifndef PZNODEBUG
+	if(i<0 || i>= TSHAPE::NSides) {
+		std::cout << " TPZIntelGen<TSHAPE>::SetConnectIndex index " << i <<
+		" out of range\n";
+		return;
+	}
+#endif
+	fConnectIndexes[i] = connectindex;
+}
+
+/**sets the interpolation order of side to order*/
+template<class TSHAPE>
+void TPZCompElH1<TSHAPE>::SetSideOrder(int side, int order) {
+	if(side<0 || side >= TSHAPE::NSides || (side >= TSHAPE::NCornerNodes && order <1)) {
+		PZError << "TPZIntelGen::SetSideOrder. Bad paramenter side " << side << " order " << order << std::endl;
+		DebugStop();
+#ifdef PZ_LOG
+		std::stringstream sout;
+		sout << __PRETTY_FUNCTION__ << " Bad side or order " << side << " order " << order;
+		LOGPZ_ERROR(logger,sout.str())
+#endif
+		return;
+	}
+	if(side>= TSHAPE::NCornerNodes) {
+		if(fConnectIndexes[side] == -1) return;
+        int prevorder = this->fPreferredOrder;
+        if (this->ConnectIndex(TSHAPE::NSides-1) != -1) {
+            prevorder = EffectiveSideOrder(TSHAPE::NSides-1);
+        }
+		TPZConnect &c = this->Connect(side);
+        int previousconnectorder = c.Order();
+        if (order != previousconnectorder)
+        {
+            c.SetOrder(order,this->ConnectIndex(side));
+            int64_t seqnum = c.SequenceNumber();
+            int nvar = 1;
+            TPZMaterial * mat = this->Material();
+            if(mat) nvar = mat->NStateVariables();
+            int nshape = TSHAPE::NConnectShapeF(side, order);
+            c.SetNShape(nshape);
+            c.SetNState(nvar);
+            this->Mesh()->Block().Set(seqnum,nshape*nvar);
+            TPZGeoElSide gelside(this->Reference(),side);
+            TPZStack<TPZCompElSide> equal;
+            gelside.EqualLevelCompElementList(equal, 1, 0);
+            int64_t neq = equal.size();
+            for (int64_t eq=0; eq<neq; eq++) {
+                TPZInterpolatedElement *intel = dynamic_cast<TPZInterpolatedElement*>(equal[eq].Element());
+                intel->AdjustIntegrationRule();
+            }
+        }
+        
+        int neworder = prevorder;
+        if (this->ConnectIndex(TSHAPE::NSides-1) != -1) {
+            neworder = EffectiveSideOrder(TSHAPE::NSides-1);
+        }
+		if(neworder != prevorder) {
+            this->AdjustIntegrationRule();
+		}
+	}
+}
+
+/**returns the actual interpolation order of the polynomial along the side*/
+template<class TSHAPE>
+int TPZCompElH1<TSHAPE>::EffectiveSideOrder(int side) const {
+
+	if(side < TSHAPE::NCornerNodes || side >= TSHAPE::NSides) return 0;
+	if(fConnectIndexes[side] == -1)
+	{
+		std::stringstream sout ;
+		sout << __PRETTY_FUNCTION__ << " side " << side << std::endl;
+		//Print(sout);
+#ifdef PZ_LOG
+		LOGPZ_ERROR(logger,sout.str());
+#else
+		std::cout << sout.str() << std::endl;
+#endif
+		DebugStop();
+		return -1;
+	}
+    TPZStack<int> lowdim;
+    this->Reference()->LowerDimensionSides(side,lowdim);
+	TPZConnect &c = this->Connect(side);
+	int order = c.Order();
+    for (int is=0; is<lowdim.size(); is++) {
+        TPZConnect &c = this->MidSideConnect(lowdim[is]);
+        if(c.Order() > order) order = c.Order();
+    }
+    return order;
+}
+
+template<class TSHAPE>
+int TPZCompElH1<TSHAPE>::NConnectShapeF(int connect, int order) const{
+    
+    if(connect < TSHAPE::NCornerNodes) return TSHAPE::NConnectShapeF(connect,0);
+	if(order < 0) return 0;
+    int nshape = TSHAPE::NConnectShapeF(connect, order);
+#ifdef PZDEBUG
+    if(nshape < 0 )
+    {
+        nshape = TSHAPE::NConnectShapeF(connect, order);
+        DebugStop();
+    }
+#endif
+	return nshape;
+}
+
+template<class TSHAPE>
+int TPZCompElH1<TSHAPE>::NSideConnects(int side) const {
+	return TSHAPE::NContainedSides(side);
+}
+
+template<class TSHAPE>
+int TPZCompElH1<TSHAPE>::SideConnectLocId(int node, int side) const {
+	return TSHAPE::ContainedSideLocId(side,node);
+}
+
+/**Identifies the interpolation order on the interior of the element*/
+template<class TSHAPE>
+void TPZCompElH1<TSHAPE>::GetInterpolationOrder(TPZVec<int> &ord) {
+	ord.Resize(TSHAPE::NSides-TSHAPE::NCornerNodes);
+	int i;
+	for(i=0; i<TSHAPE::NSides-TSHAPE::NCornerNodes; i++) {
+		ord[i] = this->Connect(i+TSHAPE::NCornerNodes).Order();
+	}
+}
+
+
+/**compute the values of the shape function of the side*/
+template<class TSHAPE>
+void TPZCompElH1<TSHAPE>::SideShapeFunction(int side,TPZVec<REAL> &point,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi) {
+	
+	int nc = TSHAPE::NContainedSides(side);
+	int nn = TSHAPE::NSideNodes(side);
+	TPZManVector<int64_t,27> id(nn);
+	TPZManVector<int,27> order(nc-nn);
+	int n,c;
+	TPZGeoEl *ref = this->Reference();
+	for (n=0;n<nn;n++){
+		int nodloc = TSHAPE::SideNodeLocId(side,n);
+		id [n] = ref->NodePtr(nodloc)->Id();
+	}
+	for (c=nn;c<nc;c++){
+		int conloc = TSHAPE::ContainedSideLocId(side,c);
+        order[c-nn] = this->Connect(conloc).Order();
+	}
+	TSHAPE::SideShape(side, point, id, order, phi, dphi);
+}
+
+template<class TSHAPE>
+void TPZCompElH1<TSHAPE>::Shape(TPZVec<REAL> &pt, TPZFMatrix<REAL> &phi, TPZFMatrix<REAL> &dphi) {
+	TPZManVector<int64_t,TSHAPE::NCornerNodes> id(TSHAPE::NCornerNodes,0);
+	TPZManVector<int, TSHAPE::NSides-TSHAPE::NCornerNodes+1> ord(TSHAPE::NSides-TSHAPE::NCornerNodes,0);
+	int i;
+	TPZGeoEl *ref = this->Reference();
+	for(i=0; i<TSHAPE::NCornerNodes; i++) {
+		id[i] = ref->NodePtr(i)->Id();
+	}
+	for(i=0; i<TSHAPE::NSides-TSHAPE::NCornerNodes; i++) {
+		ord[i] = this->Connect(i+TSHAPE::NCornerNodes).Order();
+	}
+	TSHAPE::Shape(pt,id,ord,phi,dphi);
+}
+
+#include "pzshapepoint.h"
+#include "pzshapelinear.h"
+#include "pzshapetriang.h"
+#include "pzshapequad.h"
+#include "pzshapetetra.h"
+#include "pzshapeprism.h"
+#include "pzshapecube.h"
+#include "pzshapepiram.h"
+#include "pzshapepiramHdiv.h"
+
+
+
+using namespace pzshape;
+
+template class TPZCompElH1<TPZShapeTriang>;
+template class TPZCompElH1<TPZShapePoint>;
+template class TPZCompElH1<TPZShapeLinear>;
+template class TPZCompElH1<TPZShapeQuad>;
+template class TPZCompElH1<TPZShapeTetra>;
+template class TPZCompElH1<TPZShapePrism>;
+template class TPZCompElH1<TPZShapePiram>;
+template class TPZCompElH1<TPZShapePiramHdiv>;
+template class TPZCompElH1<TPZShapeCube>;
+
+#ifndef BORLAND
+template class TPZRestoreClass< TPZCompElH1<TPZShapePoint>>;
+template class TPZRestoreClass< TPZCompElH1<TPZShapeLinear>>;
+template class TPZRestoreClass< TPZCompElH1<TPZShapeTriang>>;
+template class TPZRestoreClass< TPZCompElH1<TPZShapeQuad>>;
+template class TPZRestoreClass< TPZCompElH1<TPZShapeCube>>;
+template class TPZRestoreClass< TPZCompElH1<TPZShapeTetra>>;
+template class TPZRestoreClass< TPZCompElH1<TPZShapePrism>>;
+template class TPZRestoreClass< TPZCompElH1<TPZShapePiram>>;
+template class TPZRestoreClass< TPZCompElH1<TPZShapePiramHdiv>>;
+#endif

--- a/Mesh/TPZCompElH1.h
+++ b/Mesh/TPZCompElH1.h
@@ -1,0 +1,82 @@
+#ifndef TPZCOMPELH1_H
+#define TPZCOMPELH1_H
+
+
+#include "pzelctemp.h"
+
+/**
+   @brief TPZCompElH1 implements a H1-conforming approximation space.
+*/
+template<class TSHAPE>
+class TPZCompElH1  : public TPZIntelGen<TSHAPE>{
+protected:
+  ///! Indexes of the connects associated with the elements
+  TPZManVector<int64_t,TSHAPE::NSides> fConnectIndexes =
+    TPZManVector<int64_t,TSHAPE::NSides>(TSHAPE::NSides,-1);
+public:
+
+  TPZCompElH1() = default;
+
+  TPZCompElH1(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+	
+	TPZCompElH1(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index, int nocreate);
+	
+	TPZCompElH1(TPZCompMesh &mesh, const TPZCompElH1<TSHAPE> &copy);
+
+  TPZCompElH1(const TPZCompElH1 &) = default;
+  TPZCompElH1(TPZCompElH1 &&) = default;
+  ~TPZCompElH1();
+  TPZCompElH1 & operator =(const TPZCompElH1 &) = default;
+  TPZCompElH1 & operator =(TPZCompElH1 &&) = default;
+	/** @brief Constructor used to generate patch mesh... generates a map of connect index from global mesh to clone mesh */
+	TPZCompElH1(TPZCompMesh &mesh,
+				const TPZCompElH1<TSHAPE> &copy,
+				std::map<int64_t,int64_t> & gl2lcConMap,
+				std::map<int64_t,int64_t> & gl2lcElMap);
+  
+  virtual TPZCompEl *Clone(TPZCompMesh &mesh) const  override {
+		return new TPZCompElH1<TSHAPE> (mesh, *this);
+	}
+	
+	/**
+	 * @brief Create a copy of the given element. The clone copy have the connect indexes
+	 * mapped to the local clone connects by the given map
+	 * @param mesh Patch clone mesh
+	 * @param gl2lcConMap map the connects indexes from global element (original) to the local copy.
+	 * @param gl2lcElMap map the indexes of the elements between the original element and the patch element
+	 */
+	virtual TPZCompEl *ClonePatchEl(TPZCompMesh &mesh,std::map<int64_t,int64_t> & gl2lcConMap,std::map<int64_t,int64_t>&gl2lcElMap) const override
+	{
+		return new TPZCompElH1<TSHAPE> (mesh, *this, gl2lcConMap, gl2lcElMap);
+	}
+  
+  inline int NConnects() const override{
+		return TSHAPE::NSides;
+	}
+  int NSideConnects(int side) const override;
+  
+  int NConnectShapeF(int connect, int order) const override;
+
+  void SetConnectIndex(int i, int64_t connectindex) override;
+
+  void SetSideOrder(int side, int order) override;
+
+  int EffectiveSideOrder(int side) const override;
+
+  int SideConnectLocId(int node, int side) const override;
+
+  void GetInterpolationOrder(TPZVec<int> &ord) override;
+
+  //! Reference to the connect vector
+  inline const TPZVec<int64_t> & ConnectVec() const override{
+    return fConnectIndexes;
+  }
+
+  	/** @brief Compute the values of the shape function of the side*/
+	virtual void SideShapeFunction(int side,TPZVec<REAL> &point,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi) override;
+	
+	void Shape(TPZVec<REAL> &pt, TPZFMatrix<REAL> &phi, TPZFMatrix<REAL> &dphi) override;
+};
+
+
+#endif /* TPZCOMPELH1_H */

--- a/Mesh/TPZCompElHCurl.cpp
+++ b/Mesh/TPZCompElHCurl.cpp
@@ -181,7 +181,10 @@ int TPZCompElHCurl<TSHAPE>::ClassId() const{
 
 template<class TSHAPE>
 int TPZCompElHCurl<TSHAPE>::StaticClassId(){
-    return Hash("TPZCompElHCurl") ^ TPZIntelGen<TSHAPE>().ClassId() << 1;
+    //TODO:NATHANFRAN
+    DebugStop();
+    // return Hash("TPZCompElHCurl") ^ TPZIntelGen<TSHAPE>()::ClassId() << 1;
+    return -1;
 }
 
 
@@ -334,6 +337,14 @@ int TPZCompElHCurl<TSHAPE>::EffectiveSideOrder(int side) const{
         DebugStop();
     }
 	return -1;
+}
+
+template<class TSHAPE>
+void TPZCompElHCurl<TSHAPE>::GetInterpolationOrder(TPZVec<int> &ord) {
+	ord.Resize(TSHAPE::NSides-TSHAPE::NCornerNodes);
+	for(auto i=0; i<TSHAPE::NSides-TSHAPE::NCornerNodes; i++) {
+		ord[i] = this->Connect(i).Order();
+	}
 }
 
 template<class TSHAPE>

--- a/Mesh/TPZCompElHCurl.h
+++ b/Mesh/TPZCompElHCurl.h
@@ -66,6 +66,10 @@ public:
 template<class TSHAPE>
 class TPZCompElHCurl : public TPZIntelGen<TSHAPE> {
 protected:
+    ///! Indexes of the connects associated with the elements
+    TPZManVector<int64_t,TSHAPE::NSides - TSHAPE::NCornerNodes> fConnectIndexes =
+        TPZManVector<int64_t,TSHAPE::NSides - TSHAPE::NCornerNodes>(TSHAPE::NSides-TSHAPE::NCornerNodes,-1);
+    
     /// vector describing the permutation associated with each side
     TPZManVector<int, TSHAPE::NSides - TSHAPE::NCornerNodes> fSidePermutation;
 
@@ -95,11 +99,11 @@ public:
     //since TPZCompElHCurl is an abstract class
     static int StaticClassId();
     /** @brief Set create function in TPZCompMesh to create elements of this type */
-	void SetCreateFunctions(TPZCompMesh *mesh) override;
+    void SetCreateFunctions(TPZCompMesh *mesh) override;
 
     MElementType Type() override;
 
-	int NConnects() const override;
+    int NConnects() const override;
 	/** @brief return the local index for connect */
     int SideConnectLocId(int con, int side) const override;
 
@@ -109,9 +113,16 @@ public:
         return 0;
     }
 
+    void GetInterpolationOrder(TPZVec<int> &ord) override;
+        
     int64_t ConnectIndex(int con) const override;
 
     void SetConnectIndex(int i, int64_t connectindex) override;
+
+    //! Reference to the connect vector
+    const TPZVec<int64_t> & ConnectVec() const override{
+        return fConnectIndexes;
+    }
 
     /**
     * @brief Number of shapefunctions of the connect associated

--- a/Mesh/TPZCompElHCurlFull.h
+++ b/Mesh/TPZCompElHCurlFull.h
@@ -39,6 +39,22 @@ public:
     /** @brief Returns the unique identifier for reading/writing objects to streams */
     int ClassId() const override;
 
+  virtual TPZCompEl *Clone(TPZCompMesh &mesh) const  override {
+		return new TPZCompElHCurlFull<TSHAPE> (mesh, *this);
+	}
+	
+	/**
+	 * @brief Create a copy of the given element. The clone copy have the connect indexes
+	 * mapped to the local clone connects by the given map
+	 * @param mesh Patch clone mesh
+	 * @param gl2lcConMap map the connects indexes from global element (original) to the local copy.
+	 * @param gl2lcElMap map the indexes of the elements between the original element and the patch element
+	 */
+	virtual TPZCompEl *ClonePatchEl(TPZCompMesh &mesh,std::map<int64_t,int64_t> & gl2lcConMap,std::map<int64_t,int64_t>&gl2lcElMap) const override
+	{
+		return new TPZCompElHCurlFull<TSHAPE> (mesh, *this, gl2lcConMap, gl2lcElMap);
+	}
+
     /**
     * @brief Number of shapefunctions of the connect associated
     * @param connect connect number

--- a/Mesh/pzcompelwithmem.cpp
+++ b/Mesh/pzcompelwithmem.cpp
@@ -159,15 +159,16 @@ inline void TPZCompElWithMem<TPZInterfaceElement>::PrepareIntPtIndices() {
     }
     
 }
+#include "TPZCompElH1.h"
 
-template class TPZRestoreClass<TPZCompElWithMem<TPZIntelGen<pzshape::TPZShapePoint> >>;
-template class TPZRestoreClass<TPZCompElWithMem<TPZIntelGen<pzshape::TPZShapeLinear> >>;
-template class TPZRestoreClass<TPZCompElWithMem<TPZIntelGen<pzshape::TPZShapeTriang> >>;
-template class TPZRestoreClass<TPZCompElWithMem<TPZIntelGen<pzshape::TPZShapeQuad> >>;
-template class TPZRestoreClass<TPZCompElWithMem<TPZIntelGen<pzshape::TPZShapeCube> >>;
-template class TPZRestoreClass<TPZCompElWithMem<TPZIntelGen<pzshape::TPZShapeTetra> >>;
-template class TPZRestoreClass<TPZCompElWithMem<TPZIntelGen<pzshape::TPZShapePrism> >>;
-template class TPZRestoreClass<TPZCompElWithMem<TPZIntelGen<pzshape::TPZShapePiram> >>;
+template class TPZRestoreClass<TPZCompElWithMem<TPZCompElH1<pzshape::TPZShapePoint> >>;
+template class TPZRestoreClass<TPZCompElWithMem<TPZCompElH1<pzshape::TPZShapeLinear> >>;
+template class TPZRestoreClass<TPZCompElWithMem<TPZCompElH1<pzshape::TPZShapeTriang> >>;
+template class TPZRestoreClass<TPZCompElWithMem<TPZCompElH1<pzshape::TPZShapeQuad> >>;
+template class TPZRestoreClass<TPZCompElWithMem<TPZCompElH1<pzshape::TPZShapeCube> >>;
+template class TPZRestoreClass<TPZCompElWithMem<TPZCompElH1<pzshape::TPZShapeTetra> >>;
+template class TPZRestoreClass<TPZCompElWithMem<TPZCompElH1<pzshape::TPZShapePrism> >>;
+template class TPZRestoreClass<TPZCompElWithMem<TPZCompElH1<pzshape::TPZShapePiram> >>;
 
 #include "pzgeopoint.h"
 #include "pzgeoquad.h"

--- a/Mesh/pzcreateapproxspace.cpp
+++ b/Mesh/pzcreateapproxspace.cpp
@@ -8,6 +8,7 @@
 #include "pzcmesh.h"
 #include "pzcondensedcompel.h"
 #include "pzinterpolationspace.h" 
+#include "TPZCompElH1.h"
 
 #include "pzshapecube.h"
 #include "pzshapelinear.h"
@@ -71,7 +72,7 @@ TPZCompEl *CreateNoElement(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 TPZCompEl *CreatePointEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
     {
-		return new TPZIntelGen<TPZShapePoint>(mesh,gel,index);
+		return new TPZCompElH1<TPZShapePoint>(mesh,gel,index);
     }
     index = -1;
 	return NULL;
@@ -79,7 +80,7 @@ TPZCompEl *CreatePointEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 TPZCompEl *CreateLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
     {
-		TPZCompEl *result = new TPZIntelGen<TPZShapeLinear>(mesh,gel,index);
+		TPZCompEl *result = new TPZCompElH1<TPZShapeLinear>(mesh,gel,index);
         return result;//new TPZCondensedCompel(result);
     }
     index = -1;
@@ -88,7 +89,7 @@ TPZCompEl *CreateLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 TPZCompEl *CreateQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
     {
-		return new TPZIntelGen<TPZShapeQuad>(mesh,gel,index);
+		return new TPZCompElH1<TPZShapeQuad>(mesh,gel,index);
     }
     index = -1;
 	return NULL;
@@ -96,31 +97,31 @@ TPZCompEl *CreateQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 
 TPZCompEl *CreateTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZIntelGen<TPZShapeTriang>(mesh,gel,index);
+		return new TPZCompElH1<TPZShapeTriang>(mesh,gel,index);
     index = -1;
 	return NULL;
 }
 TPZCompEl *CreateCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZIntelGen<TPZShapeCube>(mesh,gel,index);
+		return new TPZCompElH1<TPZShapeCube>(mesh,gel,index);
     index = -1;
 	return NULL;
 }
 TPZCompEl *CreatePrismEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZIntelGen<TPZShapePrism>(mesh,gel,index);
+		return new TPZCompElH1<TPZShapePrism>(mesh,gel,index);
     index = -1;
 	return NULL;
 }
 TPZCompEl *CreatePyramEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZIntelGen<TPZShapePiram>(mesh,gel,index);
+		return new TPZCompElH1<TPZShapePiram>(mesh,gel,index);
     index = -1;
 	return NULL;
 }
 TPZCompEl *CreateTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZIntelGen<TPZShapeTetra>(mesh,gel,index);
+		return new TPZCompElH1<TPZShapeTetra>(mesh,gel,index);
     index = -1;
 	return NULL;
 }
@@ -129,49 +130,49 @@ TPZCompEl *CreateTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 // with mem
 TPZCompEl *CreatePointElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem <TPZIntelGen<TPZShapePoint> >(mesh,gel,index) ;
+		return new TPZCompElWithMem <TPZCompElH1<TPZShapePoint> >(mesh,gel,index) ;
     index = -1;
 	return NULL;
 }
 TPZCompEl *CreateLinearElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem <TPZIntelGen<TPZShapeLinear> >(mesh,gel,index);
+		return new TPZCompElWithMem <TPZCompElH1<TPZShapeLinear> >(mesh,gel,index);
     index = -1;
 	return NULL;
 }
 TPZCompEl *CreateQuadElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem <TPZIntelGen<TPZShapeQuad> >(mesh,gel,index);
+		return new TPZCompElWithMem <TPZCompElH1<TPZShapeQuad> >(mesh,gel,index);
     index = -1;
 	return NULL;
 }
 TPZCompEl *CreateTriangleElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem < TPZIntelGen<TPZShapeTriang> >(mesh,gel,index);
+		return new TPZCompElWithMem < TPZCompElH1<TPZShapeTriang> >(mesh,gel,index);
     index = -1;
 	return NULL;
 }
 TPZCompEl *CreateCubeElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem <TPZIntelGen<TPZShapeCube> >(mesh,gel,index);
+		return new TPZCompElWithMem <TPZCompElH1<TPZShapeCube> >(mesh,gel,index);
     index = -1;
 	return NULL;
 }
 TPZCompEl *CreatePrismElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem <TPZIntelGen<TPZShapePrism> >(mesh,gel,index);
+		return new TPZCompElWithMem <TPZCompElH1<TPZShapePrism> >(mesh,gel,index);
     index = -1;
 	return NULL;
 }
 TPZCompEl *CreatePyramElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem <TPZIntelGen<TPZShapePiram> >(mesh,gel,index);
+		return new TPZCompElWithMem <TPZCompElH1<TPZShapePiram> >(mesh,gel,index);
     index = -1;
 	return NULL;
 }
 TPZCompEl *CreateTetraElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem <TPZIntelGen<TPZShapeTetra> >(mesh,gel,index);
+		return new TPZCompElWithMem <TPZCompElH1<TPZShapeTetra> >(mesh,gel,index);
     index = -1;
 	return NULL;
 }

--- a/Mesh/pzelchdiv.cpp
+++ b/Mesh/pzelchdiv.cpp
@@ -36,7 +36,7 @@ TPZRegisterClassId(&TPZCompElHDiv::ClassId),
 TPZIntelGen<TSHAPE>(mesh,gel,index,1), fSideOrient(TSHAPE::NFacets,1) {
 	this->TPZInterpolationSpace::fPreferredOrder = mesh.GetDefaultOrder();
 	int nconflux= TPZCompElHDiv::NConnects();
-    this->fConnectIndexes.Resize(nconflux);
+  this->fConnectIndexes.Resize(nconflux);
 	gel->SetReference(this);
 
 //    int nfaces = TSHAPE::NumSides(TSHAPE::Dimension-1);
@@ -1540,6 +1540,7 @@ template<class TSHAPE>
 void TPZCompElHDiv<TSHAPE>::Write(TPZStream &buf, int withclassid) const
 {
 	TPZInterpolatedElement::Write(buf,withclassid);
+  buf.Write(fConnectIndexes.begin(),TSHAPE::NSides);
 	TPZManVector<int,3> order(3,0);
 	this->fIntRule.GetOrder(order);
 	buf.Write(order);
@@ -1563,6 +1564,7 @@ template<class TSHAPE>
 void TPZCompElHDiv<TSHAPE>::Read(TPZStream &buf, void *context)
 {
 	TPZInterpolatedElement::Read(buf,context);
+  buf.Read(fConnectIndexes.begin(),TSHAPE::NSides);
 	TPZManVector<int,3> order;
 	buf.Read(order);
 	this-> fIntRule.SetOrder(order);

--- a/Mesh/pzelchdiv.h
+++ b/Mesh/pzelchdiv.h
@@ -28,6 +28,9 @@ class TPZCompElHDiv : public TPZIntelGen<TSHAPE> {
     std::list<TPZOneShapeRestraint> fRestraints;
 
 protected:
+  ///! Indexes of the connects associated with the elements
+  TPZManVector<int64_t,TSHAPE::NFacets+1> fConnectIndexes =
+    TPZManVector<int64_t,TSHAPE::NFacets+1>(TSHAPE::NFacets+1,-1);
     /** @brief To append vectors */
 	void Append(TPZFMatrix<REAL> &u1, TPZFMatrix<REAL> &u2, TPZFMatrix<REAL> &u12);
 
@@ -79,6 +82,11 @@ public:
 	virtual int NConnects() const override;
 	
 	virtual void SetConnectIndex(int i, int64_t connectindex) override;
+
+  //! Reference to the connect vector
+  inline const TPZVec<int64_t> & ConnectVec() const override{
+    return fConnectIndexes;
+  }
 	
     /// return the first one dof restraint
     int RestrainedFace();

--- a/Mesh/pzelchdivbound2.cpp
+++ b/Mesh/pzelchdivbound2.cpp
@@ -26,38 +26,37 @@ TPZIntelGen<TSHAPE>(mesh,gel,index,1), fSideOrient(1){
 	//int i;
 	this->TPZInterpolationSpace::fPreferredOrder = mesh.GetDefaultOrder();
 	//for(i=0; i<TSHAPE::NSides; i++) this->fConnectIndexes[i]=-1;
-		this->fConnectIndexes[0]=-1;
-	gel->SetReference(this);
-    TPZIntelGen<TSHAPE>::fConnectIndexes.resize(1);
+  this->fConnectIndexes[0]=-1;
+  gel->SetReference(this);
 		
-    this->fConnectIndexes[0] = this->CreateMidSideConnect(TSHAPE::NSides-1);
+  this->fConnectIndexes[0] = this->CreateMidSideConnect(TSHAPE::NSides-1);
 #ifdef PZ_LOG
-    if (logger.isDebugEnabled())
+  if (logger.isDebugEnabled())
 		{
-				std::stringstream sout;
-				sout << "After creating boundary flux connect " << this->fConnectIndexes[0] << std::endl;
-				//	this->Print(sout);
-				LOGPZ_DEBUG(logger,sout.str())
-		}
+      std::stringstream sout;
+      sout << "After creating boundary flux connect " << this->fConnectIndexes[0] << std::endl;
+      //	this->Print(sout);
+      LOGPZ_DEBUG(logger,sout.str())
+        }
 #endif
     
-    mesh.ConnectVec()[this->fConnectIndexes[0]].IncrementElConnected();
+  mesh.ConnectVec()[this->fConnectIndexes[0]].IncrementElConnected();
     
 		
 	
 #ifdef PZ_LOG
-    if (logger.isDebugEnabled())
-	{
-		std::stringstream sout;
+  if (logger.isDebugEnabled())
+    {
+      std::stringstream sout;
 		
-		sout << std::endl<<" Criando Connects: "<< std::endl;
-		for(int j=0; j< NConnects();j++)
-		{
-			sout<<" "<< this->fConnectIndexes[j];
+      sout << std::endl<<" Criando Connects: "<< std::endl;
+      for(int j=0; j< NConnects();j++)
+        {
+          sout<<" "<< this->fConnectIndexes[j];
 			
-		}
-		LOGPZ_DEBUG(logger,sout.str())
-	}
+        }
+      LOGPZ_DEBUG(logger,sout.str())
+        }
 #endif
 	int sideorder = EffectiveSideOrder(TSHAPE::NSides-1);
 	sideorder = 2*sideorder;
@@ -68,13 +67,13 @@ TPZIntelGen<TSHAPE>(mesh,gel,index,1), fSideOrient(1){
 	this->fIntRule.SetOrder(order);
 
 #ifdef PZ_LOG
-    if (logger.isDebugEnabled())
-	 {
-         std::stringstream sout;
-         sout << "Finalizando criacao do elemento ";
-         this->Print(sout);
-         LOGPZ_DEBUG(logger,sout.str())
-	 }
+  if (logger.isDebugEnabled())
+    {
+      std::stringstream sout;
+      sout << "Finalizando criacao do elemento ";
+      this->Print(sout);
+      LOGPZ_DEBUG(logger,sout.str())
+        }
 #endif
 	 
 }
@@ -588,7 +587,8 @@ template<class TSHAPE>
 void TPZCompElHDivBound2<TSHAPE>::Read(TPZStream &buf, void *context)
 {
 	TPZIntelGen<TSHAPE>::Read(buf,context);
-    buf.Read(&fSideOrient);
+  buf.Read(&fSideOrient);
+  buf.Read(fConnectIndexes.begin(),TSHAPE::NSides);
 }
 
 /** Save the element data to a stream */
@@ -596,7 +596,8 @@ template<class TSHAPE>
 void TPZCompElHDivBound2<TSHAPE>::Write(TPZStream &buf, int withclassid) const
 {
 	TPZIntelGen<TSHAPE>::Write(buf,withclassid);
-    buf.Write(&fSideOrient);
+  buf.Write(&fSideOrient);
+  buf.Write(fConnectIndexes.begin(),TSHAPE::NSides);
 }
 
 /** @brief Prints the relevant data of the element to the output stream */

--- a/Mesh/pzelchdivbound2.h
+++ b/Mesh/pzelchdivbound2.h
@@ -21,12 +21,15 @@
  */
 template<class TSHAPE>
 class TPZCompElHDivBound2 : public TPZIntelGen<TSHAPE> {
-    
-    int fSideOrient;
+  int fSideOrient;
 	
 	/** @brief Method to append vectors */
 	void Append(TPZFMatrix<REAL> &u1, TPZFMatrix<REAL> &u2, TPZFMatrix<REAL> &u12);
-    
+
+protected:
+  ///! Indexes of the connects associated with the elements
+  TPZManVector<int64_t,1> fConnectIndexes =
+    TPZManVector<int64_t,1>(1,-1);
 public:
 	
 	TPZCompElHDivBound2(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
@@ -73,7 +76,11 @@ public:
 	virtual void SetConnectIndex(int i, int64_t connectindex) override;
 	
 	virtual int NConnectShapeF(int connect, int order) const override;
-	
+
+  inline const TPZVec<int64_t> & ConnectVec() const override{
+    return fConnectIndexes;
+  }
+  
 	virtual int Dimension() const  override {
 		return TSHAPE::Dimension;
 	}

--- a/Mesh/pzelctemp.cpp
+++ b/Mesh/pzelctemp.cpp
@@ -10,43 +10,53 @@
 #include "pzlog.h"
 #include "pzcmesh.h"
 
+#include "TPZMatSingleSpace.h"
+
 #ifdef PZ_LOG
 static TPZLogger logger("pz.mesh.tpzintelgen");
 #endif
 
 template<class TSHAPE>
 TPZIntelGen<TSHAPE>::TPZIntelGen(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) : TPZRegisterClassId(&TPZIntelGen::ClassId),
-TPZInterpolatedElement(mesh,gel,index), fConnectIndexes(TSHAPE::NSides,-1) {
+TPZInterpolatedElement(mesh,gel,index){
 
-	for(int i=0; i<TSHAPE::NSides; i++) fConnectIndexes[i]=-1;
 	//  RemoveSideRestraintsII(EInsert);
 	gel->SetReference(this);
-    int matid = gel->MaterialId();
+  int matid = gel->MaterialId();
 #ifdef PZDEBUG
-    if (mesh.FindMaterial(matid) == 0) {
-        DebugStop();
-    }
+  if (mesh.FindMaterial(matid) == 0) {
+    DebugStop();
+  }
 #endif
-	for(int i=0;i<TSHAPE::NSides;i++) {
-		fConnectIndexes[i] = CreateMidSideConnect(i);
-		mesh.ConnectVec()[fConnectIndexes[i]].IncrementElConnected();
-	}
-	
-    AdjustIntegrationRule();
+  //TODO: NATHANFRAN ASKPHIL
 
-	
+
+  
+  // AdjustIntegrationRule();
+	int order = fPreferredOrder;
+  int integrationruleorder = 0;
+  auto *mat =
+    dynamic_cast<TPZMatSingleSpace*>(this->Material());
+
+  if (mat) {
+    integrationruleorder = mat->IntegrationRuleOrder(order);
+  }else
+    {
+      integrationruleorder = order + order;
+    }
+  SetIntegrationRule(integrationruleorder);
 }
 
 template<class TSHAPE>
 TPZIntelGen<TSHAPE>::TPZIntelGen(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index, int nocreate) : TPZRegisterClassId(&TPZIntelGen::ClassId),
-TPZInterpolatedElement(mesh,gel,index),fConnectIndexes(TSHAPE::NSides,-1)
+TPZInterpolatedElement(mesh,gel,index)
 {
 	fPreferredOrder = -1;
 }
 
 template<class TSHAPE>
 TPZIntelGen<TSHAPE>::TPZIntelGen(TPZCompMesh &mesh, const TPZIntelGen<TSHAPE> &copy) : TPZRegisterClassId(&TPZIntelGen::ClassId),
-TPZInterpolatedElement(mesh,copy), fConnectIndexes(copy.fConnectIndexes),fIntRule(copy.fIntRule) {
+TPZInterpolatedElement(mesh,copy), fIntRule(copy.fIntRule) {
 	fPreferredOrder = copy.fPreferredOrder;
 }
 
@@ -57,60 +67,37 @@ TPZIntelGen<TSHAPE>::TPZIntelGen(TPZCompMesh &mesh,
 								 std::map<int64_t,int64_t> & gl2lcConMap,
 								 std::map<int64_t,int64_t> & gl2lcElMap) :
 TPZRegisterClassId(&TPZIntelGen::ClassId), 
-TPZInterpolatedElement(mesh,copy,gl2lcElMap), fConnectIndexes(TSHAPE::NSides,-1), fIntRule(copy.fIntRule)
+TPZInterpolatedElement(mesh,copy,gl2lcElMap), fIntRule(copy.fIntRule)
 {
 	
 	fPreferredOrder = copy.fPreferredOrder;
 	int i;
-	for(i=0;i<TSHAPE::NSides;i++)
-	{
-		int64_t lcIdx = -1;
-		int64_t glIdx = copy.fConnectIndexes[i];
-		if (gl2lcConMap.find(glIdx) != gl2lcConMap.end()) lcIdx = gl2lcConMap[glIdx];
-		else
-		{
-			std::stringstream sout;
-			sout << "ERROR in : " << __PRETTY_FUNCTION__
-			<< " trying to clone the connect index: " << glIdx
-			<< " wich is not in mapped connect indexes!";
-			LOGPZ_ERROR(logger, sout.str().c_str());
-			fConnectIndexes[i] = -1;
-			return;
-		}
-		fConnectIndexes[i] = lcIdx;
-	}
+	// for(i=0;i<TSHAPE::NSides;i++)
+	// {
+	// 	int64_t lcIdx = -1;
+	// 	int64_t glIdx = copy.fConnectIndexes[i];
+	// 	if (gl2lcConMap.find(glIdx) != gl2lcConMap.end()) lcIdx = gl2lcConMap[glIdx];
+	// 	else
+	// 	{
+	// 		std::stringstream sout;
+	// 		sout << "ERROR in : " << __PRETTY_FUNCTION__
+	// 		<< " trying to clone the connect index: " << glIdx
+	// 		<< " wich is not in mapped connect indexes!";
+	// 		LOGPZ_ERROR(logger, sout.str().c_str());
+	// 		fConnectIndexes[i] = -1;
+	// 		return;
+	// 	}
+	// 	fConnectIndexes[i] = lcIdx;
+	// }
+  //TODO:NATHANFRAN
 }
 
 
 template<class TSHAPE>
 TPZIntelGen<TSHAPE>::TPZIntelGen() :
 TPZRegisterClassId(&TPZIntelGen::ClassId), 
-TPZInterpolatedElement(), fConnectIndexes(TSHAPE::NSides,-1), fIntRule() {
+TPZInterpolatedElement(), fIntRule() {
 	fPreferredOrder = -1;
-	int i;
-	for(i=0;i<TSHAPE::NSides;i++) {
-		fConnectIndexes[i] = -1;
-	}
-}
-
-template<class TSHAPE>
-TPZIntelGen<TSHAPE>::~TPZIntelGen() {
-    TPZGeoEl *gel = Reference();
-    if (gel) {
-        TPZCompEl *cel = gel->Reference();
-        if (cel == this) {
-            RemoveSideRestraintsII(EDelete);
-        }
-        Reference()->ResetReference();
-    }
-    TPZStack<int64_t > connectlist;
-    BuildConnectList(connectlist);
-    int64_t nconnects = connectlist.size();
-    for (int ic = 0; ic < nconnects; ic++) {
-        if (connectlist[ic] != -1){
-            fMesh->ConnectVec()[connectlist[ic]].DecrementElConnected();
-        }
-    }
 }
 
 template<class TSHAPE>
@@ -118,48 +105,11 @@ MElementType TPZIntelGen<TSHAPE>::Type() {
 	return TSHAPE::Type();
 }
 
-template<class TSHAPE>
-void TPZIntelGen<TSHAPE>::SetConnectIndex(int i, int64_t connectindex){
-#ifndef PZNODEBUG
-	if(i<0 || i>= TSHAPE::NSides) {
-		std::cout << " TPZIntelGen<TSHAPE>::SetConnectIndex index " << i <<
-		" out of range\n";
-		return;
-	}
-#endif
-	fConnectIndexes[i] = connectindex;
-}
-
-template<class TSHAPE>
-int TPZIntelGen<TSHAPE>::NConnectShapeF(int connect, int order) const{
-    
-    if(connect < TSHAPE::NCornerNodes) return TSHAPE::NConnectShapeF(connect,0);
-	if(order < 0) return 0;
-    int nshape = TSHAPE::NConnectShapeF(connect, order);
-#ifdef PZDEBUG
-    if(nshape < 0 )
-    {
-        nshape = TSHAPE::NConnectShapeF(connect, order);
-        DebugStop();
-    }
-#endif
-	return nshape;
-}
 
 template<class TSHAPE>
 void TPZIntelGen<TSHAPE>::SetIntegrationRule(int ord) {
 	TPZManVector<int,3> order(TSHAPE::Dimension,ord);
 	fIntRule.SetOrder(order);
-}
-
-template<class TSHAPE>
-int TPZIntelGen<TSHAPE>::NSideConnects(int side) const {
-	return TSHAPE::NContainedSides(side);
-}
-
-template<class TSHAPE>
-int TPZIntelGen<TSHAPE>::SideConnectLocId(int node, int side) const {
-	return TSHAPE::ContainedSideLocId(side,node);
 }
 
 /**Sets the interpolation order for the interior of the element*/
@@ -168,16 +118,7 @@ void TPZIntelGen<TSHAPE>::SetInterpolationOrder(int order) {
 	fPreferredOrder = order;
 }
 
-/**Identifies the interpolation order on the interior of the element*/
-template<class TSHAPE>
-void TPZIntelGen<TSHAPE>::GetInterpolationOrder(TPZVec<int> &ord) {
-	ord.Resize(TSHAPE::NSides-TSHAPE::NCornerNodes);
-	int i;
-	for(i=0; i<TSHAPE::NSides-TSHAPE::NCornerNodes; i++) {
-		ord[i] = Connect(i+TSHAPE::NCornerNodes).Order();
-	}
-}
-
+//TODO:NATHANFRAN ASKPHIL
 /**return the preferred order of the polynomial along side iside*/
 template<class TSHAPE>
 int TPZIntelGen<TSHAPE>::PreferredSideOrder(int side) {
@@ -202,7 +143,8 @@ int64_t TPZIntelGen<TSHAPE>::ConnectIndex(int con) const{
 	}
 	
 #endif
-	return fConnectIndexes[con];
+
+	return this->ConnectVec()[con];
 }
 
 
@@ -217,125 +159,11 @@ void TPZIntelGen<TSHAPE>::SetPreferredOrder(int order)
 	fPreferredOrder = order;
 }
 
-/**sets the interpolation order of side to order*/
-template<class TSHAPE>
-void TPZIntelGen<TSHAPE>::SetSideOrder(int side, int order) {
-	if(side<0 || side >= TSHAPE::NSides || (side >= TSHAPE::NCornerNodes && order <1)) {
-		PZError << "TPZIntelGen::SetSideOrder. Bad paramenter side " << side << " order " << order << std::endl;
-		DebugStop();
-#ifdef PZ_LOG
-		std::stringstream sout;
-		sout << __PRETTY_FUNCTION__ << " Bad side or order " << side << " order " << order;
-		LOGPZ_ERROR(logger,sout.str())
-#endif
-		return;
-	}
-	if(side>= TSHAPE::NCornerNodes) {
-		if(fConnectIndexes[side] == -1) return;
-        int prevorder = fPreferredOrder;
-        if (ConnectIndex(TSHAPE::NSides-1) != -1) {
-            prevorder = EffectiveSideOrder(TSHAPE::NSides-1);
-        }
-		TPZConnect &c = Connect(side);
-        int previousconnectorder = c.Order();
-        if (order != previousconnectorder)
-        {
-            c.SetOrder(order,ConnectIndex(side));
-            int64_t seqnum = c.SequenceNumber();
-            int nvar = 1;
-            TPZMaterial * mat = Material();
-            if(mat) nvar = mat->NStateVariables();
-            int nshape = TSHAPE::NConnectShapeF(side, order);
-            c.SetNShape(nshape);
-            c.SetNState(nvar);
-            Mesh()->Block().Set(seqnum,nshape*nvar);
-            TPZGeoElSide gelside(Reference(),side);
-            TPZStack<TPZCompElSide> equal;
-            gelside.EqualLevelCompElementList(equal, 1, 0);
-            int64_t neq = equal.size();
-            for (int64_t eq=0; eq<neq; eq++) {
-                TPZInterpolatedElement *intel = dynamic_cast<TPZInterpolatedElement*>(equal[eq].Element());
-                intel->AdjustIntegrationRule();
-            }
-        }
-        
-        int neworder = prevorder;
-        if (ConnectIndex(TSHAPE::NSides-1) != -1) {
-            neworder = EffectiveSideOrder(TSHAPE::NSides-1);
-        }
-		if(neworder != prevorder) {
-            AdjustIntegrationRule();
-		}
-	}
-}
 
-/**returns the actual interpolation order of the polynomial along the side*/
-template<class TSHAPE>
-int TPZIntelGen<TSHAPE>::EffectiveSideOrder(int side) const {
-	if(side < TSHAPE::NCornerNodes || side >= TSHAPE::NSides) return 0;
-	if(fConnectIndexes[side] == -1)
-	{
-		std::stringstream sout ;
-		sout << __PRETTY_FUNCTION__ << " side " << side << std::endl;
-		//Print(sout);
-#ifdef PZ_LOG
-		LOGPZ_ERROR(logger,sout.str());
-#else
-		std::cout << sout.str() << std::endl;
-#endif
-		DebugStop();
-		return -1;
-	}
-    TPZStack<int> lowdim;
-    Reference()->LowerDimensionSides(side,lowdim);
-	TPZConnect &c = Connect(side);
-	int order = c.Order();
-    for (int is=0; is<lowdim.size(); is++) {
-        TPZConnect &c = MidSideConnect(lowdim[is]);
-        if(c.Order() > order) order = c.Order();
-    }
-    return order;
-}
 /**returns the actual interpolation order of the polynomial for a connect*/
 template<class TSHAPE>
 int TPZIntelGen<TSHAPE>::ConnectOrder(int connect) const {
 	return Connect(connect).Order();
-}
-
-/**compute the values of the shape function of the side*/
-template<class TSHAPE>
-void TPZIntelGen<TSHAPE>::SideShapeFunction(int side,TPZVec<REAL> &point,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi) {
-	
-	int nc = TSHAPE::NContainedSides(side);
-	int nn = TSHAPE::NSideNodes(side);
-	TPZManVector<int64_t,27> id(nn);
-	TPZManVector<int,27> order(nc-nn);
-	int n,c;
-	TPZGeoEl *ref = Reference();
-	for (n=0;n<nn;n++){
-		int nodloc = TSHAPE::SideNodeLocId(side,n);
-		id [n] = ref->NodePtr(nodloc)->Id();
-	}
-	for (c=nn;c<nc;c++){
-		int conloc = TSHAPE::ContainedSideLocId(side,c);
-        order[c-nn] = Connect(conloc).Order();
-	}
-	TSHAPE::SideShape(side, point, id, order, phi, dphi);
-}
-
-template<class TSHAPE>
-void TPZIntelGen<TSHAPE>::Shape(TPZVec<REAL> &pt, TPZFMatrix<REAL> &phi, TPZFMatrix<REAL> &dphi) {
-	TPZManVector<int64_t,TSHAPE::NCornerNodes> id(TSHAPE::NCornerNodes,0);
-	TPZManVector<int, TSHAPE::NSides-TSHAPE::NCornerNodes+1> ord(TSHAPE::NSides-TSHAPE::NCornerNodes,0);
-	int i;
-	TPZGeoEl *ref = Reference();
-	for(i=0; i<TSHAPE::NCornerNodes; i++) {
-		id[i] = ref->NodePtr(i)->Id();
-	}
-	for(i=0; i<TSHAPE::NSides-TSHAPE::NCornerNodes; i++) {
-		ord[i] = Connect(i+TSHAPE::NCornerNodes).Order();
-	}
-	TSHAPE::Shape(pt,id,ord,phi,dphi);
 }
 
 /** Returns the transformation which transform a point from the side to the interior of the element */
@@ -352,7 +180,6 @@ void TPZIntelGen<TSHAPE>::Write(TPZStream &buf, int withclassid) const
 	TPZManVector<int,3> order(3,0);
 	fIntRule.GetOrder(order);
 	buf.Write(order);
-	buf.Write(fConnectIndexes.begin(),TSHAPE::NSides);
 	buf.Write(&fPreferredOrder,1);
 	int classid = this->ClassId();
 	buf.Write ( &classid, 1 );
@@ -366,7 +193,6 @@ void TPZIntelGen<TSHAPE>::Read(TPZStream &buf, void *context)
 	TPZManVector<int,3> order;
 	buf.Read(order);
 	fIntRule.SetOrder(order);
-	buf.Read(fConnectIndexes.begin(),TSHAPE::NSides);
 	buf.Read(&fPreferredOrder,1);
 	int classid = -1;
 	buf.Read( &classid, 1 );
@@ -401,18 +227,6 @@ void TPZIntelGen<TSHAPE>::CreateGraphicalElement(TPZGraphMesh &grafgrid, int dim
 		new typename TSHAPE::GraphElType(this,&grafgrid);
 	}
 }
-
-#ifndef BORLAND
-template class TPZRestoreClass< TPZIntelGen<TPZShapePoint>>;
-template class TPZRestoreClass< TPZIntelGen<TPZShapeLinear>>;
-template class TPZRestoreClass< TPZIntelGen<TPZShapeTriang>>;
-template class TPZRestoreClass< TPZIntelGen<TPZShapeQuad>>;
-template class TPZRestoreClass< TPZIntelGen<TPZShapeCube>>;
-template class TPZRestoreClass< TPZIntelGen<TPZShapeTetra>>;
-template class TPZRestoreClass< TPZIntelGen<TPZShapePrism>>;
-template class TPZRestoreClass< TPZIntelGen<TPZShapePiram>>;
-template class TPZRestoreClass< TPZIntelGen<TPZShapePiramHdiv>>;
-#endif
 
 #include "TPZRefCube.h"
 

--- a/Mesh/pzelctemp.h
+++ b/Mesh/pzelctemp.h
@@ -21,9 +21,6 @@ class TPZIntelGen : public TPZInterpolatedElement {
 	
 protected:
 	
-    /// Indexes of the connects associated with the elements
-    TPZManVector<int64_t,TSHAPE::NSides> fConnectIndexes;
-	
     /// Integration rule associated with the topology of the element
 	typename TSHAPE::IntruleType fIntRule;
 	
@@ -43,11 +40,9 @@ public:
 	
 	TPZIntelGen();
 	
-	virtual ~TPZIntelGen();
+	~TPZIntelGen() = default;
 	
-	virtual TPZCompEl *Clone(TPZCompMesh &mesh) const override {
-		return new TPZIntelGen<TSHAPE> (mesh, *this);
-	}
+	virtual TPZCompEl *Clone(TPZCompMesh &mesh) const override = 0;
 	
 	/**
 	 * @brief Create a copy of the given element. The clone copy have the connect indexes
@@ -56,21 +51,20 @@ public:
 	 * @param gl2lcConMap map the connects indexes from global element (original) to the local copy.
 	 * @param gl2lcElMap map the indexes of the elements between the original element and the patch element
 	 */
-	virtual TPZCompEl *ClonePatchEl(TPZCompMesh &mesh,std::map<int64_t,int64_t> & gl2lcConMap,std::map<int64_t,int64_t>&gl2lcElMap) const override
-	{
-		return new TPZIntelGen<TSHAPE> (mesh, *this, gl2lcConMap, gl2lcElMap);
-	}
+	virtual TPZCompEl *ClonePatchEl(TPZCompMesh &mesh,std::map<int64_t,int64_t> & gl2lcConMap,std::map<int64_t,int64_t>&gl2lcElMap) const override = 0;
 	
 	
 	virtual MElementType Type() override;
+
+
+  //! Reference to the connect vector
+  virtual const TPZVec<int64_t> & ConnectVec() const = 0;
+  
+	virtual int NConnects() const override = 0;
 	
-	virtual int NConnects() const override{
-		return fConnectIndexes.size();
-	}
+	void SetConnectIndex(int i, int64_t connectindex) override = 0;
 	
-	virtual void SetConnectIndex(int i, int64_t connectindex) override;
-	
-	virtual int NConnectShapeF(int connect, int order) const override;
+	int NConnectShapeF(int connect, int order) const override = 0;
 	
 	virtual int Dimension() const override {
 		return TSHAPE::Dimension;
@@ -80,9 +74,9 @@ public:
 		return TSHAPE::NCornerNodes;
 	}
 	
-	virtual int NSideConnects(int side) const override;
+	virtual int NSideConnects(int side) const override = 0;
 	
-	virtual int SideConnectLocId(int node, int side) const override;
+	virtual int SideConnectLocId(int node, int side) const override = 0;
 	
 	virtual int64_t ConnectIndex(int node) const  override;
     
@@ -92,7 +86,7 @@ public:
 	virtual void SetInterpolationOrder(int order);
 	
 	/** @brief Identifies the interpolation order on the interior of the element*/
-	virtual void GetInterpolationOrder(TPZVec<int> &ord) override;
+	virtual void GetInterpolationOrder(TPZVec<int> &ord) override = 0;
 	
 	/** @brief Returns the preferred order of the polynomial along side iside*/
 	virtual int PreferredSideOrder(int iside) override;
@@ -103,17 +97,17 @@ public:
 	virtual void SetPreferredOrder(int order) override;
 	
 	/** @brief Sets the interpolation order of side to order*/
-	virtual void SetSideOrder(int side, int order) override;
+	void SetSideOrder(int side, int order) override = 0;
 	
 	/** @brief Returns the actual interpolation order of the polynomial along the side*/
-    virtual int EffectiveSideOrder(int side) const override;
+   int EffectiveSideOrder(int side) const override = 0;
 	/** @brief Returns the actual interpolation order of the polynomial for a connect*/
 	virtual int ConnectOrder(int connect) const;
 
 	/** @brief Compute the values of the shape function of the side*/
-	virtual void SideShapeFunction(int side,TPZVec<REAL> &point,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi) override;
+	virtual void SideShapeFunction(int side,TPZVec<REAL> &point,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi) override = 0;
 	
-	void Shape(TPZVec<REAL> &pt, TPZFMatrix<REAL> &phi, TPZFMatrix<REAL> &dphi) override;
+	void Shape(TPZVec<REAL> &pt, TPZFMatrix<REAL> &phi, TPZFMatrix<REAL> &dphi) override = 0;
 	
 	void CreateGraphicalElement(TPZGraphMesh &grafgrid, int dimension) override;
 	

--- a/Post/pzpostprocanalysis.cpp
+++ b/Post/pzpostprocanalysis.cpp
@@ -374,66 +374,69 @@ void TPZPostProcAnalysis::SetAllCreateFunctionsPostProc(TPZCompMesh *cmesh)
     cmesh->ApproxSpace().SetCreateFunctions(functions);
 }
 
+
+#include "TPZCompElH1.h"
+
 using namespace pzshape;
 
-template class TPZCompElPostProc< TPZIntelGen<TPZShapePoint> >;
-template class TPZCompElPostProc< TPZIntelGen<TPZShapeLinear> >;
-template class TPZCompElPostProc< TPZIntelGen<TPZShapeQuad> >;
-template class TPZCompElPostProc< TPZIntelGen<TPZShapeTriang> >;
-template class TPZCompElPostProc< TPZIntelGen<TPZShapeCube> >;
-template class TPZCompElPostProc< TPZIntelGen<TPZShapePrism> >;
-template class TPZCompElPostProc< TPZIntelGen<TPZShapePiram> >;
-template class TPZCompElPostProc< TPZIntelGen<TPZShapeTetra> >;
+template class TPZCompElPostProc< TPZCompElH1<TPZShapePoint> >;
+template class TPZCompElPostProc< TPZCompElH1<TPZShapeLinear> >;
+template class TPZCompElPostProc< TPZCompElH1<TPZShapeQuad> >;
+template class TPZCompElPostProc< TPZCompElH1<TPZShapeTriang> >;
+template class TPZCompElPostProc< TPZCompElH1<TPZShapeCube> >;
+template class TPZCompElPostProc< TPZCompElH1<TPZShapePrism> >;
+template class TPZCompElPostProc< TPZCompElH1<TPZShapePiram> >;
+template class TPZCompElPostProc< TPZCompElH1<TPZShapeTetra> >;
 template class TPZCompElPostProc< TPZCompElDisc >;
 
-template class TPZRestoreClass<TPZCompElPostProc< TPZIntelGen<TPZShapePoint> >>;
-template class TPZRestoreClass<TPZCompElPostProc< TPZIntelGen<TPZShapeLinear> >>;
-template class TPZRestoreClass<TPZCompElPostProc< TPZIntelGen<TPZShapeQuad> >>;
-template class TPZRestoreClass<TPZCompElPostProc< TPZIntelGen<TPZShapeTriang> >>;
-template class TPZRestoreClass<TPZCompElPostProc< TPZIntelGen<TPZShapeCube> >>;
-template class TPZRestoreClass<TPZCompElPostProc< TPZIntelGen<TPZShapePrism> >>;
-template class TPZRestoreClass<TPZCompElPostProc< TPZIntelGen<TPZShapePiram> >>;
-template class TPZRestoreClass<TPZCompElPostProc< TPZIntelGen<TPZShapeTetra> >>;
+template class TPZRestoreClass<TPZCompElPostProc< TPZCompElH1<TPZShapePoint> >>;
+template class TPZRestoreClass<TPZCompElPostProc< TPZCompElH1<TPZShapeLinear> >>;
+template class TPZRestoreClass<TPZCompElPostProc< TPZCompElH1<TPZShapeQuad> >>;
+template class TPZRestoreClass<TPZCompElPostProc< TPZCompElH1<TPZShapeTriang> >>;
+template class TPZRestoreClass<TPZCompElPostProc< TPZCompElH1<TPZShapeCube> >>;
+template class TPZRestoreClass<TPZCompElPostProc< TPZCompElH1<TPZShapePrism> >>;
+template class TPZRestoreClass<TPZCompElPostProc< TPZCompElH1<TPZShapePiram> >>;
+template class TPZRestoreClass<TPZCompElPostProc< TPZCompElH1<TPZShapeTetra> >>;
 template class TPZRestoreClass<TPZCompElPostProc< TPZCompElDisc >>;
 
 TPZCompEl *TPZPostProcAnalysis::CreatePointEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc< TPZIntelGen<TPZShapePoint> >(mesh,gel,index);
+		return new TPZCompElPostProc< TPZCompElH1<TPZShapePoint> >(mesh,gel,index);
 	return NULL;
 }
 TPZCompEl *TPZPostProcAnalysis::CreateLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc<TPZIntelGen<TPZShapeLinear> >(mesh,gel,index);
+		return new TPZCompElPostProc<TPZCompElH1<TPZShapeLinear> >(mesh,gel,index);
 	return NULL;
 }
 TPZCompEl *TPZPostProcAnalysis::CreateQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc<TPZIntelGen<TPZShapeQuad> >(mesh,gel,index);
+		return new TPZCompElPostProc<TPZCompElH1<TPZShapeQuad> >(mesh,gel,index);
 	return NULL;
 }
 TPZCompEl *TPZPostProcAnalysis::CreateTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc<TPZIntelGen<TPZShapeTriang> >(mesh,gel,index);
+		return new TPZCompElPostProc<TPZCompElH1<TPZShapeTriang> >(mesh,gel,index);
 	return NULL;
 }
 TPZCompEl *TPZPostProcAnalysis::CreateCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc<TPZIntelGen<TPZShapeCube> >(mesh,gel,index);
+		return new TPZCompElPostProc<TPZCompElH1<TPZShapeCube> >(mesh,gel,index);
 	return NULL;
 }
 TPZCompEl *TPZPostProcAnalysis::CreatePrismEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc< TPZIntelGen<TPZShapePrism> >(mesh,gel,index);
+		return new TPZCompElPostProc< TPZCompElH1<TPZShapePrism> >(mesh,gel,index);
 	return NULL;
 }
 TPZCompEl *TPZPostProcAnalysis::CreatePyramEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc<TPZIntelGen<TPZShapePiram> >(mesh,gel,index);
+		return new TPZCompElPostProc<TPZCompElH1<TPZShapePiram> >(mesh,gel,index);
 	return NULL;
 }
 TPZCompEl *TPZPostProcAnalysis::CreateTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc<TPZIntelGen<TPZShapeTetra> >(mesh,gel,index);
+		return new TPZCompElPostProc<TPZCompElH1<TPZShapeTetra> >(mesh,gel,index);
 	return NULL;
 }
 


### PR DESCRIPTION
This PR is part of an ongoing refactor with regards to the generation of the shape functions.

Previously, `TPZIntelGen<TSHAPE>` would represent the first computational element associated with a given shape, but also a H1-conforming approximation space. Now, the latter was moved to a new class `TPZCompElH1<TSHAPE>`.