### PR TITLE
TPZKrylovSolver restarting

### DIFF
--- a/UnitTest_PZ/TestEigenSolvers/TestEigenSolver.cpp
+++ b/UnitTest_PZ/TestEigenSolvers/TestEigenSolver.cpp
@@ -38,11 +38,10 @@ template<class matx, class TVar>
 void TestArnoldiIteration(bool sym);
 
 
-/**solves a dummy EVP using the arnoldi solver.
-for hermitian matrices it is ensured that 
+/**solves an EVP and ensures that
 lambda - lambda_approx <= residual norm*/
 template<class matx, class TVar>
-void TestArnoldiSolver();
+void TestArnoldiSolver(TPZAutoPointer<matx> A, const TPZFMatrix<CTVar> &sol);
 
 TEMPLATE_TEST_CASE("Arnoldi Iteration", "[eigen_tests]",
                    double)
@@ -75,21 +74,143 @@ TEMPLATE_TEST_CASE("Arnoldi Iteration", "[eigen_tests]",
 }
 
 #ifdef PZ_USING_LAPACK
-TEMPLATE_TEST_CASE("Arnoldi Solver", "[eigen_tests]",
-                   double)
+TEMPLATE_TEST_CASE("Arnoldi Solver 1", "[eigen_tests]",
+                   TPZFYsmpMatrix<double>,
+                   TPZFMatrix<double>,
+                   TPZFMatrix<std::complex<double>>
+                   )
 {
-  
-  SECTION("TPZSkylNSymMatrix")
-    {TestArnoldiSolver<TPZSkylNSymMatrix<TestType>,TestType>();}
-  SECTION("TPZSkylMatrix")
-    {TestArnoldiSolver<TPZSkylMatrix<TestType>,TestType>();}
-  SECTION("TPZFYsmpMatrix")
-    {TestArnoldiSolver<TPZFYsmpMatrix<TestType>,TestType>();}
-  SECTION("TPZSYsmpMatrix")
-    {TestArnoldiSolver<TPZSYsmpMatrix<TestType>,TestType>();}
 
+  /*
+    The following matrices are solved:
+    [ 1 1 ]
+    [ 1 1 ]
+    (real eigenpairs: 0, 2)
+    [ 1 -1 ]
+    [ 1  1 ]
+    (complex eigenpairs: 1+j, 1-j)
+
+    for complex types:
+    [ 1 i]
+    [-i 1]
+    (real eigenpairs: 2, 0)
+    [ 1 i ]
+    [ i 1 ]
+    (complex eigenpairs: 1+j, 1-j)
+*/
+  constexpr int dim{2};
+  TPZAutoPointer<TestType> basis_mat = [dim]() -> TestType *{
+    if constexpr (std::is_same_v<TPZFMatrix<double>,TestType> ||
+                  std::is_same_v<TPZFMatrix<std::complex<double>>,TestType>){
+      return new TestType(dim,dim,0);
+    }else if constexpr (std::is_same_v<TPZFYsmpMatrix<double>,TestType> ||
+                  std::is_same_v<TPZFYsmpMatrix<std::complex<double>>,TestType>){
+      //full matrix
+      auto mat = new TestType(dim,dim);
+      TPZVec<int64_t> ia(dim+1,0), ja(dim*dim,0);
+      for(int i = 0; i < dim; i++){
+        ia[i] = dim*i;
+        for(int j = 0; j < dim; j++){
+          ja[dim*i+j] = j;
+        }
+      }
+      ia[dim] = dim*dim;
+      TPZVec<typename TestType::Type> a(dim*dim,0);
+      mat->SetData(ia,ja,a);
+      return mat;
+    }else{
+      return nullptr;
+    }
+  }();
+  
+  SECTION("real_mat_real_eigenpairs"){
+    auto mat = basis_mat;
+    mat->PutVal(0,0,1);
+    mat->PutVal(1,1,1);
+    mat->PutVal(0,1,1);
+    mat->PutVal(1,0,1);
+    TPZFMatrix<CType(typename TestType::Type)> sol(dim,1);
+    sol(0,0) = 0;
+    sol(1,0) = 2;
+    if constexpr (std::is_same_v<typename TestType::Type,double>){
+      TestArnoldiSolver<TestType, double>(mat, sol);
+    }else{
+      TestArnoldiSolver<TestType, std::complex<double>>(mat, sol);
+    }
+  }
+  SECTION("real_mat_cplx_eigenpairs"){
+    using namespace std::complex_literals;
+    auto mat = basis_mat;
+    mat->PutVal(0,0,1);
+    mat->PutVal(1,1,1);
+    mat->PutVal(0,1,-1);
+    mat->PutVal(1,0,1);
+    TPZFMatrix<CType(typename TestType::Type)> sol(dim,1);
+    sol(0,0) = 1.-1i;
+    sol(1,0) = 1.+1i;
+    if constexpr (std::is_same_v<typename TestType::Type,double>){
+      TestArnoldiSolver<TestType, double>(mat,sol);
+    }else{
+      TestArnoldiSolver<TestType, std::complex<double>>(mat,sol);
+    }
+  }
+  if constexpr (std::is_same_v<typename TestType::Type,std::complex<double>>){
+    using namespace std::complex_literals;
+    SECTION("cplx_mat_real_eigenpairs"){
+      auto mat = basis_mat;
+      mat->PutVal(0,0,1);
+      mat->PutVal(1,1,1);
+      mat->PutVal(0,1,1i);
+      mat->PutVal(1,0,-1i);
+      TPZFMatrix<CType(typename TestType::Type)> sol(dim,1);
+      sol(0,0) = 2.;
+      sol(1,0) = 0.;
+      TestArnoldiSolver<TestType, std::complex<double>>(mat,sol);
+    }
+    SECTION("cplx_mat_cplx_eigenpairs"){
+      auto mat = basis_mat;
+      mat->PutVal(0,0,1);
+      mat->PutVal(1,1,1);
+      mat->PutVal(0,1,1i);
+      mat->PutVal(1,0,1i);
+      TPZFMatrix<CType(typename TestType::Type)> sol(dim,1);
+      sol(0,0) = 1.+1i;
+      sol(1,0) = 1.-1i;
+      TestArnoldiSolver<TestType, std::complex<double>>(mat,sol);
+    }
+  }
 }
