### PR TITLE
Add Solution and NSolutionVariables methods to TPZNullMaterial

### DIFF
--- a/Material/TPZNullMaterial.cpp
+++ b/Material/TPZNullMaterial.cpp
@@ -4,7 +4,7 @@
 
 #include "TPZNullMaterial.h"
 #include "TPZStream.h"
-#include "TPZMaterialData.h"
+#include "TPZMaterialDataT.h"
 
 template<class TVar>
 int TPZNullMaterial<TVar>::ClassId() const {
@@ -61,6 +61,33 @@ void TPZNullMaterial<TVar>::Print(std::ostream &out) const {
 template<class TVar>
 TPZMaterial *TPZNullMaterial<TVar>::NewMaterial() const {
     return new TPZNullMaterial<TVar>(*this);
+}
+
+template<class TVar>
+void TPZNullMaterial<TVar>::Solution(const TPZMaterialDataT<TVar> &data, int var, TPZVec<TVar> &sol) {
+    if (var == 0) {
+        sol = data.sol[0];
+    } else if (var == 1) {
+        TVar val = 0.;
+        for (int i = 0; i < 3; i++) {
+            val += data.dsol[0](i, i);
+        }
+        sol[0] = val;
+    } else {
+        DebugStop();
+    }
+}
+
+template<class TVar>
+int TPZNullMaterial<TVar>::NSolutionVariables(int var) const {
+    if (var == 0) {
+        return 1;
+    } else if (var == 1) {
+        return 3;
+    } else {
+        DebugStop();
+        return 0;
+    }
 }
 
 template class TPZNullMaterial<STATE>;

--- a/Material/TPZNullMaterial.h
+++ b/Material/TPZNullMaterial.h
@@ -63,9 +63,8 @@ public:
                           uint64_t &du_row,
                           uint64_t &du_col) const override;
 
-    void Solution(const TPZMaterialDataT<TVar> &data, int var,
-                  TPZVec<TVar> &sol) override
-    {}
+    void Solution(const TPZMaterialDataT<TVar> &data, int var, TPZVec<TVar> &sol) override;
+
     void Contribute(const TPZMaterialDataT<TVar> &data, REAL weight,
                             TPZFMatrix<TVar> &ek,
                             TPZFMatrix<TVar> &ef) override
@@ -79,13 +78,13 @@ public:
     void Print(std::ostream &out = std::cout) const override;
 
     /** @brief Returns the variable index associated with the name */
-    int VariableIndex(const std::string &name) const override { return 0;}    
+    int VariableIndex(const std::string &name) const override { return 0;}
 
     /**
 	 * @brief Returns the number of variables associated with the variable indexed by var.
 	 * @param var Index variable into the solution, is obtained by calling VariableIndex
 	 */
-    int NSolutionVariables(int var) const override{return 0;}
+    [[nodiscard]] int NSolutionVariables(int var) const override;
 
     /** @brief Unique identifier for serialization purposes */
     [[nodiscard]] int ClassId() const override;


### PR DESCRIPTION
This PR makes it possible to access the solution of a null material, needed in the ErrorEstimation project. 