### PR TITLE
Added SBFemHdiv refactored code

### DIFF
--- a/Mesh/TPZCompElHDivCollapsed.cpp
+++ b/Mesh/TPZCompElHDivCollapsed.cpp
@@ -223,11 +223,13 @@ int TPZCompElHDivCollapsed<TSHAPE>::NConnectShapeF(int connect, int connectorder
     }
     else if(connect == TSHAPE::NFacets+1)
     {
-        return TPZShapeHDivCollapsed<TSHAPE>::ComputeNConnectShapeF(connect,connectorder);
+        TPZManVector<int,22> order(TSHAPE::NSides-TSHAPE::NCornerNodes,connectorder);
+        return TSHAPE::NShapeF(order);
     }
     else if(connect == TSHAPE::NFacets+2)
     {
-        return TPZShapeHDivCollapsed<TSHAPE>::ComputeNConnectShapeF(connect,connectorder);
+        TPZManVector<int,22> order(TSHAPE::NSides-TSHAPE::NCornerNodes,connectorder);
+        return TSHAPE::NShapeF(order);
     }
     else DebugStop();
     return -1;
@@ -424,7 +426,7 @@ void TPZCompElHDivCollapsed<TSHAPE>::ComputeRequiredDataT(TPZMaterialDataT<TVar>
     data.axes = axeslocal;
     const int dim = TSHAPE::Dimension+1;
     const int nvecshapestd = data.fDeformedDirections.Cols();
-    TPZManVector<REAL> topdir(dim,0.), botdir(dim,0.); // top and bot directions in the deformed element
+    TPZManVector<REAL> topdir(3,0.), botdir(3,0.); // top and bot directions in the deformed element
     TPZManVector<REAL,3> vecup={0,0,0}, vecdown={0,0,0};
     vecup[dim-1] = 1.;
     vecdown[dim-1] = -1.;
@@ -456,7 +458,7 @@ void TPZCompElHDivCollapsed<TSHAPE>::ComputeRequiredDataT(TPZMaterialDataT<TVar>
         // the shape functions related to the top and bottom connect that communicate
         // with the adjacent 3D elements
         const int64_t nvecshapecollpased = nvecshapestd+nvec_top+nvec_bottom;
-        data.fDeformedDirections.Resize(dim,nvecshapecollpased);
+        data.fDeformedDirections.Resize(3,nvecshapecollpased);
         data.fVecShapeIndex.Resize(nvecshapecollpased);
         data.divphi.Resize(nvecshapecollpased,1);
         data.phi.Resize(nvecshapecollpased,1);
@@ -585,8 +587,23 @@ void TPZCompElHDivCollapsed<TSHAPE>::CleanupMaterialData(TPZMaterialData &data)
     data.fUserData = nullptr;
 }
 
+template<class TSHAPE>
+int TPZCompElHDivCollapsed<TSHAPE>::ConnectOrder(int connect) const {
+	if (connect < 0 || connect >= NConnects()){
+#ifdef PZ_LOG
+		{
+			std::stringstream sout;
+			sout << "Connect index out of range connect " << connect <<
+			" nconnects " << NConnects();
+			LOGPZ_DEBUG(logger,sout.str())
+		}
+#endif
+		return -1;
+	}
 
-
+    TPZConnect &c = this->Connect(connect);
+    return c.Order();
+}
 
 template<class TSHAPE>
 void TPZCompElHDivCollapsed<TSHAPE>::SetCreateFunctions(TPZCompMesh* mesh) {

--- a/Mesh/TPZCompElHDivCollapsed.h
+++ b/Mesh/TPZCompElHDivCollapsed.h
@@ -150,6 +150,8 @@ public:
 	void Read(TPZStream &buf, void *context) override;
     /** @brief Refinement along the element */
 //    virtual void PRefine(int order) override;
+
+	virtual int ConnectOrder(int connect) const override;
 	
 };
 

--- a/Mesh/TPZCompElHDivSBFem.cpp
+++ b/Mesh/TPZCompElHDivSBFem.cpp
@@ -5,6 +5,7 @@
 
 
 #include "TPZCompElHDivSBFem.h"
+#include "TPZShapeHDivCollapsed.h"
 #include "pzgeoel.h"
 #include "TPZMaterial.h"
 #include "pzlog.h"
@@ -22,13 +23,13 @@ static LoggerPtr logger(Logger::getLogger("pz.mesh.TPZCompElHDivSBFem"));
 // Initialize with the geometry of the SBFemVolume
 template<class TSHAPE>
 TPZCompElHDivSBFem<TSHAPE>::TPZCompElHDivSBFem(TPZCompMesh &mesh, TPZGeoEl *gel, TPZGeoElSide &gelside, int64_t &index) :
-TPZCompElHDivCollapsed<TSHAPE>(mesh, gel, index), fGelVolSide(gelside)
+TPZCompElHDivCollapsed<TSHAPE>(mesh, gel, index), fGeoElVolSide(gelside)
 {
 }
 
 template<class TSHAPE>
 TPZCompElHDivSBFem<TSHAPE>::TPZCompElHDivSBFem(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
-TPZCompElHDivCollapsed<TSHAPE>(mesh, gel, index), fGelVolSide(0)
+TPZCompElHDivCollapsed<TSHAPE>(mesh, gel, index), fGeoElVolSide(0)
 {
 }
 
@@ -36,7 +37,7 @@ template<class TSHAPE>
 TPZCompElHDivSBFem<TSHAPE>::TPZCompElHDivSBFem(TPZCompMesh &mesh, const TPZCompElHDivSBFem<TSHAPE> &copy) :
 TPZCompElHDivCollapsed<TSHAPE>(mesh,copy)
 {
-    fGelVolSide = copy.fGelVolSide;
+    fGeoElVolSide = copy.fGeoElVolSide;
 }
 
 template<class TSHAPE>
@@ -53,14 +54,14 @@ TPZCompElHDivSBFem<TSHAPE>::~TPZCompElHDivSBFem()
 template<class TSHAPE>
 void TPZCompElHDivSBFem<TSHAPE>::SetGelVolumeSide(TPZGeoElSide &gelside)
 {
-    fGelVolSide = gelside;
+    fGeoElVolSide = gelside;
 }
 
 // Get the GeoElSide for the volumetric SBFEM element
 template<class TSHAPE>
 TPZGeoElSide & TPZCompElHDivSBFem<TSHAPE>::GetGelVolumeSide()
 {
-    return fGelVolSide;
+    return fGeoElVolSide;
 }
 
 template<class TSHAPE>
@@ -72,27 +73,32 @@ void TPZCompElHDivSBFem<TSHAPE>::ComputeRequiredData(TPZMaterialDataT<STATE> &da
     TPZCompElHDivCollapsed<TSHAPE>::ComputeRequiredData(data, qsi);
     data.fNeedsSol = needssol;
 
-    auto nshape2d = data.phi.Rows();
-    auto nshape1d = 0;
-    for (int i = 0; i < 3; i++)
-    {
-        nshape1d += this->NConnectShapeF(i, this->fPreferredOrder);
-    }
+    TPZShapeData &shapedata = data;
 
-    HDivCollapsedDirections(data, nshape1d);
+    int porderboundbottom = this->ConnectOrder(TSHAPE::NFacets+1); // to be implemented
+    int porderboundtop = this->ConnectOrder(TSHAPE::NFacets+2);
 
-    
-    int64_t nshape = (nshape2d - nshape1d) / 2;
-    // Adjusting divergence values
-    for (int64_t i = 0; i < nshape1d; i++)
+    int nshape = TPZShapeHDivCollapsed<TSHAPE>::NShapeF(data);
+    int nshapeboundleft = TPZCompElHDivCollapsed<TSHAPE>::NConnectShapeF(TSHAPE::NFacets+1, porderboundbottom);
+    int nshapeboundright = TPZCompElHDivCollapsed<TSHAPE>::NConnectShapeF(TSHAPE::NFacets+2, porderboundtop);
+    int nshape1d = nshape - nshapeboundleft - nshapeboundright;
+
+    ComputeSBFemVolumeHdivData(data, nshape1d);
+
+    // Adjusting divergence and phi values
+    for (int i = 0; i < nshape1d; i++)
     {
         data.divphi(i) = data.fDPhi(0,i);
+        data.phi(i) = data.fPhi(i);
     }
-    for (int64_t i = 0; i < nshape; i++)
+    for (int i = 0; i < nshapeboundleft; i++)
     {
         data.divphi(i+nshape1d) = 0;
-        data.divphi(i+nshape1d+nshape) = data.phi(i+nshape1d);
-        data.phi(i+nshape1d+nshape) = 0;
+    }
+    for (int i = 0; i < nshapeboundright; i++)
+    {
+        data.divphi(i+nshape1d+nshapeboundleft) = data.fPhi(i+nshape1d);
+        data.phi(i+nshape1d+nshapeboundleft) = 0;
     }
     
 #ifdef LOG4CXX
@@ -108,45 +114,50 @@ void TPZCompElHDivSBFem<TSHAPE>::ComputeRequiredData(TPZMaterialDataT<STATE> &da
 
 // This function will compute the directions for the HDiv collapsed based on the information of neighbourhood
 template<class TSHAPE>
-void TPZCompElHDivSBFem<TSHAPE>::HDivCollapsedDirections(TPZMaterialDataT<STATE> &data, int64_t nshape1d)
+void TPZCompElHDivSBFem<TSHAPE>::ComputeSBFemVolumeHdivData(TPZMaterialDataT<STATE> &data, int64_t nshape1d)
 {
     // Computing the deformed directions for the 2d functions using the information of the neighbourhood
     // Inspired in TPZSBFemVolume::ComputeKMatrices
-    auto detjac1d = data.detjac;
-    auto axes1d = data.axes;
+
+    // Before entering in this method, the material data was computed
+    // (ComputeRequiredData calls this method and before it called ComputeRequiredData from TPZCompElHDivSBFem)
 
     // The Reference element will be the skeleton
     TPZGeoEl *Ref1D = this->Reference();
     int dim1 = TSHAPE::Dimension;
+    auto detjac1d = data.detjac;
+    auto axes1d = data.axes;
 
-    // The Volume element will be the one passed as an argument by the TPZSBFemVolumeHDiv - GEO DO EL 1D
+    // The Volume element will be the one passed as an argument by the TPZSBFemVolumeHDiv
     // The SBFemVolumeHdiv will compute the Contribute for the SBFemHdiv element
-    // Before that, the material data must be computed (It will call ComputeRequiredData from TPZCompElHDivSBFem)
-    TPZGeoEl * gelvolume = fGelVolSide.Element();
+    TPZGeoEl * gelvolume = fGeoElVolSide.Element();
     int dim2 = gelvolume->Dimension();
 
     // Find the higher side of the skeleton element
     TPZGeoElSide SkeletonSide(Ref1D, Ref1D->NSides() - 1);
 
-    // Create a transformation between these sides
+    // Create a transformation between the sides: Skeleton and Volume
     TPZTransform<REAL> tr(dim2, dim1);
-    tr = SkeletonSide.NeighbourSideTransform(fGelVolSide);
-    TPZTransform<REAL> t2 = gelvolume->SideToSideTransform(fGelVolSide.Side(), gelvolume->NSides() - 1);
+    tr = SkeletonSide.NeighbourSideTransform(fGeoElVolSide);
+    TPZTransform<REAL> t2 = gelvolume->SideToSideTransform(fGeoElVolSide.Side(), gelvolume->NSides() - 1);
     tr = t2.Multiply(tr);
 
-    // Applying the transformation
+    // Applying the transformation to obtain the 2d parametric coordinate
     TPZManVector<REAL, 3> xi(dim1), xiquad(dim2), xivol(dim2);
     xi = data.xParametric;
     tr.Apply(xi, xiquad);
     xivol = xiquad;
     xivol[dim2 - 1] = -0.5;
 
-    // Computing the data for the volumetric element
+    // Computing data for the volumetric element
     gelvolume->X(xivol, data.x);
     gelvolume->Jacobian(xiquad, data.jacobian, data.axes, data.detjac, data.jacinv);
 
     auto axes = data.axes;
-    if (dim2 == 3) {
+    if (dim2 == 3)
+    {
+        PZError << __PRETTY_FUNCTION__ << "is not ready for 3D examples yet. \n";
+        DebugStop();
         AdjustAxes3D(axes, data.axes, data.jacobian, data.jacinv, data.detjac);
     }
 
@@ -154,45 +165,46 @@ void TPZCompElHDivSBFem<TSHAPE>::HDivCollapsedDirections(TPZMaterialDataT<STATE>
     ExtendShapeFunctions(data, detjac1d);
 
     auto ndir = data.fDeformedDirections.Cols()-1;
-
-    if (dim2 == 3)
-    {
-        std::cout << "Function not verified for 3D cases yet\n";
-        DebugStop();
-    }
     
     TPZFNMatrix<9,REAL> grad(dim2,dim2,0);
     gelvolume->GradX(xivol,grad);
     REAL detjac = sqrt(2*data.detjac);
     
     TPZFNMatrix<9,REAL> jaccollapsed;
-    data.axes.Resize(data.jacobian.Cols(),3);
-    data.jacobian.Multiply(data.axes,jaccollapsed);
-    TPZFMatrix<REAL> fDeformedDirectionsCopy(data.fDeformedDirections);
+    data.axes.Resize(dim2,dim2);
+    // data.fDeformedDirections.Resize(3,data.fMasterDirections.Cols());
+    data.fDeformedDirections.Zero();
+    TPZFMatrix<REAL> internaldir(data.fDeformedDirections);
+    TPZIntelGen<TSHAPE>::Reference()->HDivDirections(data.xParametric, internaldir);
 
     auto signal = 0, signal0 = 0;
     TPZManVector<REAL,2> signalvec(2,0);
-    for (int i = 0; i < dim2; i++)
-    {
-        signal += -data.axes(1,i);
-    }
+    // for (int i = 0; i < dim2; i++)
+    // {
+    //     signal += -data.axes(1,i);
+    // }
+    TPZFMatrix<REAL> directions(2,2,0.);
+    data.axes.Multiply(data.jacobian,directions);
     
-    for (auto j = 0; j < 3; j++)
+    for (auto j = 0; j < nshape1d; j++)
     {
         for (auto i = 0; i < dim2; i++)
         {
-            data.fDeformedDirections(i,j) = data.fDeformedDirections(i,0);
+            data.fDeformedDirections(i,j) = -internaldir(i,0);
         }
     }
-    for (auto j = 3; j < data.fDeformedDirections.Cols(); j++)
+    for (int j = 0; j < data.fHDivNumConnectShape[3]; j++)
     {
-        data.fDeformedDirections(2,j) = 0.;
         for (auto i = 0; i < dim2; i++)
         {
-            for (int k = 0; k < 3; k++)
-            {
-                data.fDeformedDirections(i,j) = signal*fDeformedDirectionsCopy(k,j)*grad(i,1)*2./fabs(detjac1d);
-            }
+            data.fDeformedDirections(i,nshape1d+j) = this->fbottom_side_orient*grad(i,1)*2./fabs(detjac1d);
+        }
+    }
+    for (int j = 0; j < data.fHDivNumConnectShape[4]; j++)
+    {
+        for (auto i = 0; i < dim2; i++)
+        {
+            data.fDeformedDirections(i,nshape1d+data.fHDivNumConnectShape[3]+j) = this->ftop_side_orient*grad(i,1)*2./fabs(detjac1d);
         }
     }
 }
@@ -250,34 +262,36 @@ void TPZCompElHDivSBFem<TSHAPE>::AdjustAxes3D(const TPZFMatrix<REAL> &axes2D, TP
 template <class TSHAPE>
 void TPZCompElHDivSBFem<TSHAPE>::ExtendShapeFunctions(TPZMaterialDataT<STATE> &data, REAL detjac1d)
 {
-    int dim = fGelVolSide.Element()->Dimension();
+    int dim = fGeoElVolSide.Element()->Dimension();
 
-    auto nshape = data.phi.Rows();
-    auto nshape1d = 0;
-    for (int i = 0; i < 3; i++)
-    {
-        nshape1d += this->NConnectShapeF(i, this->fPreferredOrder);
-    }
+    TPZShapeData& shapedata = data;
+    int porderboundbottom = this->ConnectOrder(TSHAPE::NFacets+1);
+    int porderboundtop = this->ConnectOrder(TSHAPE::NFacets+2);
 
-    int64_t nshape2d = (nshape - nshape1d) / 2;
-    for (int ish = 0; ish < nshape2d; ish++)
+    auto nshape = TPZShapeHDivCollapsed<TSHAPE>::NShapeF(shapedata);
+    int nshapeboundleft = TPZCompElHDivCollapsed<TSHAPE>::NConnectShapeF(TSHAPE::NFacets+1, porderboundbottom);
+    int nshapeboundright = TPZCompElHDivCollapsed<TSHAPE>::NConnectShapeF(TSHAPE::NFacets+2, porderboundtop);
+    int nshape1d = nshape - nshapeboundleft - nshapeboundright;
+
+    shapedata.fDPhi.Resize(dim, nshape);
+
+    for (int ish = 0; ish < nshapeboundleft; ish++)
     {
         for (int d = 0; d < dim - 1; d++)
         {
-            data.fDPhi(d, ish + nshape1d) = 0.;
-            data.fDPhi(d, ish + nshape1d+nshape2d) = data.phi(ish);
+            shapedata.fDPhi(d, ish + nshape1d) = 0.;
+            shapedata.fDPhi(d, ish + nshape1d+nshapeboundleft) = shapedata.fPhi(ish);
         }
-        data.fDPhi(dim-1, ish+nshape1d) = - data.phi(ish) / 2.;
-        data.fDPhi(dim-1, ish+nshape1d+nshape2d) = 0.;
+        shapedata.fDPhi(dim-1, ish+nshape1d) = -shapedata.fPhi(ish) / 2.;
+        shapedata.fDPhi(dim-1, ish+nshape1d+nshapeboundleft) = 0.;
     }
    
-    TPZFNMatrix<50,REAL> philoc(data.phi.Rows(),data.phi.Cols()),dphiloc(data.fDPhi.Rows(),data.fDPhi.Cols());
-    TPZManVector<int,TSHAPE::NSides> ord;
-    ord.Resize(TSHAPE::NSides-TSHAPE::NCornerNodes, 0);
-    TPZShapeData &shapedata = data;
+    TPZFNMatrix<50,REAL> philoc(data.fPhi.Rows(),data.fPhi.Cols(),0.),
+        dphiloc(data.fDPhi.Rows(),data.fDPhi.Cols(),0.);
+    TPZManVector<int,TSHAPE::NSides> ord(TSHAPE::NFacets+3, 0);
+
     const int nconnects = shapedata.fHDivConnectOrders.size();
-    ord = shapedata.fHDivConnectOrders[nconnects-2];
-//    TPZCompElHDivCollapsed<TSHAPE>::fBottom.GetInterpolationOrder(ord);
+    ord = shapedata.fHDivConnectOrders;
 
     int nc = this->Reference()->NCornerNodes();
     TPZManVector<int64_t,8> id(nc);
@@ -293,41 +307,26 @@ void TPZCompElHDivSBFem<TSHAPE>::ExtendShapeFunctions(TPZMaterialDataT<STATE> &d
     TSHAPE::GetSideHDivPermutation(transformid, permutegather);
     
     TPZManVector<int64_t,27> FirstIndex(TSHAPE::NSides+1);
-//    TPZCompElHDivCollapsed<TSHAPE>::fBottom.FirstShapeIndex(FirstIndex);
-    FirstIndex.Resize(TSHAPE::NSides+1);
-    FirstIndex[0]=0;
+    fCelFlux->FirstShapeIndex(FirstIndex);
     int order = shapedata.fHDivConnectOrders[nconnects-2];
-    for(int iside=0;iside<TSHAPE::NSides;iside++)
-    {
-        
-        if(TSHAPE::Type()==EQuadrilateral){
-            FirstIndex[iside+1] = FirstIndex[iside] + TSHAPE::NConnectShapeF(iside,order);
-        }
-        else{
-            FirstIndex[iside+1] = FirstIndex[iside] + TSHAPE::NConnectShapeF(iside,order);
-        }
-    }
     
-    
-    
-//    int order = TPZCompElHDivCollapsed<TSHAPE>::fBottom.Connect(0).Order();
     for (int side=0; side < TSHAPE::NSides; side++)
     {
         int ifirst = FirstIndex[side];
         int kfirst = FirstIndex[permutegather[side]];
-        int nshape = TSHAPE::NConnectShapeF(side,order);
-        for (int i=0; i<nshape; i++)
+        int nshapeloc = TSHAPE::NConnectShapeF(side,order);
+        for (int i=0; i<nshapeloc; i++)
         {
-            data.phi(nshape1d + ifirst+i,0) = philoc(kfirst+i,0);
+            data.fPhi(nshape1d + ifirst+i,0) = philoc(kfirst+i,0);
             for (int d=0; d< TSHAPE::Dimension; d++)
             {
                 data.fDPhi(d,nshape1d + ifirst+i) = dphiloc(d,kfirst+i);
             }
         }
     }
+
     data.divsol.Resize(1);
     data.divsol[0].Resize(1,0.);
-    
 
     TPZInterpolationSpace::Convert2Axes(data.fDPhi, data.jacinv, data.dphix);
 }

--- a/Mesh/TPZCompElHDivSBFem.h
+++ b/Mesh/TPZCompElHDivSBFem.h
@@ -21,10 +21,10 @@ template<class TSHAPE>
 class TPZCompElHDivSBFem : public TPZCompElHDivCollapsed<TSHAPE> {
 
     /// geometric element representing the collapsed volume
-    TPZGeoElSide fGelVolSide;
+    TPZGeoElSide fGeoElVolSide;
 
-    /// vector which defines whether the normal is outward or not
-    TPZManVector<int, TSHAPE::NFacets> fSideOrient;
+    /// element representing the flux element
+    TPZCompElHDivBound2<TSHAPE> * fCelFlux;
     
 public:
 	    
@@ -53,13 +53,18 @@ public:
 
     void ComputeDeformedDirections(TPZMaterialDataT<STATE> &data);
 
-    void HDivCollapsedDirections(TPZMaterialDataT<STATE> &data, int64_t nshape1d);
+    void ComputeSBFemVolumeHdivData(TPZMaterialDataT<STATE> &data, int64_t nshape1d);
 
     void AdjustAxes3D(const TPZFMatrix<REAL> &axes2D, TPZFMatrix<REAL> &axes3D, TPZFMatrix<REAL> &jac3D, TPZFMatrix<REAL> &jacinv3D, REAL detjac);
 
     void ExtendShapeFunctions(TPZMaterialDataT<STATE> &data2d, REAL nshape1d);
 
     virtual void ComputeSolution(TPZVec<REAL> &qsi, TPZMaterialDataT<STATE> &data);
+
+    void SetCompElFlux(TPZCompElHDivBound2<TSHAPE> * cel)
+    {
+        fCelFlux = cel;
+    }
 
 };
 

--- a/Mesh/TPZMultiphysicsCompMesh.cpp
+++ b/Mesh/TPZMultiphysicsCompMesh.cpp
@@ -82,7 +82,14 @@ void TPZMultiphysicsCompMesh::BuildMultiphysicsSpace(TPZVec<int> & active_approx
   
     SetNMeshes(n_approx_spaces);
     Reference()->ResetReference();
-    SetAllCreateFunctionsMultiphysicElem();
+    if (ApproxSpace().Style() == TPZCreateApproximationSpace::EMultiphysics)
+    {
+        SetAllCreateFunctionsMultiphysicElem();
+    }
+    else if (ApproxSpace().Style() == TPZCreateApproximationSpace::EMultiphysicsSBFem)
+    {
+        SetAllCreateFunctionsSBFemMultiphysics();
+    }
     // delete all elements and connects in the mesh
     CleanElementsConnects();
     TPZCompMesh::AutoBuild();
@@ -132,12 +139,12 @@ void TPZMultiphysicsCompMesh::BuildMultiphysicsSpace(TPZVec<TPZCompMesh * > & me
     int n_approx_spaces = m_mesh_vector.size();
     SetNMeshes(n_approx_spaces);
     Reference()->ResetReference();
-    if(ApproxSpace().Style() != TPZCreateApproximationSpace::EMultiphysics)
-    {
-        std::cout << __PRETTY_FUNCTION__ << " Modifying the style of approximation space "
-        " to multiphysics\n";
-        SetAllCreateFunctionsMultiphysicElem();
-    }
+    // if(ApproxSpace().Style() != TPZCreateApproximationSpace::EMultiphysics)
+    // {
+    //     std::cout << __PRETTY_FUNCTION__ << " Modifying the style of approximation space "
+    //     " to multiphysics\n";
+    //     SetAllCreateFunctionsMultiphysicElem();
+    // }
     // delete all elements and connects in the mesh
     CleanElementsConnects();
     TPZCompMesh::AutoBuild(gelindexes);

--- a/Mesh/TPZSBFemMultiphysicsElGroup.cpp
+++ b/Mesh/TPZSBFemMultiphysicsElGroup.cpp
@@ -261,8 +261,8 @@ void TPZSBFemMultiphysicsElGroup::CalcStiff(TPZElementMatrixT<STATE> &ek,TPZElem
     TPZFMatrix<STATE> globmatkeep(globmat);
     TPZFNMatrix<100,complex<double> > eigenVectors;
     TPZManVector<complex<double> > eigenvalues;
-    globmatkeep.SolveEigenProblem(eigenvalues, eigenVectors);
-    // this->SolveEigenProblemSBFEM(globmatkeep, eigenvalues, eigenVectors);
+    // globmatkeep.SolveEigenProblem(eigenvalues, eigenVectors);
+    this->SolveEigenProblemSBFEM(globmatkeep, eigenvalues, eigenVectors);
 #ifdef LOG4CXX
     if (loggerfulleigensys->isDebugEnabled())
     {
@@ -456,6 +456,12 @@ void TPZSBFemMultiphysicsElGroup::ComputeMatrices(TPZElementMatrixT<STATE> &E0, 
             E1.fMat(i,j) = ek.fMat(i+n,j);
             E2.fMat(i,j) = ek.fMat(i+n,j+n);
         }
+    }
+    {
+        std::ofstream out("coefmatrices.txt");
+        E0.fMat.Print("E0pz = ", out, EMathematicaInput);
+        E1.fMat.Print("E1pz = ", out, EMathematicaInput);
+        E2.fMat.Print("E2pz = ", out, EMathematicaInput);
     }
 
 #ifdef LOG4CXX

--- a/Mesh/TPZSBFemVolume.cpp
+++ b/Mesh/TPZSBFemVolume.cpp
@@ -397,7 +397,7 @@ void TPZSBFemVolume::ReallyComputeSolution(TPZMaterialDataT<STATE>& data)
             std::stringstream sout;
             sout << "uh_xi " << uh_xi << std::endl;
             sout << "Duh_xi " << Duh_xi << std::endl;
-            data1d.phi.Print(sout);
+            data1d.fPhi.Print(sout);
             LOGPZ_DEBUG(logger, sout.str())
         }
 #endif

--- a/Mesh/TPZSBFemVolumeHdiv.cpp
+++ b/Mesh/TPZSBFemVolumeHdiv.cpp
@@ -194,7 +194,7 @@ void TPZSBFemVolumeHdiv::ReallyComputeSolution(TPZMaterialDataT<STATE> & data)
                     for (int d = 0; d < dim; d++)
                     {
                         int id = (ishape + is)* nstate + istate;
-                        data.sol[s][d] += data.phi(id) * data.fDeformedDirections(d,ic) * uh_xi[id].real();
+                        data.sol[s][d] += data.fPhi(id) * data.fDeformedDirections(d,ic) * uh_xi[id].real();
                     }
                 }
             }

--- a/Mesh/TPZSBFemVolumeL2.cpp
+++ b/Mesh/TPZSBFemVolumeL2.cpp
@@ -100,7 +100,7 @@ void TPZSBFemVolumeL2::ReallyComputeSolution(TPZMaterialDataT<STATE> & data)
     Ref2D->Jacobian(qsi, data2d.jacobian, data2d.axes, data2d.detjac, data2d.jacinv);
     axes = data2d.axes;
 
-    int nshape = data1d.phi.Rows();
+    int nshape = data1d.fPhi.Rows();
     int nstate = mat2d->NStateVariables();
 #ifdef PZDEBUG
     if (fPhi.Cols() != fCoeficients.Rows()) {
@@ -136,7 +136,7 @@ void TPZSBFemVolumeL2::ReallyComputeSolution(TPZMaterialDataT<STATE> & data)
             std::stringstream sout;
             sout << "uh_xi " << uh_xi << std::endl;
             sout << "Duh_xi " << Duh_xi << std::endl;
-            data1d.phi.Print(sout);
+            data1d.fPhi.Print(sout);
             LOGPZ_DEBUG(logger, sout.str())
         }
 #endif
@@ -147,8 +147,8 @@ void TPZSBFemVolumeL2::ReallyComputeSolution(TPZMaterialDataT<STATE> & data)
         TPZManVector<STATE, 3> dsolxi(nstate, 0.);
         for (int ishape = 0; ishape < nshape; ishape++) {
             for (int istate = 0; istate < nstate; istate++) {
-                sol[s][istate] += data1d.phi(ishape) * uh_xi[ishape * nstate + istate].real();
-                dsolxi[istate] += data1d.phi(ishape) * Duh_xi[ishape * nstate + istate].real();
+                sol[s][istate] += data1d.fPhi(ishape) * uh_xi[ishape * nstate + istate].real();
+                dsolxi[istate] += data1d.fPhi(ishape) * Duh_xi[ishape * nstate + istate].real();
                 for (int d = 0; d < dim - 1; d++) {
                     dsollow(d, istate) += data1d.fDPhi(d, ishape) * uh_xi[ishape * nstate + istate].real();
                 }

--- a/Mesh/TPZSBFemVolumeMultiphysics.cpp
+++ b/Mesh/TPZSBFemVolumeMultiphysics.cpp
@@ -339,6 +339,7 @@ void TPZSBFemVolumeMultiphysics<TGeometry>::Solution(TPZVec<REAL> &qsi,int var,T
         TPZMaterialData::MShapeFunctionType shapetype = datavec[iref].fShapeType;
         msp->ComputeRequiredData(datavec[iref], myqsi);
         constexpr bool hasPhi{true};
+        datavec[iref].xParametric = myqsi;
         msp->ComputeSolution(myqsi, datavec[iref],hasPhi);
         
         datavec[iref].x.Resize(3);

--- a/Mesh/pzcmesh.h
+++ b/Mesh/pzcmesh.h
@@ -573,6 +573,11 @@ public:
         fCreate.SetAllCreateFunctionsMultiphysicElem();
     }
 
+	void SetAllCreateFunctionsSBFemMultiphysics()
+    {
+        fCreate.SetAllCreateFunctionsSBFemMultiphysics(this->Dimension());
+    }
+
     void SetAllCreateFunctionsMultiphysicElemWithMem()
     {
         fCreate.SetAllCreateFunctionsMultiphysicElemWithMem();

--- a/Mesh/pzmultiphysicscompel.h
+++ b/Mesh/pzmultiphysicscompel.h
@@ -331,6 +331,15 @@ public:
 	}	
     virtual int ClassId() const override;
 
+    void BuildCornerConnectList(std::set<int64_t> &connectindexes) const override
+    {
+        int ncorner = TGeometry::NNodes;
+        for (int ic = 0; ic < ncorner; ic++)
+        {
+            connectindexes.insert(ConnectIndex(ic));
+        }
+    }
+
 };
 
 

--- a/Pre/TPZBuildSBFemMultiphysics.cpp
+++ b/Pre/TPZBuildSBFemMultiphysics.cpp
@@ -625,11 +625,12 @@ void TPZBuildSBFemMultiphysics::CreateCompElFlux(TPZCompMesh &cmeshflux, set<int
         int64_t index;
 
         auto hdivboundleft = new TPZCompElHDivBound2<pzshape::TPZShapeLinear>(cmeshflux,gelsideleft.Element(),index);
-        hdivboundleft->SetConnectIndex(0,celhdivc->ConnectIndex(3));
+        celhdivc->SetConnectIndex(3,hdivboundleft->ConnectIndex(0));
+        celhdivc->SetCompElFlux(hdivboundleft);
         gelsideleft.Element()->ResetReference();
 
         auto hdivboundright = new TPZCompElHDivBound2<pzshape::TPZShapeLinear>(cmeshflux,gelsideright.Element(),index);
-        hdivboundright->SetConnectIndex(0,celhdivc->ConnectIndex(4));
+        celhdivc->SetConnectIndex(4,hdivboundright->ConnectIndex(0));
         gelsideright.Element()->ResetReference();
     }
 


### PR DESCRIPTION
The majority of changes were in SBFEM codes that will not affect other UnitTests. The other changes are:

- TPZCompElHDivCollapsed: Generalized the code for 2D meshes and added a `ConnectOrder` method.
- TPZShapeHDivCollapsed: Fixed a bug in `Initialize` (now the method resizes the data considering the hdivbounds). Generalize the code for 2D meshes - instead of using dimension of `nsides-ncorner`, now we use `TSHAPE::NFacets+1`.
- TPZMultiphysicsCompMesh: Multiphysics approximation space can be of type: `EMultiphysicsSBFem`.
- pzcmesh: Added a method `SetAllCreateFunctionsSBFemMultiphysics()`
- pzmultiphysicscompel.h: Added a method `BuildCornerConnectList`