+
+TEMPLATE_TEST_CASE("Arnoldi Solver 2", "[eigen_tests]",
+                   TPZSkylNSymMatrix<double>,
+                   TPZSkylMatrix<double>,
+                   TPZFYsmpMatrix<double>,
+                   TPZSYsmpMatrix<double>
+                   )
+{
+
+  TPZAutoPointer<TestType> A = new TestType;
+  constexpr int64_t dim{20};
+  constexpr int dimKrylov{20};
+  constexpr bool isSym{true};
+  A->AutoFill(dim,dim,isSym);//generates adequate storage
+  
+  for(int i = 0; i < dim; i++){
+    for(int j = 0; j < dim; j++){
+      if(!IsZero(A->GetVal(i,j))) A->PutVal(i,j,0);
+    }
+    A->PutVal(i,i,i+1);
+  }
+
+  TPZFMatrix<CType(typename TestType::Type)> sol(dim,1,0);
+  for(int i = 0; i < dim; i++){sol(i,0) = i + 1;}
+  
+  TestArnoldiSolver<TestType, typename TestType::Type>(A,sol);
+}
+
+
 #endif
+
 template<class matx, class TVar>
 void TestArnoldiIteration(bool sym)
 {
@@ -152,32 +273,28 @@ void TestArnoldiIteration(bool sym)
 }
 
 template<class matx, class TVar>
-void TestArnoldiSolver()
+void TestArnoldiSolver(TPZAutoPointer<matx> A, const TPZFMatrix<CTVar> &sol)
 {
 
   const auto oldPrecision = Catch::StringMaker<RTVar>::precision;
   Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
   
-  TPZAutoPointer<matx> A = new matx;
-  constexpr int64_t dim{20};
-  constexpr int dimKrylov{20};
-  constexpr bool isSym{true};
-  A->AutoFill(dim,dim,isSym);//generates adequate storage
   
-  for(int i = 0; i < dim; i++){
-    for(int j = 0; j < dim; j++){
-      if(!IsZero(A->GetVal(i,j))) A->PutVal(i,j,0);
-    }
-    A->PutVal(i,i,i+1);
-  }
+  const int64_t dim = A->Rows();
+  const int dimKrylov = dim;
+  
   TPZFMatrix<CTVar> cpma(dim,dim);
-  for(int i = 0; i < dim; i++)
-    cpma.PutVal(i,i,i+1);
+  for(auto i = 0; i < dim; i++){
+    for(auto j = 0; j < dim; j++){
+      cpma(i,j) = A->GetVal(i,j);
+    }
+  }
   
   TPZKrylovEigenSolver<TVar> arnoldi;
   arnoldi.SetKrylovDim(dimKrylov);
   arnoldi.SetNEigenpairs(dimKrylov);
   arnoldi.SetMatrixA(A);
+  
   TPZManVector <CTVar,10> w;
   TPZFMatrix <CTVar> eigenVectors;
   
@@ -188,13 +305,27 @@ void TestArnoldiSolver()
   TPZFMatrix<CTVar> x(dim,1);
   for(auto i = 0; i < dimKrylov; i++) std::cout<<w[i]<<std::endl;
 
-  
+  const RTVar tol = std::numeric_limits<RTVar>::epsilon()*10;
   for(auto i = 0; i < dimKrylov; i++){
     eigenVectors.GetSub(0, i, dim, 1, x);
-    const CTVar analyticW = i+1;
-    const auto res = Norm(cpma * x - w[i] * x);
-    CAPTURE(res,analyticW,w[i]);
-    REQUIRE(fabs(analyticW - w[i]) < res);
+    const auto currW = w[i];
+    //let us find WHICH eigenvalue was approximated
+    RTVar minres = 1e12;
+    int minindex=-1;
+    
+    for(auto ix = 0; ix < dim; ix++){
+      const CTVar analyticW = sol[ix];
+      const auto res = std::abs(analyticW - currW);
+      if(res < minres){
+        minres = res;
+        minindex = ix;
+      }
+    }
+    const CTVar analyticW = sol[minindex];
+    const auto res = Norm(cpma * x - currW * x);
+
+    CAPTURE(res,analyticW,currW);
+    REQUIRE((fabs(analyticW - currW) < res || res < tol));
   }
   Catch::StringMaker<RTVar>::precision = oldPrecision;
 }


### PR DESCRIPTION
Depending on the multiplicities of the eigenvalues of a given matrix, the Arnoldi iteration might not be able to generate the desired orthonormal vectors even in a simple case (identity matrix).

If that is the case, the algorithm now restarts with a random unit vector until a better approach is implemented.