### PR TITLE
Removed index argument from TPZCompEl hierarchy 

### DIFF
--- a/Analysis/TPZNLMultGridAnalysis.cpp
+++ b/Analysis/TPZNLMultGridAnalysis.cpp
@@ -159,10 +159,10 @@ TPZCompMesh  *TPZNonLinMultGridAnalysis::UniformlyRefineMesh(TPZCompMesh *coarcm
 			lev++;
 		}
 		int nsub = sub.NElements(),isub;
-		int64_t index;
+
 		//o construtor adequado ja deveria ter sido definido
 		for(isub=0; isub<nsub; isub++) {
-			disc = dynamic_cast<TPZCompElDisc *>(finemesh->CreateCompEl(sub[isub],index));
+			disc = dynamic_cast<TPZCompElDisc *>(finemesh->CreateCompEl(sub[isub]));
 			if(setdegree > 0 && setdegree != degree) disc->SetDegree(degree);
 			//caso setdegree < 0 preserva-se o grau da malha inicial
 		}

--- a/Analysis/pzmganalysis.cpp
+++ b/Analysis/pzmganalysis.cpp
@@ -451,10 +451,9 @@ TPZCompMesh  *TPZMGAnalysis::UniformlyRefineMesh(TPZCompMesh *mesh, bool withP) 
 		gel->Divide(sub);
 		int nsub = sub.NElements();
 		int isub;
-		int64_t celindex;
 		for(isub=0; isub<nsub; isub++) {
 			TPZInterpolatedElement *csint;
-			csint = (TPZInterpolatedElement *) cmesh->CreateCompEl(sub[isub],celindex);
+			csint = (TPZInterpolatedElement *) cmesh->CreateCompEl(sub[isub]);
 			if(withP) csint->PRefine(porder+1);
 			else csint->PRefine(porder);
 		}

--- a/Mesh/TPZAgglomerateEl.cpp
+++ b/Mesh/TPZAgglomerateEl.cpp
@@ -30,8 +30,8 @@
 
 using namespace std;
 
-TPZAgglomerateElement::TPZAgglomerateElement(int nummat,int64_t &index,TPZCompMesh &aggcmesh,TPZCompMesh *finemesh) :
-TPZRegisterClassId(&TPZAgglomerateElement::ClassId),TPZCompElDisc(aggcmesh,index) {
+TPZAgglomerateElement::TPZAgglomerateElement(int nummat,TPZCompMesh &aggcmesh,TPZCompMesh *finemesh) :
+TPZRegisterClassId(&TPZAgglomerateElement::ClassId),TPZCompElDisc(aggcmesh) {
 	
 	/**
 	 * o algomerado aponta para nulo mas o elemento computacional
@@ -739,7 +739,8 @@ TPZAgglomerateMesh *TPZAgglomerateElement::CreateAgglomerateMesh(TPZCompMesh *fi
 		
 		nummat = finemesh->ElementVec()[k]->Material()->Id();
 		//criando elemento de index/id i e inserindo na malha aggmesh
-		new TPZAgglomerateElement(nummat,index,*aggmesh,finemesh);
+		TPZCompEl* cel = new TPZAgglomerateElement(nummat,*aggmesh,finemesh);
+        index = cel->Index();
 		IdElNewMesh[k] = index;
 	}
 	
@@ -766,7 +767,7 @@ TPZAgglomerateMesh *TPZAgglomerateElement::CreateAgglomerateMesh(TPZCompMesh *fi
 				IdElNewMesh[i] = father;
 			} else if(eldim == surfacedim){
 				//clonando o elemento descont�uo BC, o clone existira na malha aglomerada
-				TPZCompEl * AggCell = dynamic_cast<TPZCompElDisc *>(cel)->Clone(*aggmesh,index);
+				TPZCompEl * AggCell = dynamic_cast<TPZCompElDisc *>(cel)->Clone(*aggmesh);
 				IdElNewMesh[i] = AggCell->Index();
 			}
 		}
@@ -788,7 +789,6 @@ TPZAgglomerateMesh *TPZAgglomerateElement::CreateAgglomerateMesh(TPZCompMesh *fi
 				if(aggmesh) delete aggmesh;
 				return 0;
 			}
-			int64_t index;
 			//interfaces com esquerdo e direito iguais n� s� clonadas
 			if(accumlist[indleft] == accumlist[indright]) continue;
 			
@@ -815,7 +815,7 @@ TPZAgglomerateMesh *TPZAgglomerateElement::CreateAgglomerateMesh(TPZCompMesh *fi
 			TPZCompElDisc * rightagg = dynamic_cast<TPZCompElDisc*> (aggmesh->ElementVec()[rightid]) ;
 			
 			TPZCompElSide leftcompelside(leftagg, leftside), rightcompelside(rightagg, rightside);
-			interf->CloneInterface(*aggmesh,index, /*leftagg*/leftcompelside, /*rightagg*/rightcompelside);
+			interf->CloneInterface(*aggmesh, /*leftagg*/leftcompelside, /*rightagg*/rightcompelside);
 			
 		}
 	}

--- a/Mesh/TPZAgglomerateEl.h
+++ b/Mesh/TPZAgglomerateEl.h
@@ -69,7 +69,7 @@ private:
 public:
 	
 	/** @brief Constructor: If the element is possible to grouped returns a new index, else returns -1. */
-	TPZAgglomerateElement(int nummat,int64_t &index,TPZCompMesh &aggcmesh,TPZCompMesh *finemesh);
+	TPZAgglomerateElement(int nummat,TPZCompMesh &aggcmesh,TPZCompMesh *finemesh);
 	
 	TPZAgglomerateElement();
 	

--- a/Mesh/TPZCompElDisc.h
+++ b/Mesh/TPZCompElDisc.h
@@ -108,7 +108,7 @@ public:
 	int GetMaterial( const TPZGeoElSide& gside );
 	
 	/** @brief Creates discontinuous computational element */
-	static TPZCompEl *CreateDisc(TPZGeoEl *geo, TPZCompMesh &mesh, int64_t &index);
+	static TPZCompEl *CreateDisc(TPZGeoEl *geo, TPZCompMesh &mesh);
 	
 	/**
 	 * @brief Sets the orthogonal function which will be used throughout the program.
@@ -132,9 +132,9 @@ public:
 	/** @brief Default constructor */
 	TPZCompElDisc();
 	/** @brief Constructor of the discontinuous element associated with geometric element */
-	TPZCompElDisc(TPZCompMesh &mesh,TPZGeoEl *ref,int64_t &index);//original
+	TPZCompElDisc(TPZCompMesh &mesh,TPZGeoEl *ref);//original
 	/** @brief Constructor */
-	TPZCompElDisc(TPZCompMesh &mesh,int64_t &index);//construtor do aglomerado
+	TPZCompElDisc(TPZCompMesh &mesh);//construtor do aglomerado
 	/** @brief Copy constructor */
 	TPZCompElDisc(TPZCompMesh &mesh, const TPZCompElDisc &copy);
 
@@ -150,17 +150,12 @@ public:
 				  std::map<int64_t,int64_t> &gl2lcConMap,
 				  std::map<int64_t,int64_t> &gl2lcElMap);
 	
-	TPZCompElDisc(TPZCompMesh &mesh, const TPZCompElDisc &copy,int64_t &index);
 	
 	/** @brief Set create function in TPZCompMesh to create elements of this type */
 	virtual void SetCreateFunctions(TPZCompMesh *mesh) override;
 	
 	virtual TPZCompEl *Clone(TPZCompMesh &mesh) const override {
 		return new TPZCompElDisc(mesh,*this);
-	}
-	
-	virtual TPZCompEl *Clone(TPZCompMesh &mesh,int64_t &index) const {
-		return new TPZCompElDisc(mesh,*this,index);
 	}
 	
 	/**
@@ -379,9 +374,9 @@ int ClassId() const override;
 	virtual void PRefine ( int order ) override { SetDegree( order ); }
 };
 
-inline TPZCompEl *TPZCompElDisc::CreateDisc(TPZGeoEl *geo, TPZCompMesh &mesh, int64_t &index) {
+inline TPZCompEl *TPZCompElDisc::CreateDisc(TPZGeoEl *geo, TPZCompMesh &mesh) {
 	if(!geo->Reference() && geo->NumInterfaces() == 0)
-		return new TPZCompElDisc(mesh,geo,index);
+		return new TPZCompElDisc(mesh,geo);
 	return NULL;
 }
 //Exemplo do quadrilatero:

--- a/Mesh/TPZCompElH1.cpp
+++ b/Mesh/TPZCompElH1.cpp
@@ -14,8 +14,8 @@ static int logger;
 
 
 template<class TSHAPE>
-TPZCompElH1<TSHAPE>::TPZCompElH1(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) : TPZRegisterClassId(&TPZCompElH1::ClassId),
-TPZIntelGen<TSHAPE>(mesh,gel,index){
+TPZCompElH1<TSHAPE>::TPZCompElH1(TPZCompMesh &mesh, TPZGeoEl *gel) : TPZRegisterClassId(&TPZCompElH1::ClassId),
+TPZIntelGen<TSHAPE>(mesh,gel){
 
 	for(int i=0;i<TSHAPE::NSides;i++) {
 		fConnectIndexes[i] = this->CreateMidSideConnect(i);
@@ -24,8 +24,8 @@ TPZIntelGen<TSHAPE>(mesh,gel,index){
 }
 
 template<class TSHAPE>
-TPZCompElH1<TSHAPE>::TPZCompElH1(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index, int nocreate) : TPZRegisterClassId(&TPZCompElH1::ClassId),
-TPZIntelGen<TSHAPE>(mesh,gel,index)
+TPZCompElH1<TSHAPE>::TPZCompElH1(TPZCompMesh &mesh, TPZGeoEl *gel, int nocreate) : TPZRegisterClassId(&TPZCompElH1::ClassId),
+TPZIntelGen<TSHAPE>(mesh,gel)
 {
 	
 }

--- a/Mesh/TPZCompElH1.h
+++ b/Mesh/TPZCompElH1.h
@@ -17,9 +17,9 @@ public:
 
   TPZCompElH1() = default;
 
-  TPZCompElH1(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+  TPZCompElH1(TPZCompMesh &mesh, TPZGeoEl *gel);
 	
-	TPZCompElH1(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index, int nocreate);
+	TPZCompElH1(TPZCompMesh &mesh, TPZGeoEl *gel, int nocreate);
 	
 	TPZCompElH1(TPZCompMesh &mesh, const TPZCompElH1<TSHAPE> &copy);
 

--- a/Mesh/TPZCompElHCurl.cpp
+++ b/Mesh/TPZCompElHCurl.cpp
@@ -29,9 +29,9 @@ static int logger;
  *********************************************************************************************************/
 
 template<class TSHAPE>
-TPZCompElHCurl<TSHAPE>::TPZCompElHCurl(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
+TPZCompElHCurl<TSHAPE>::TPZCompElHCurl(TPZCompMesh &mesh, TPZGeoEl *gel) :
 TPZRegisterClassId(&TPZCompElHCurl::ClassId),
-TPZIntelGen<TSHAPE>(mesh,gel,index,1)
+TPZIntelGen<TSHAPE>(mesh,gel,1)
 {
     gel->SetReference(this);
     this->TPZInterpolationSpace::fPreferredOrder = mesh.GetDefaultOrder();
@@ -962,62 +962,54 @@ IMPLEMENTHCURL(pzshape::TPZShapePrism)
     DebugStop();\
     return nullptr;
 
-TPZCompEl *CreateHCurlBoundPointEl(TPZGeoEl *gel, TPZCompMesh &mesh,
-                                   int64_t &index){HCURL_EL_NOT_AVAILABLE}
+TPZCompEl *CreateHCurlBoundPointEl(TPZGeoEl *gel, TPZCompMesh &mesh){HCURL_EL_NOT_AVAILABLE}
 
-TPZCompEl *CreateHCurlBoundLinearEl(TPZGeoEl *gel, TPZCompMesh &mesh,
-                                    int64_t &index)
+TPZCompEl *CreateHCurlBoundLinearEl(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-    return new TPZCompElHCurl<pzshape::TPZShapeLinear>(mesh, gel, index);
+    return new TPZCompElHCurl<pzshape::TPZShapeLinear>(mesh, gel);
 }
 
-TPZCompEl *CreateHCurlBoundTriangleEl(TPZGeoEl *gel, TPZCompMesh &mesh,
-                                      int64_t &index)
+TPZCompEl *CreateHCurlBoundTriangleEl(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-    return new TPZCompElHCurl<pzshape::TPZShapeTriang>(mesh, gel, index);
+    return new TPZCompElHCurl<pzshape::TPZShapeTriang>(mesh, gel);
 }
 
-TPZCompEl *CreateHCurlBoundQuadEl(TPZGeoEl *gel, TPZCompMesh &mesh,
-                                  int64_t &index)
+TPZCompEl *CreateHCurlBoundQuadEl(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-    return new TPZCompElHCurl<pzshape::TPZShapeQuad>(mesh, gel, index);
+    return new TPZCompElHCurl<pzshape::TPZShapeQuad>(mesh, gel);
 }
 
-TPZCompEl *CreateHCurlLinearEl(TPZGeoEl *gel, TPZCompMesh &mesh,
-                               int64_t &index)
+TPZCompEl *CreateHCurlLinearEl(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-    return new TPZCompElHCurl<pzshape::TPZShapeLinear>(mesh, gel, index);
+    return new TPZCompElHCurl<pzshape::TPZShapeLinear>(mesh, gel);
 }
 
-TPZCompEl *CreateHCurlTriangleEl(TPZGeoEl *gel, TPZCompMesh &mesh,
-                                 int64_t &index)
+TPZCompEl *CreateHCurlTriangleEl(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-    return new TPZCompElHCurl<pzshape::TPZShapeTriang>(mesh, gel, index);
+    return new TPZCompElHCurl<pzshape::TPZShapeTriang>(mesh, gel);
 }
 
-TPZCompEl *CreateHCurlQuadEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index)
+TPZCompEl *CreateHCurlQuadEl(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-    return new TPZCompElHCurl<pzshape::TPZShapeQuad>(mesh, gel, index);
+    return new TPZCompElHCurl<pzshape::TPZShapeQuad>(mesh, gel);
 }
 
-TPZCompEl *CreateHCurlTetraEl(TPZGeoEl *gel, TPZCompMesh &mesh,int64_t &index)
+TPZCompEl *CreateHCurlTetraEl(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-    return new TPZCompElHCurl<pzshape::TPZShapeTetra>(mesh, gel, index);
+    return new TPZCompElHCurl<pzshape::TPZShapeTetra>(mesh, gel);
 }
 
-TPZCompEl *CreateHCurlCubeEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index)
+TPZCompEl *CreateHCurlCubeEl(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-    return new TPZCompElHCurl<pzshape::TPZShapeCube>(mesh, gel, index);
+    return new TPZCompElHCurl<pzshape::TPZShapeCube>(mesh, gel);
 }
 
-TPZCompEl *CreateHCurlPrismEl(TPZGeoEl *gel, TPZCompMesh &mesh,
-                              int64_t &index)
+TPZCompEl *CreateHCurlPrismEl(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-    return new TPZCompElHCurl<pzshape::TPZShapePrism>(mesh, gel, index);
+    return new TPZCompElHCurl<pzshape::TPZShapePrism>(mesh, gel);
 }
 
-TPZCompEl *CreateHCurlPyramEl(TPZGeoEl *gel, TPZCompMesh &mesh,
-                              int64_t &index) {
+TPZCompEl *CreateHCurlPyramEl(TPZGeoEl *gel, TPZCompMesh &mesh) {
   HCURL_EL_NOT_AVAILABLE
 }
 

--- a/Mesh/TPZCompElHCurl.h
+++ b/Mesh/TPZCompElHCurl.h
@@ -24,7 +24,7 @@ protected:
     TPZManVector<int64_t,TSHAPE::NSides - TSHAPE::NCornerNodes> fConnectIndexes =
         TPZManVector<int64_t,TSHAPE::NSides - TSHAPE::NCornerNodes>(TSHAPE::NSides-TSHAPE::NCornerNodes,-1);
 public:
-    TPZCompElHCurl(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+    TPZCompElHCurl(TPZCompMesh &mesh, TPZGeoEl *gel);
 	
     TPZCompElHCurl(TPZCompMesh &mesh, const TPZCompElHCurl<TSHAPE> &copy);
 	
@@ -190,35 +190,35 @@ protected:
 
 
 /** @brief Creates computational linear element for HCurl-conforming approximation space */
-TPZCompEl *CreateHCurlLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHCurlLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational quadrilateral element for HCurl-conforming approximation space */
-TPZCompEl *CreateHCurlQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHCurlQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational triangular element for HCurl-conforming approximation space */
-TPZCompEl *CreateHCurlTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHCurlTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational cube element for HCurl-conforming approximation space */
-TPZCompEl *CreateHCurlCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHCurlCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational prismal element for HCurl-conforming approximation space */
-TPZCompEl *CreateHCurlPrismEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHCurlPrismEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational pyramidal element for HCurl-conforming approximation space */
-TPZCompEl *CreateHCurlPyramEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHCurlPyramEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational tetrahedral element for HCurl-conforming approximation space */
-TPZCompEl *CreateHCurlTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHCurlTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational point element for HCurl-conforming approximation space */
-TPZCompEl *CreateHCurlBoundPointEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHCurlBoundPointEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational linear element for HCurl-conforming approximation space */
-TPZCompEl *CreateHCurlBoundLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHCurlBoundLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational quadrilateral element for HCurl-conforming approximation space */
-TPZCompEl *CreateHCurlBoundQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHCurlBoundQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational triangular element for HCurl-conforming approximation space */
-TPZCompEl *CreateHCurlBoundTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHCurlBoundTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
-TPZCompEl * CreateRefHCurlLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
-TPZCompEl * CreateRefHCurlQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
-TPZCompEl * CreateRefHCurlTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
-TPZCompEl * CreateRefHCurlCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
-TPZCompEl * CreateRefHCurlPrismEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
-TPZCompEl * CreateRefHCurlPyramEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
-TPZCompEl * CreateRefHCurlTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl * CreateRefHCurlLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh);
+TPZCompEl * CreateRefHCurlQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh);
+TPZCompEl * CreateRefHCurlTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh);
+TPZCompEl * CreateRefHCurlCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh);
+TPZCompEl * CreateRefHCurlPrismEl(TPZGeoEl *gel,TPZCompMesh &mesh);
+TPZCompEl * CreateRefHCurlPyramEl(TPZGeoEl *gel,TPZCompMesh &mesh);
+TPZCompEl * CreateRefHCurlTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 
 /** @} */

--- a/Mesh/TPZCompElHCurlNoGrads.cpp
+++ b/Mesh/TPZCompElHCurlNoGrads.cpp
@@ -20,8 +20,8 @@ TPZCompElHCurlNoGrads<TSHAPE>::TPZCompElHCurlNoGrads() : TPZCompElHCurl<TSHAPE>(
 
 template<class TSHAPE>
 TPZCompElHCurlNoGrads<TSHAPE>::TPZCompElHCurlNoGrads(
-  TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
-  TPZCompElHCurl<TSHAPE>(mesh,gel,index)
+  TPZCompMesh &mesh, TPZGeoEl *gel) :
+  TPZCompElHCurl<TSHAPE>(mesh,gel)
 {
     this->AdjustConnects();
 }

--- a/Mesh/TPZCompElHCurlNoGrads.h
+++ b/Mesh/TPZCompElHCurlNoGrads.h
@@ -18,7 +18,7 @@ public:
   //!Default constructor.
   TPZCompElHCurlNoGrads();
   //! Ctor taking mesh, geoel and returning index
-  TPZCompElHCurlNoGrads(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+  TPZCompElHCurlNoGrads(TPZCompMesh &mesh, TPZGeoEl *gel);
   /**
    * @brief Number of shapefunctions of the connect associated
    * @param connect connect number

--- a/Mesh/TPZCompElHDivCollapsed.cpp
+++ b/Mesh/TPZCompElHDivCollapsed.cpp
@@ -22,9 +22,9 @@ static int logger;
 #endif
 
 template<class TSHAPE>
-TPZCompElHDivCollapsed<TSHAPE>::TPZCompElHDivCollapsed(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
+TPZCompElHDivCollapsed<TSHAPE>::TPZCompElHDivCollapsed(TPZCompMesh &mesh, TPZGeoEl *gel) :
 TPZRegisterClassId(&TPZCompElHDivCollapsed::ClassId),
-TPZCompElHDiv<TSHAPE>(mesh,gel,index)
+TPZCompElHDiv<TSHAPE>(mesh,gel)
 {
 //    fbottom_c_index = -1; set at constructor in .h
 //    ftop_c_index = -1; set at constructor in .h

--- a/Mesh/TPZCompElHDivCollapsed.h
+++ b/Mesh/TPZCompElHDivCollapsed.h
@@ -35,7 +35,7 @@ protected:
     void InitMaterialDataT(TPZMaterialDataT<TVar> &data);
 public:
 	    
-	TPZCompElHDivCollapsed(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+	TPZCompElHDivCollapsed(TPZCompMesh &mesh, TPZGeoEl *gel);
 	
 	TPZCompElHDivCollapsed(TPZCompMesh &mesh, const TPZCompElHDivCollapsed<TSHAPE> &copy);
 	

--- a/Mesh/TPZCompElHDivConstant.cpp
+++ b/Mesh/TPZCompElHDivConstant.cpp
@@ -19,8 +19,8 @@ static TPZLogger logger("pz.strmatrix");
 #endif
 
 template<class TSHAPE>
-TPZCompElHDivConstant<TSHAPE>::TPZCompElHDivConstant(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
-TPZRegisterClassId(&TPZCompElHDivConstant::ClassId), TPZCompElHDiv<TSHAPE>(mesh,gel,index) {
+TPZCompElHDivConstant<TSHAPE>::TPZCompElHDivConstant(TPZCompMesh &mesh, TPZGeoEl *gel) :
+TPZRegisterClassId(&TPZCompElHDivConstant::ClassId), TPZCompElHDiv<TSHAPE>(mesh,gel) {
     this->AdjustConnects();
 }
 

--- a/Mesh/TPZCompElHDivConstant.h
+++ b/Mesh/TPZCompElHDivConstant.h
@@ -37,7 +37,7 @@ public:
 	    
 	TPZCompElHDivConstant();
     
-    TPZCompElHDivConstant(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+    TPZCompElHDivConstant(TPZCompMesh &mesh, TPZGeoEl *gel);
 	
     virtual void InitMaterialData(TPZMaterialData &data) override;
 

--- a/Mesh/TPZCompElHDivConstantBC.cpp
+++ b/Mesh/TPZCompElHDivConstantBC.cpp
@@ -36,8 +36,8 @@ void TPZCompElHDivConstantBC<TSHAPE>::AdjustConnects()
 }
 
 template<class TSHAPE>
-TPZCompElHDivConstantBC<TSHAPE>::TPZCompElHDivConstantBC(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index, int shapetype) :
-TPZRegisterClassId(&TPZCompElHDivConstantBC::ClassId), TPZCompElHDivBound2<TSHAPE>(mesh,gel,index), fShapeType(shapetype)  {
+TPZCompElHDivConstantBC<TSHAPE>::TPZCompElHDivConstantBC(TPZCompMesh &mesh, TPZGeoEl *gel, int shapetype) :
+TPZRegisterClassId(&TPZCompElHDivConstantBC::ClassId), TPZCompElHDivBound2<TSHAPE>(mesh,gel), fShapeType(shapetype)  {
     AdjustConnects();
 }
 

--- a/Mesh/TPZCompElHDivConstantBC.h
+++ b/Mesh/TPZCompElHDivConstantBC.h
@@ -34,7 +34,7 @@ public:
 	    
 	TPZCompElHDivConstantBC();
     
-    TPZCompElHDivConstantBC(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index, int shapetype = EHDivKernel);
+    TPZCompElHDivConstantBC(TPZCompMesh &mesh, TPZGeoEl *gel, int shapetype = EHDivKernel);
 	
 	virtual ~TPZCompElHDivConstantBC();
 

--- a/Mesh/TPZCompElHDivSBFem.cpp
+++ b/Mesh/TPZCompElHDivSBFem.cpp
@@ -22,14 +22,14 @@ static LoggerPtr logger(Logger::getLogger("pz.mesh.TPZCompElHDivSBFem"));
 
 // Initialize with the geometry of the SBFemVolume
 template<class TSHAPE>
-TPZCompElHDivSBFem<TSHAPE>::TPZCompElHDivSBFem(TPZCompMesh &mesh, TPZGeoEl *gel, TPZGeoElSide &gelside, int64_t &index) :
-TPZCompElHDivCollapsed<TSHAPE>(mesh, gel, index), fGeoElVolSide(gelside)
+TPZCompElHDivSBFem<TSHAPE>::TPZCompElHDivSBFem(TPZCompMesh &mesh, TPZGeoEl *gel, TPZGeoElSide &gelside) :
+TPZCompElHDivCollapsed<TSHAPE>(mesh, gel), fGeoElVolSide(gelside)
 {
 }
 
 template<class TSHAPE>
-TPZCompElHDivSBFem<TSHAPE>::TPZCompElHDivSBFem(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
-TPZCompElHDivCollapsed<TSHAPE>(mesh, gel, index), fGeoElVolSide(0)
+TPZCompElHDivSBFem<TSHAPE>::TPZCompElHDivSBFem(TPZCompMesh &mesh, TPZGeoEl *gel) :
+TPZCompElHDivCollapsed<TSHAPE>(mesh, gel), fGeoElVolSide(0)
 {
 }
 

--- a/Mesh/TPZCompElHDivSBFem.h
+++ b/Mesh/TPZCompElHDivSBFem.h
@@ -28,9 +28,9 @@ class TPZCompElHDivSBFem : public TPZCompElHDivCollapsed<TSHAPE> {
     
 public:
 	    
-	TPZCompElHDivSBFem(TPZCompMesh &mesh, TPZGeoEl *gel, TPZGeoElSide &gelside, int64_t &index);
+	TPZCompElHDivSBFem(TPZCompMesh &mesh, TPZGeoEl *gel, TPZGeoElSide &gelside);
 
-	TPZCompElHDivSBFem(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+	TPZCompElHDivSBFem(TPZCompMesh &mesh, TPZGeoEl *gel);
 	
 	TPZCompElHDivSBFem(TPZCompMesh &mesh, const TPZCompElHDivSBFem<TSHAPE> &copy);
 	
@@ -77,8 +77,8 @@ int TPZCompElHDivSBFem<TSHAPE>::ClassId() const{
 
 
 /** @brief Creates computational linear element for HDiv approximate space */
-TPZCompEl *CreateHDivColapsedLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivColapsedLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational quadrilateral element for HDiv approximate space */
-TPZCompEl *CreateHDivColapsedQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivColapsedQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational triangular element for HDiv approximate space */
-TPZCompEl *CreateHDivColapsedTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivColapsedTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh);

--- a/Mesh/TPZCompElKernelHDiv.cpp
+++ b/Mesh/TPZCompElKernelHDiv.cpp
@@ -15,8 +15,8 @@ static TPZLogger logger("pz.strmatrix");
 #endif
 
 template<class TSHAPE>
-TPZCompElKernelHDiv<TSHAPE>::TPZCompElKernelHDiv(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
-TPZRegisterClassId(&TPZCompElKernelHDiv::ClassId), TPZCompElH1<TSHAPE>(mesh,gel,index) {
+TPZCompElKernelHDiv<TSHAPE>::TPZCompElKernelHDiv(TPZCompMesh &mesh, TPZGeoEl *gel) :
+TPZRegisterClassId(&TPZCompElKernelHDiv::ClassId), TPZCompElH1<TSHAPE>(mesh,gel) {
 
 }
 

--- a/Mesh/TPZCompElKernelHDiv.h
+++ b/Mesh/TPZCompElKernelHDiv.h
@@ -39,7 +39,7 @@ public:
 	    
 	TPZCompElKernelHDiv();
     
-    TPZCompElKernelHDiv(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+    TPZCompElKernelHDiv(TPZCompMesh &mesh, TPZGeoEl *gel);
 	
     virtual void InitMaterialData(TPZMaterialData &data) override;
 

--- a/Mesh/TPZCompElKernelHDiv3D.cpp
+++ b/Mesh/TPZCompElKernelHDiv3D.cpp
@@ -29,8 +29,8 @@ static TPZLogger logger("pz.strmatrix");
 using namespace std;
 
 template<class TSHAPE>
-TPZCompElKernelHDiv3D<TSHAPE>::TPZCompElKernelHDiv3D(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index, int shapetype) :
-TPZRegisterClassId(&TPZCompElKernelHDiv3D::ClassId), TPZCompElHCurlNoGrads<TSHAPE>(mesh,gel,index), fSideOrient(TSHAPE::NFacets,1), fShapeType(shapetype) {
+TPZCompElKernelHDiv3D<TSHAPE>::TPZCompElKernelHDiv3D(TPZCompMesh &mesh, TPZGeoEl *gel, int shapetype) :
+TPZRegisterClassId(&TPZCompElKernelHDiv3D::ClassId), TPZCompElHCurlNoGrads<TSHAPE>(mesh,gel), fSideOrient(TSHAPE::NFacets,1), fShapeType(shapetype) {
     int firstside = TSHAPE::NSides-TSHAPE::NFacets-1;
     for(int side = firstside ; side < TSHAPE::NSides-1; side++ )
     {

--- a/Mesh/TPZCompElKernelHDiv3D.h
+++ b/Mesh/TPZCompElKernelHDiv3D.h
@@ -36,7 +36,7 @@ class TPZCompElKernelHDiv3D : public TPZCompElHCurlNoGrads<TSHAPE> {
 
 public:
 	    
-	TPZCompElKernelHDiv3D(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index, int shapetype = EHDivKernel);
+	TPZCompElKernelHDiv3D(TPZCompMesh &mesh, TPZGeoEl *gel, int shapetype = EHDivKernel);
 	
 	TPZCompElKernelHDiv3D(){};
 	

--- a/Mesh/TPZCompElKernelHDivBC.cpp
+++ b/Mesh/TPZCompElKernelHDivBC.cpp
@@ -9,8 +9,8 @@
 #include "TPZShapeHDivKernel2DBound.h"
 
 template<class TSHAPE>
-TPZCompElKernelHDivBC<TSHAPE>::TPZCompElKernelHDivBC(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
-TPZRegisterClassId(&TPZCompElKernelHDivBC::ClassId), TPZCompElH1<TSHAPE>(mesh,gel,index) {
+TPZCompElKernelHDivBC<TSHAPE>::TPZCompElKernelHDivBC(TPZCompMesh &mesh, TPZGeoEl *gel) :
+TPZRegisterClassId(&TPZCompElKernelHDivBC::ClassId), TPZCompElH1<TSHAPE>(mesh,gel) {
 
 }
 

--- a/Mesh/TPZCompElKernelHDivBC.h
+++ b/Mesh/TPZCompElKernelHDivBC.h
@@ -29,7 +29,7 @@ class TPZCompElKernelHDivBC : public TPZCompElH1<TSHAPE>  {
 public:	    
 	TPZCompElKernelHDivBC();
     
-    TPZCompElKernelHDivBC(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+    TPZCompElKernelHDivBC(TPZCompMesh &mesh, TPZGeoEl *gel);
 	
 	virtual ~TPZCompElKernelHDivBC();
 

--- a/Mesh/TPZCompElKernelHDivBC3D.cpp
+++ b/Mesh/TPZCompElKernelHDivBC3D.cpp
@@ -14,8 +14,8 @@ static TPZLogger logger("pz.strmatrix");
 #endif
 
 template<class TSHAPE>
-TPZCompElKernelHDivBC3D<TSHAPE>::TPZCompElKernelHDivBC3D(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index, int shapetype) :
-TPZRegisterClassId(&TPZCompElKernelHDivBC3D::ClassId), TPZCompElHCurlNoGrads<TSHAPE>(mesh,gel,index), fShapeType(shapetype)  {
+TPZCompElKernelHDivBC3D<TSHAPE>::TPZCompElKernelHDivBC3D(TPZCompMesh &mesh, TPZGeoEl *gel, int shapetype) :
+TPZRegisterClassId(&TPZCompElKernelHDivBC3D::ClassId), TPZCompElHCurlNoGrads<TSHAPE>(mesh,gel), fShapeType(shapetype)  {
 
 }
 

--- a/Mesh/TPZCompElKernelHDivBC3D.h
+++ b/Mesh/TPZCompElKernelHDivBC3D.h
@@ -39,7 +39,7 @@ public:
 	    
 	TPZCompElKernelHDivBC3D();
     
-    TPZCompElKernelHDivBC3D(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index, int shapetype = EHDivKernel);
+    TPZCompElKernelHDivBC3D(TPZCompMesh &mesh, TPZGeoEl *gel, int shapetype = EHDivKernel);
 	
     virtual void InitMaterialData(TPZMaterialData &data) override;
 

--- a/Mesh/TPZCompElLagrange.h
+++ b/Mesh/TPZCompElLagrange.h
@@ -53,8 +53,8 @@ public:
         
     }
     
-    TPZCompElLagrange(TPZCompMesh &mesh, int64_t connect1, int idf1, int64_t connect2, int idf2, int64_t &index) : TPZRegisterClassId(&TPZCompElLagrange::ClassId),
-    TPZCompEl(mesh,0,index), fDef(1)
+    TPZCompElLagrange(TPZCompMesh &mesh, int64_t connect1, int idf1, int64_t connect2, int idf2) : TPZRegisterClassId(&TPZCompElLagrange::ClassId),
+    TPZCompEl(mesh,0), fDef(1)
     {
         fDef[0].fConnect[0] = connect1;
         fDef[0].fConnect[1] = connect2;
@@ -74,21 +74,11 @@ public:
 #endif
     }
     
-    TPZCompElLagrange(TPZCompMesh &mesh, const TPZVec<TLagrange> &Dependencies, int64_t &index) : TPZRegisterClassId(&TPZCompElLagrange::ClassId),
-    TPZCompEl(mesh,0,index), fDef(Dependencies)
+    TPZCompElLagrange(TPZCompMesh &mesh, const TPZVec<TLagrange> &Dependencies) : TPZRegisterClassId(&TPZCompElLagrange::ClassId),
+    TPZCompEl(mesh,0), fDef(Dependencies)
     {
     }
     
-	/** @brief Put a copy of the element in the referred mesh */
-	TPZCompElLagrange(TPZCompMesh &mesh, const TPZCompEl &copy) : TPZRegisterClassId(&TPZCompElLagrange::ClassId),
-    TPZCompEl(mesh,copy)
-    {
-        const TPZCompElLagrange *lcop = dynamic_cast<const TPZCompElLagrange *>(&copy);
-        if (!lcop) {
-            DebugStop();
-        }
-        fDef = lcop->fDef;
-    }
 	
 	/** @brief Put a copy of the element in the patch mesh */
 	TPZCompElLagrange(TPZCompMesh &mesh, const TPZCompEl &copy, std::map<int64_t,int64_t> &gl2lcElMap) : TPZRegisterClassId(&TPZCompElLagrange::ClassId),
@@ -102,9 +92,9 @@ public:
         
     }
 	
-	/** @brief Copy of the element in the new mesh with alocated index */
-	TPZCompElLagrange(TPZCompMesh &mesh, const TPZCompEl &copy, int64_t &index) : TPZRegisterClassId(&TPZCompElLagrange::ClassId),
-    TPZCompEl(mesh,copy,index)
+	/** @brief Copy of the element in the new mesh */
+	TPZCompElLagrange(TPZCompMesh &mesh, const TPZCompEl &copy) : TPZRegisterClassId(&TPZCompElLagrange::ClassId),
+    TPZCompEl(mesh,copy)
     {
         const TPZCompElLagrange *lcop = dynamic_cast<const TPZCompElLagrange *>(&copy);
         if (!lcop) {

--- a/Mesh/TPZCompMeshTools.cpp
+++ b/Mesh/TPZCompMeshTools.cpp
@@ -354,8 +354,8 @@ void TPZCompMeshTools::GroupElements(TPZCompMesh *cmesh, std::set<int64_t> elbas
         }
         if (elgroup.size()) {
             elgroup.insert(el);
-            int64_t grindex;
-            TPZElementGroup *elgr = new TPZElementGroup(*cmesh,grindex);
+            TPZElementGroup *elgr = new TPZElementGroup(*cmesh);
+            const int64_t grindex = elgr->Index();
             for (std::set<int64_t>::iterator it = elgroup.begin(); it != elgroup.end(); it++) {
                 elgr->AddElement(cmesh->Element(*it));
             }
@@ -414,8 +414,8 @@ void TPZCompMeshTools::GroupElements(TPZCompMesh *cmesh)
         }
         if (elgroup.size()) {
             elgroup.insert(el);
-            int64_t grindex;
-            TPZElementGroup *elgr = new TPZElementGroup(*cmesh,grindex);
+            TPZElementGroup *elgr = new TPZElementGroup(*cmesh);
+            const int64_t grindex = elgr->Index();
             for (std::set<int64_t>::iterator it = elgroup.begin(); it != elgroup.end(); it++) {
                 elgr->AddElement(cmesh->Element(*it));
                 grouped.insert(*it);
@@ -462,8 +462,8 @@ void TPZCompMeshTools::UnCondensedElements(TPZCompMesh *cmesh){
 void TPZCompMeshTools::PutinSubmeshes(TPZCompMesh *cmesh, std::map<int64_t,std::set<int64_t> >&elindices, std::map<int64_t,int64_t> &indices, int KeepOneLagrangian)
 {
     for (std::map<int64_t,std::set<int64_t> >::iterator it = elindices.begin(); it != elindices.end(); it++) {
-        int64_t index;
-        TPZSubCompMesh *subcmesh = new TPZSubCompMesh(*cmesh,index);
+        TPZSubCompMesh *subcmesh = new TPZSubCompMesh(*cmesh);
+        const int64_t index = subcmesh->Index();
         indices[it->first] = index;
         for (std::set<int64_t>::iterator itloc = it->second.begin(); itloc != it->second.end(); itloc++) {
             subcmesh->TransferElement(cmesh, *itloc);
@@ -520,7 +520,8 @@ void TPZCompMeshTools::PutinSubmeshes(TPZCompMesh *cmesh, std::map<int64_t,std::
 /// Put the element set into a subcompmesh and make the connects internal
 void TPZCompMeshTools::PutinSubmeshes(TPZCompMesh *cmesh, std::set<int64_t> &elindices, int64_t &index, int KeepOneLagrangian)
 {
-    TPZSubCompMesh *subcmesh = new TPZSubCompMesh(*cmesh,index);
+    TPZSubCompMesh *subcmesh = new TPZSubCompMesh(*cmesh);
+    index = subcmesh->Index();
     for (std::set<int64_t>::iterator it = elindices.begin(); it != elindices.end(); it++) {
         subcmesh->TransferElement(cmesh, *it);
     }
@@ -1069,8 +1070,8 @@ void TPZCompMeshTools::GroupNeighbourElements(TPZCompMesh *cmesh, const std::set
     for(auto el : seed_elements)
     {
         elhandled[el] = 1;
-        int64_t index;
-        TPZElementGroup *elgr = new TPZElementGroup(*cmesh,index);
+        TPZElementGroup *elgr = new TPZElementGroup(*cmesh);
+        const int64_t index = elgr->Index();
         if(index < nel) elhandled[index] = 1;
         groupindexes.insert(index);
         TPZCompEl *cel = cmesh->Element(el);

--- a/Mesh/TPZInterfaceEl.cpp
+++ b/Mesh/TPZInterfaceEl.cpp
@@ -114,10 +114,10 @@ TPZInterfaceElement::~TPZInterfaceElement() {
     }
 }
 
-TPZInterfaceElement::TPZInterfaceElement(TPZCompMesh &mesh,TPZGeoEl *geo,int64_t &index,
+TPZInterfaceElement::TPZInterfaceElement(TPZCompMesh &mesh,TPZGeoEl *geo,
                                          TPZCompElSide& left, TPZCompElSide& right)
 : TPZRegisterClassId(&TPZInterfaceElement::ClassId),
-TPZCompEl(mesh,geo,index)
+TPZCompEl(mesh,geo)
 {
 	
 	geo->SetReference(this);
@@ -136,53 +136,13 @@ TPZCompEl(mesh,geo,index)
 	this->IncrementElConnected();
 }
 
-TPZInterfaceElement::TPZInterfaceElement(TPZCompMesh &mesh,TPZGeoEl *geo,int64_t &index)
+TPZInterfaceElement::TPZInterfaceElement(TPZCompMesh &mesh,TPZGeoEl *geo)
 : TPZRegisterClassId(&TPZInterfaceElement::ClassId),
-TPZCompEl(mesh,geo,index), fLeftElSide(), fRightElSide(){
-	geo->SetReference(this);
-	geo->IncrementNumInterfaces();
-	this->IncrementElConnected();
+TPZCompEl(mesh,geo), fLeftElSide(), fRightElSide(){
+    geo->SetReference(this);
+    geo->IncrementNumInterfaces();
+    this->IncrementElConnected();
 }
-
-TPZInterfaceElement::TPZInterfaceElement(TPZCompMesh &mesh, const TPZInterfaceElement &copy)
-: TPZRegisterClassId(&TPZInterfaceElement::ClassId),
-TPZCompEl(mesh,copy) {
-	
-	this->fLeftElSide.SetElement( mesh.ElementVec()[copy.fLeftElSide.Element()->Index()] );
-	this->fLeftElSide.SetSide( copy.fLeftElSide.Side() );
-	
-	this->fRightElSide.SetElement( mesh.ElementVec()[copy.fRightElSide.Element()->Index()] );
-	this->fRightElSide.SetSide( copy.fRightElSide.Side() );
-	
-#ifdef PZDEBUG
-	if( !fLeftElSide.Element() || ! fRightElSide.Element() ) {
-		cout << "Something wrong with clone of interface element\n";
-		DebugStop();
-	}
-	if(fLeftElSide.Element()->Mesh() != &mesh || fRightElSide.Element()->Mesh() != &mesh) {
-		cout << "The discontinuous elements should be cloned before the interface elements\n";
-		DebugStop();
-	}
-#endif
-	
-    if (copy.fIntegrationRule) {
-        fIntegrationRule = copy.fIntegrationRule->Clone();
-    }
-	fCenterNormal = copy.fCenterNormal;
-	
-	//TPZMaterial * mat = copy.Material();
-	
-	this->IncrementElConnected();
-	
-	if (this->Reference()){
-		this->Reference()->IncrementNumInterfaces();
-	}
-	else{
-		PZError << "ERROR at " << __PRETTY_FUNCTION__ << " at line " << __LINE__ << " - this->Reference() is NULL\n";
-		DebugStop();
-	}
-}
-
 
 TPZInterfaceElement::TPZInterfaceElement(TPZCompMesh &mesh,
                                          const TPZInterfaceElement &copy,
@@ -239,9 +199,9 @@ TPZRegisterClassId(&TPZInterfaceElement::ClassId),TPZCompEl(mesh,copy)
 
 
 
-TPZInterfaceElement::TPZInterfaceElement(TPZCompMesh &mesh,const TPZInterfaceElement &copy,int64_t &index)
+TPZInterfaceElement::TPZInterfaceElement(TPZCompMesh &mesh,const TPZInterfaceElement &copy)
 : TPZRegisterClassId(&TPZInterfaceElement::ClassId),
-TPZCompEl(mesh,copy,index) {
+TPZCompEl(mesh,copy) {
 	
 	//ambos elementos esquerdo e direito j�foram clonados e moram na malha aglomerada
 	//o geometrico da malha fina aponta para o computacional da malha aglomerada
@@ -286,8 +246,8 @@ fCenterNormal(3,0.)
 	//NOTHING TO BE DONE HERE
 }
 
-TPZCompEl * TPZInterfaceElement::CloneInterface(TPZCompMesh &aggmesh,int64_t &index, /*TPZCompElDisc **/TPZCompElSide &left, /*TPZCompElDisc **/TPZCompElSide &right) const {
-	return  new TPZInterfaceElement(aggmesh, this->Reference(), index, left, right);
+TPZCompEl * TPZInterfaceElement::CloneInterface(TPZCompMesh &aggmesh, /*TPZCompElDisc **/TPZCompElSide &left, /*TPZCompElDisc **/TPZCompElSide &right) const {
+	return  new TPZInterfaceElement(aggmesh, this->Reference(), left, right);
 }
 
 template<class TVar>

--- a/Mesh/TPZInterfaceEl.h
+++ b/Mesh/TPZInterfaceEl.h
@@ -163,7 +163,7 @@ public:
 	enum CalcStiffOptions{ENone = -1, EStandard /*Deprecated*/ = 0, EPenalty, EContDisc,EReferred};
 	
 	/** @brief Constuctor to continuous and/or discontinuous neighbours. */
-	TPZInterfaceElement(TPZCompMesh &mesh,TPZGeoEl *geo,int64_t &index,TPZCompElSide & left, TPZCompElSide &right);
+	TPZInterfaceElement(TPZCompMesh &mesh,TPZGeoEl *geo,TPZCompElSide & left, TPZCompElSide &right);
 	
 	/** @brief Simple copy constructor. */
 	TPZInterfaceElement(TPZCompMesh &mesh, const TPZInterfaceElement &copy);
@@ -180,14 +180,12 @@ public:
 						std::map<int64_t,int64_t> &gl2lcConIdx,
 						std::map<int64_t,int64_t> &gl2lcElIdx);
 
-	/** @brief Copy constructor with specified index */
-	TPZInterfaceElement(TPZCompMesh &mesh, const TPZInterfaceElement &copy, int64_t &index);
 	
 	/** @brief Empty constructor. */
 	TPZInterfaceElement();
 	
 	/** @brief Default TPZCompEl constructor. SetLeftRightElements must be called before any computation. */
-	TPZInterfaceElement(TPZCompMesh &mesh,TPZGeoEl *geo,int64_t &index);
+	TPZInterfaceElement(TPZCompMesh &mesh,TPZGeoEl *geo);
 	
 	/** @brief Destructor */
 	~TPZInterfaceElement();
@@ -210,7 +208,7 @@ public:
 	}
 	
 	/** @brief Method used in TPZAgglomerateElement::CreateAgglomerateMesh */
-	TPZCompEl * CloneInterface(TPZCompMesh &aggmesh,int64_t &index, /*TPZCompElDisc **/TPZCompElSide & left, /*TPZCompElDisc **/ TPZCompElSide &right) const;
+	TPZCompEl * CloneInterface(TPZCompMesh &aggmesh, /*TPZCompElDisc **/TPZCompElSide & left, /*TPZCompElDisc **/ TPZCompElSide &right) const;
 	
 	/** @brief Identifies the elements of left and right volume of the interface */
 	void VolumeEls(TPZCompEl &thirdel);

--- a/Mesh/TPZMultiphysicsInterfaceEl.cpp
+++ b/Mesh/TPZMultiphysicsInterfaceEl.cpp
@@ -39,8 +39,8 @@ TPZCompEl(),fLeftElSide(0), fRightElSide(0)
 {
 }
 
-TPZMultiphysicsInterfaceElement::TPZMultiphysicsInterfaceElement(TPZCompMesh &mesh, TPZGeoEl *ref, int64_t &index) :
-TPZRegisterClassId(&TPZMultiphysicsInterfaceElement::ClassId),TPZCompEl(mesh, ref, index),fLeftElSide(0), fRightElSide(0)
+TPZMultiphysicsInterfaceElement::TPZMultiphysicsInterfaceElement(TPZCompMesh &mesh, TPZGeoEl *ref) :
+TPZRegisterClassId(&TPZMultiphysicsInterfaceElement::ClassId),TPZCompEl(mesh, ref),fLeftElSide(0), fRightElSide(0)
 {
     
     ref->SetReference(this);
@@ -53,9 +53,9 @@ TPZRegisterClassId(&TPZMultiphysicsInterfaceElement::ClassId),TPZCompEl(mesh, re
     ref->IncrementNumInterfaces();
 }
 
-TPZMultiphysicsInterfaceElement::TPZMultiphysicsInterfaceElement(TPZCompMesh &mesh, TPZGeoEl *ref, int64_t &index,
+TPZMultiphysicsInterfaceElement::TPZMultiphysicsInterfaceElement(TPZCompMesh &mesh, TPZGeoEl *ref,
                                                                     TPZCompElSide leftside, TPZCompElSide rightside) : 
-TPZRegisterClassId(&TPZMultiphysicsInterfaceElement::ClassId),TPZCompEl(mesh, ref, index)
+TPZRegisterClassId(&TPZMultiphysicsInterfaceElement::ClassId),TPZCompEl(mesh, ref)
 {
 	
 	ref->SetReference(this);

--- a/Mesh/TPZMultiphysicsInterfaceEl.h
+++ b/Mesh/TPZMultiphysicsInterfaceEl.h
@@ -60,10 +60,10 @@ public:
 	TPZMultiphysicsInterfaceElement();
 	
 	/** @brief Constructor */
-	TPZMultiphysicsInterfaceElement(TPZCompMesh &mesh, TPZGeoEl *ref, int64_t &index, TPZCompElSide left, TPZCompElSide right);
+	TPZMultiphysicsInterfaceElement(TPZCompMesh &mesh, TPZGeoEl *ref, TPZCompElSide left, TPZCompElSide right);
     
     /** @brief Constructor */
-    TPZMultiphysicsInterfaceElement(TPZCompMesh &mesh, TPZGeoEl *ref, int64_t &index);
+    TPZMultiphysicsInterfaceElement(TPZCompMesh &mesh, TPZGeoEl *ref);
     
     /** @brief create a copy of the given element */
     TPZMultiphysicsInterfaceElement(TPZCompMesh &mesh, const TPZMultiphysicsInterfaceElement &copy);

--- a/Mesh/TPZSBFemElementGroup.cpp
+++ b/Mesh/TPZSBFemElementGroup.cpp
@@ -60,7 +60,7 @@ static LoggerPtr loggerstiffnessbubble(Logger::getLogger("pz.mesh.sbfemstiffness
 static LoggerPtr loggersbfemstifnessdata(Logger::getLogger("pz.mesh.sbfemstifnessdata"));
 #endif
 
-TPZSBFemElementGroup::TPZSBFemElementGroup(TPZCompMesh &mesh, int64_t &index) : TPZElementGroup(mesh,index)
+TPZSBFemElementGroup::TPZSBFemElementGroup(TPZCompMesh &mesh) : TPZElementGroup(mesh)
 {
     fInternalPolynomialOrder = TPZSBFemElementGroup::gDefaultPolynomialOrder;
     fPolynomialShapeFunctions = TPZSBFemElementGroup::gPolynomialShapeFunctions;

--- a/Mesh/TPZSBFemElementGroup.h
+++ b/Mesh/TPZSBFemElementGroup.h
@@ -88,7 +88,7 @@ public:
     }
     
     /// constructor
-    TPZSBFemElementGroup(TPZCompMesh &mesh, int64_t &index);
+    TPZSBFemElementGroup(TPZCompMesh &mesh);
     
     /** @brief add an element to the element group
      */

--- a/Mesh/TPZSBFemMultiphysicsElGroup.cpp
+++ b/Mesh/TPZSBFemMultiphysicsElGroup.cpp
@@ -110,8 +110,9 @@ void TPZSBFemMultiphysicsElGroup::GroupandCondense(set<int> & condensedmatid)
 #ifdef PZDEBUG
     if (fElGroup.size() == 0 || condensedmatid.size() == 0) DebugStop();
 #endif
-    int64_t index;
-    fCondensedEls = new TPZElementGroup(*Mesh(), index);
+
+    fCondensedEls = new TPZElementGroup(*Mesh());
+    const int64_t index = fCondensedEls->Index();
 
     for (auto celvol : fElGroup)
     {

--- a/Mesh/TPZSBFemMultiphysicsElGroup.h
+++ b/Mesh/TPZSBFemMultiphysicsElGroup.h
@@ -54,7 +54,7 @@ public:
     }
     
     /// constructor
-    TPZSBFemMultiphysicsElGroup(TPZCompMesh &mesh, int64_t &index) : TPZSBFemElementGroup(mesh,index)
+    TPZSBFemMultiphysicsElGroup(TPZCompMesh &mesh) : TPZSBFemElementGroup(mesh)
     { 
     }
 

--- a/Mesh/TPZSBFemVolume.cpp
+++ b/Mesh/TPZSBFemVolume.cpp
@@ -31,7 +31,7 @@ static LoggerPtr loggerLBF(Logger::getLogger("pz.mesh.sbfemvolume.bodyloads"));
 static LoggerPtr loggerEvaluateError(Logger::getLogger("pz.mesh.sbfemvolume.error"));
 #endif
 
-TPZSBFemVolume::TPZSBFemVolume(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) : TPZInterpolationSpace(mesh, gel, index), fElementGroupIndex(-1), fSkeleton(-1), fDensity(1.) {
+TPZSBFemVolume::TPZSBFemVolume(TPZCompMesh &mesh, TPZGeoEl *gel) : TPZInterpolationSpace(mesh, gel), fElementGroupIndex(-1), fSkeleton(-1), fDensity(1.) {
 
 }
 
@@ -252,9 +252,9 @@ void TPZSBFemVolume::ExtendShapeFunctions(TPZMaterialDataT<STATE> &data1d, TPZMa
     TPZInterpolationSpace::Convert2Axes(data2d.fDPhi, data2d.jacinv, data2d.dphix);
 }
 
-TPZCompEl * CreateSBFemCompEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index)
+TPZCompEl * CreateSBFemCompEl(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-    return new TPZSBFemVolume(mesh, gel, index);
+    return new TPZSBFemVolume(mesh, gel);
 }
 
 /// initialize the data structures of the eigenvectors and eigenvalues associated with this volume element

--- a/Mesh/TPZSBFemVolume.h
+++ b/Mesh/TPZSBFemVolume.h
@@ -64,7 +64,7 @@ protected:
     void AdjustAxes3D(const TPZFMatrix<REAL> &axes2D, TPZFMatrix<REAL> &axes3D, TPZFMatrix<REAL> &jac3D, TPZFMatrix<REAL> &jacinv3D, REAL detjac);
 public:
     
-    TPZSBFemVolume(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+    TPZSBFemVolume(TPZCompMesh &mesh, TPZGeoEl *gel);
     
     virtual ~TPZSBFemVolume()
     {
@@ -394,7 +394,7 @@ public:
 };
 
 
-TPZCompEl * CreateSBFemCompEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl * CreateSBFemCompEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 
 

--- a/Mesh/TPZSBFemVolumeHdiv.cpp
+++ b/Mesh/TPZSBFemVolumeHdiv.cpp
@@ -26,7 +26,7 @@
 // static LoggerPtr logger(Logger::getLogger("pz.mesh.sbfemvolume"));
 // #endif
 
-TPZSBFemVolumeHdiv::TPZSBFemVolumeHdiv(TPZCompMesh & mesh, TPZGeoEl * gel, int64_t & index) : TPZInterpolationSpace(mesh, gel, index), fElementGroupIndex(-1), fSkeleton(-1)
+TPZSBFemVolumeHdiv::TPZSBFemVolumeHdiv(TPZCompMesh & mesh, TPZGeoEl * gel) : TPZInterpolationSpace(mesh, gel), fElementGroupIndex(-1), fSkeleton(-1)
 {
     fElementVec1D.Resize(3);
 }
@@ -266,7 +266,7 @@ int TPZSBFemVolumeHdiv::NConnects() const
     return fConnectIndexes.size();   
 }
 
-TPZCompEl * CreateSBFemFluxCompEl(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index)
+TPZCompEl * CreateSBFemFluxCompEl(TPZCompMesh &mesh, TPZGeoEl *gel)
 {
-    return new TPZSBFemVolumeHdiv(mesh, gel, index);    
+    return new TPZSBFemVolumeHdiv(mesh, gel);    
 }

--- a/Mesh/TPZSBFemVolumeHdiv.h
+++ b/Mesh/TPZSBFemVolumeHdiv.h
@@ -71,7 +71,7 @@ class TPZSBFemVolumeHdiv : public TPZInterpolationSpace
 
 public:
     
-    TPZSBFemVolumeHdiv(TPZCompMesh & mesh, TPZGeoEl * gel, int64_t & index);
+    TPZSBFemVolumeHdiv(TPZCompMesh & mesh, TPZGeoEl * gel);
     
     virtual ~TPZSBFemVolumeHdiv()
     {
@@ -177,4 +177,4 @@ public:
     };
 };
 
-TPZCompEl * CreateSBFemFluxCompEl(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+TPZCompEl * CreateSBFemFluxCompEl(TPZCompMesh &mesh, TPZGeoEl *gel);

--- a/Mesh/TPZSBFemVolumeL2.cpp
+++ b/Mesh/TPZSBFemVolumeL2.cpp
@@ -25,7 +25,7 @@
 // static LoggerPtr logger(Logger::getLogger("pz.mesh.sbfemvolume"));
 // #endif
 
-TPZSBFemVolumeL2::TPZSBFemVolumeL2(TPZCompMesh & mesh, TPZGeoEl * gel, int64_t & index) : TPZSBFemVolume(mesh, gel, index)
+TPZSBFemVolumeL2::TPZSBFemVolumeL2(TPZCompMesh & mesh, TPZGeoEl * gel) : TPZSBFemVolume(mesh, gel)
 {
     fElementVec1D.Resize(3);
 }
@@ -174,7 +174,7 @@ void TPZSBFemVolumeL2::ReallyComputeSolution(TPZMaterialDataT<STATE> & data)
 
 #include "pzaxestools.h"
 
-TPZCompEl * CreateSBFemPressureCompEl(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index)
+TPZCompEl * CreateSBFemPressureCompEl(TPZCompMesh &mesh, TPZGeoEl *gel)
 {
-    return new TPZSBFemVolumeL2(mesh, gel, index);    
+    return new TPZSBFemVolumeL2(mesh, gel);
 }

--- a/Mesh/TPZSBFemVolumeL2.h
+++ b/Mesh/TPZSBFemVolumeL2.h
@@ -64,7 +64,7 @@ class TPZSBFemVolumeL2 : public TPZSBFemVolume
 
 public:
     
-    TPZSBFemVolumeL2(TPZCompMesh & mesh, TPZGeoEl * gel, int64_t & index);
+    TPZSBFemVolumeL2(TPZCompMesh & mesh, TPZGeoEl * gel);
     
     virtual ~TPZSBFemVolumeL2()
     {
@@ -206,4 +206,4 @@ public:
     }
 };
 
-TPZCompEl * CreateSBFemPressureCompEl(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+TPZCompEl * CreateSBFemPressureCompEl(TPZCompMesh &mesh, TPZGeoEl *gel);

--- a/Mesh/TPZSBFemVolumeMultiphysics.cpp
+++ b/Mesh/TPZSBFemVolumeMultiphysics.cpp
@@ -38,7 +38,7 @@ static LoggerPtr logger(Logger::getLogger("pz.mesh.sbfemvolume"));
 #endif
 
 template<class TGeometry>
-TPZSBFemVolumeMultiphysics<TGeometry>::TPZSBFemVolumeMultiphysics(TPZCompMesh & mesh, TPZGeoEl * gel, int64_t & index) : TPZMultiphysicsCompEl<TGeometry>(mesh, gel, index)
+TPZSBFemVolumeMultiphysics<TGeometry>::TPZSBFemVolumeMultiphysics(TPZCompMesh & mesh, TPZGeoEl * gel) : TPZMultiphysicsCompEl<TGeometry>(mesh, gel)
 {
     fElementVec1D.Resize(7);
 }
@@ -565,24 +565,24 @@ int TPZSBFemVolumeMultiphysics<TGeometry>::NShapeF() const
     return nshape;
 }
 
-TPZCompEl * CreateSBFemMultiphysicsLinearEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index)
+TPZCompEl * CreateSBFemMultiphysicsLinearEl(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-    return new TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoLinear>(mesh, gel, index);    
+    return new TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoLinear>(mesh, gel);
 }
 
-TPZCompEl * CreateSBFemMultiphysicsQuadEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index)
+TPZCompEl * CreateSBFemMultiphysicsQuadEl(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-    return new TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad>(mesh, gel, index);    
+    return new TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoQuad>(mesh, gel);
 }
 
-TPZCompEl * CreateSBFemMultiphysicsCubeEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index)
+TPZCompEl * CreateSBFemMultiphysicsCubeEl(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-    return new TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoCube>(mesh, gel, index);    
+    return new TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoCube>(mesh, gel);
 }
 
-TPZCompEl * CreateSBFemMultiphysicsPrismaEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index)
+TPZCompEl * CreateSBFemMultiphysicsPrismaEl(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-    return new TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoPrism>(mesh, gel, index);    
+    return new TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoPrism>(mesh, gel);    
 }
 
 template class TPZSBFemVolumeMultiphysics<pzgeom::TPZGeoPoint>;

--- a/Mesh/TPZSBFemVolumeMultiphysics.h
+++ b/Mesh/TPZSBFemVolumeMultiphysics.h
@@ -63,7 +63,7 @@ class TPZSBFemVolumeMultiphysics : public TPZMultiphysicsCompEl<TGeometry>
 
 public:
     
-    TPZSBFemVolumeMultiphysics(TPZCompMesh & mesh, TPZGeoEl * gel, int64_t & index);
+    TPZSBFemVolumeMultiphysics(TPZCompMesh & mesh, TPZGeoEl * gel);
     
     virtual ~TPZSBFemVolumeMultiphysics()
     {
@@ -169,10 +169,10 @@ public:
     }
 };
 
-TPZCompEl * CreateSBFemMultiphysicsLinearEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
+TPZCompEl * CreateSBFemMultiphysicsLinearEl(TPZGeoEl *gel, TPZCompMesh &mesh);
 
-TPZCompEl * CreateSBFemMultiphysicsQuadEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
+TPZCompEl * CreateSBFemMultiphysicsQuadEl(TPZGeoEl *gel, TPZCompMesh &mesh);
 
-TPZCompEl * CreateSBFemMultiphysicsCubeEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
+TPZCompEl * CreateSBFemMultiphysicsCubeEl(TPZGeoEl *gel, TPZCompMesh &mesh);
 
-TPZCompEl * CreateSBFemMultiphysicsPrismaEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
+TPZCompEl * CreateSBFemMultiphysicsPrismaEl(TPZGeoEl *gel, TPZCompMesh &mesh);

--- a/Mesh/pzcmesh.cpp
+++ b/Mesh/pzcmesh.cpp
@@ -421,7 +421,6 @@ void TPZCompMesh::AutoBuildContDisc(const TPZVec<TPZGeoEl*> &continuous, const T
 	int64_t nelem = elvec.NElements();
 	
 	int64_t neltocreate = 0;
-	int64_t index;
 	for(int64_t i=0; i<nelem; i++) {
 		TPZGeoEl *gel = elvec[i];
 		if(!gel) continue;
@@ -447,7 +446,7 @@ void TPZCompMesh::AutoBuildContDisc(const TPZVec<TPZGeoEl*> &continuous, const T
 			}
 			
 			if(gel->NumInterfaces() == 0){
-				CreateCompEl(gel,index);
+				CreateCompEl(gel);
 			}
 		}
 	}
@@ -465,7 +464,7 @@ void TPZCompMesh::AutoBuildContDisc(const TPZVec<TPZGeoEl*> &continuous, const T
 			}
 			
 			if(gel->NumInterfaces() == 0){
-				CreateCompEl(gel,index);
+				CreateCompEl(gel);
 			}
 		}
 	}
@@ -1346,7 +1345,8 @@ void TPZCompMesh::Coarsen(TPZVec<int64_t> &elements, int64_t &index, bool Create
 	if (CreateDiscontinuous) fCreate.SetAllCreateFunctionsDiscontinuous();
 	else fCreate.SetAllCreateFunctionsContinuous();
 	
-	TPZCompEl * newcel = CreateCompEl(father,index);
+	TPZCompEl * newcel = CreateCompEl(father);
+    index = newcel->Index();
 	
 	TPZCompElDisc * newdisc = dynamic_cast<TPZCompElDisc*>(newcel);
 	if (newdisc){

--- a/Mesh/pzcmesh.h
+++ b/Mesh/pzcmesh.h
@@ -493,9 +493,9 @@ private:
 public:
 	
     /** @brief Create a computational element based on the geometric element */
-    TPZCompEl *CreateCompEl(TPZGeoEl *gel, int64_t &index)
+    TPZCompEl *CreateCompEl(TPZGeoEl *gel)
     {
-        return fCreate.CreateCompEl(gel, *this, index);
+        return fCreate.CreateCompEl(gel, *this);
     }
     
 	/** @brief Creates the computational elements, and the degree of freedom nodes */ 

--- a/Mesh/pzcompel.cpp
+++ b/Mesh/pzcompel.cpp
@@ -121,9 +121,9 @@ int TPZCompEl::gOrder = 2;
 TPZCompEl::TPZCompEl() : fMesh(0), fIndex(-1), fReferenceIndex(-1), fIntegrationRule(0) {
 }
 
-TPZCompEl::TPZCompEl(TPZCompMesh &mesh, TPZGeoEl *ref, int64_t &index) : fIntegrationRule(0) {
+TPZCompEl::TPZCompEl(TPZCompMesh &mesh, TPZGeoEl *ref) : fIntegrationRule(0) {
     fMesh = &mesh;
-    index = mesh.ElementVec().AllocateNewElement();
+    const int64_t index = mesh.ElementVec().AllocateNewElement();
     mesh.ElementVec()[index] = this;
     fIndex = index;
     fReferenceIndex = (ref == 0) ? -1 : ref->Index();
@@ -132,17 +132,6 @@ TPZCompEl::TPZCompEl(TPZCompMesh &mesh, TPZGeoEl *ref, int64_t &index) : fIntegr
 TPZCompEl::TPZCompEl(TPZCompMesh &mesh, const TPZCompEl &copy): fIntegrationRule(0) {
     fMesh = &mesh;
     int64_t index = copy.fIndex;
-    if(index >= 0) mesh.ElementVec()[index] = this;
-    fIndex = index;
-    fReferenceIndex = copy.fReferenceIndex;
-    if (copy.fIntegrationRule) {
-        fIntegrationRule = copy.fIntegrationRule->Clone();
-    }
-}
-
-TPZCompEl::TPZCompEl(TPZCompMesh &mesh, const TPZCompEl &copy, int64_t &index) : fIntegrationRule(0) {
-    fMesh = &mesh;
-    index = mesh.ElementVec().AllocateNewElement();
     if(index >= 0) mesh.ElementVec()[index] = this;
     fIndex = index;
     fReferenceIndex = copy.fReferenceIndex;

--- a/Mesh/pzcompel.h
+++ b/Mesh/pzcompel.h
@@ -106,17 +106,14 @@ public:
 	
 	/** @brief Put a copy of the element in the patch mesh */
 	TPZCompEl(TPZCompMesh &mesh, const TPZCompEl &copy, std::map<int64_t,int64_t> &gl2lcElMap);
-	
-	/** @brief Copy of the element in the new mesh returning allocated index */
-	TPZCompEl(TPZCompMesh &mesh, const TPZCompEl &copy, int64_t &index);
-	
+		
 	/**
 	 * @brief Creates a computational element within mesh. Inserts the element within the data structure of the mesh
 	 * @param mesh mesh wher will be created the element
 	 * @param gel geometric element for which the computational element will be created
 	 * @param index new elemen index
 	 */
-	TPZCompEl(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+	TPZCompEl(TPZCompMesh &mesh, TPZGeoEl *gel);
 	
 	/** @brief Sets the value of the default interpolation order */
 	static void SetgOrder( int order );

--- a/Mesh/pzcompelwithmem.h
+++ b/Mesh/pzcompelwithmem.h
@@ -44,9 +44,9 @@ public:
     
     virtual ~TPZCompElWithMem();
     
-    TPZCompElWithMem(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+    TPZCompElWithMem(TPZCompMesh &mesh, TPZGeoEl *gel);
     
-    TPZCompElWithMem(TPZCompMesh &mesh, TPZGeoEl *ref, int64_t &index, TPZCompElSide left, TPZCompElSide right);
+    TPZCompElWithMem(TPZCompMesh &mesh, TPZGeoEl *ref, TPZCompElSide left, TPZCompElSide right);
     
     TPZCompElWithMem(TPZCompMesh &mesh, const TPZCompElWithMem<TBASE> &copy);
     
@@ -157,16 +157,16 @@ TBASE() {
 }
 
 template<class TBASE>
-TPZCompElWithMem<TBASE>::TPZCompElWithMem(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
+TPZCompElWithMem<TBASE>::TPZCompElWithMem(TPZCompMesh &mesh, TPZGeoEl *gel) :
 TPZRegisterClassId(&TPZCompElWithMem::ClassId),
-TBASE(mesh, gel, index){
+TBASE(mesh, gel){
     PrepareIntPtIndices();
 }
 
 template<class TBASE>
-TPZCompElWithMem<TBASE>::TPZCompElWithMem(TPZCompMesh &mesh, TPZGeoEl *ref, int64_t &index, TPZCompElSide left, TPZCompElSide right) :
+TPZCompElWithMem<TBASE>::TPZCompElWithMem(TPZCompMesh &mesh, TPZGeoEl *ref, TPZCompElSide left, TPZCompElSide right) :
 TPZRegisterClassId(&TPZCompElWithMem::ClassId),
-TBASE(mesh, ref, index, left, right){
+TBASE(mesh, ref, left, right){
     PrepareIntPtIndices();
 }
 

--- a/Mesh/pzcreateapproxspace.cpp
+++ b/Mesh/pzcreateapproxspace.cpp
@@ -37,26 +37,26 @@ static TPZLogger logger("pz.mesh.tpzcreateapproximationspace");
 #endif
 
 /** @brief Creates computational point element */
-TPZCompEl *CreatePointEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreatePointEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational linear element */
-TPZCompEl *CreateLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational quadrilateral element */
-TPZCompEl *CreateQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational triangular element */
-TPZCompEl *CreateTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational cube element */
-TPZCompEl *CreateCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational prismal element */
-TPZCompEl *CreatePrismEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreatePrismEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational pyramidal element */
-TPZCompEl *CreatePyramEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreatePyramEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational tetrahedral element */
-TPZCompEl *CreateTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 
 using namespace pzshape;
 
-TPZCompEl *CreateNoElement(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateNoElement(TPZGeoEl *gel,TPZCompMesh &mesh) {
 #ifdef PZ_LOG
     if (logger.isWarnEnabled()) {
         std::stringstream sout;
@@ -64,116 +64,116 @@ TPZCompEl *CreateNoElement(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
         LOGPZ_WARN(logger, sout.str())
     }
 #endif
-    index = -1;
+    
 	return NULL;
 }
 
 
-TPZCompEl *CreatePointEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreatePointEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
     {
-		return new TPZCompElH1<TPZShapePoint>(mesh,gel,index);
+		return new TPZCompElH1<TPZShapePoint>(mesh,gel);
     }
-    index = -1;
+    
 	return NULL;
 }
-TPZCompEl *CreateLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
     {
-		TPZCompEl *result = new TPZCompElH1<TPZShapeLinear>(mesh,gel,index);
+		TPZCompEl *result = new TPZCompElH1<TPZShapeLinear>(mesh,gel);
         return result;//new TPZCondensedCompel(result);
     }
-    index = -1;
+    
 	return NULL;
 }
-TPZCompEl *CreateQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
     {
-		return new TPZCompElH1<TPZShapeQuad>(mesh,gel,index);
+		return new TPZCompElH1<TPZShapeQuad>(mesh,gel);
     }
-    index = -1;
+    
 	return NULL;
 }
 
-TPZCompEl *CreateTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElH1<TPZShapeTriang>(mesh,gel,index);
-    index = -1;
+		return new TPZCompElH1<TPZShapeTriang>(mesh,gel);
+    
 	return NULL;
 }
-TPZCompEl *CreateCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElH1<TPZShapeCube>(mesh,gel,index);
-    index = -1;
+		return new TPZCompElH1<TPZShapeCube>(mesh,gel);
+    
 	return NULL;
 }
-TPZCompEl *CreatePrismEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreatePrismEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElH1<TPZShapePrism>(mesh,gel,index);
-    index = -1;
+		return new TPZCompElH1<TPZShapePrism>(mesh,gel);
+    
 	return NULL;
 }
-TPZCompEl *CreatePyramEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreatePyramEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElH1<TPZShapePiram>(mesh,gel,index);
-    index = -1;
+		return new TPZCompElH1<TPZShapePiram>(mesh,gel);
+    
 	return NULL;
 }
-TPZCompEl *CreateTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElH1<TPZShapeTetra>(mesh,gel,index);
-    index = -1;
+		return new TPZCompElH1<TPZShapeTetra>(mesh,gel);
+    
 	return NULL;
 }
 
 
 // with mem
-TPZCompEl *CreatePointElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreatePointElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem <TPZCompElH1<TPZShapePoint> >(mesh,gel,index) ;
-    index = -1;
+		return new TPZCompElWithMem <TPZCompElH1<TPZShapePoint> >(mesh,gel) ;
+    
 	return NULL;
 }
-TPZCompEl *CreateLinearElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateLinearElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem <TPZCompElH1<TPZShapeLinear> >(mesh,gel,index);
-    index = -1;
+		return new TPZCompElWithMem <TPZCompElH1<TPZShapeLinear> >(mesh,gel);
+    
 	return NULL;
 }
-TPZCompEl *CreateQuadElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateQuadElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem <TPZCompElH1<TPZShapeQuad> >(mesh,gel,index);
-    index = -1;
+		return new TPZCompElWithMem <TPZCompElH1<TPZShapeQuad> >(mesh,gel);
+    
 	return NULL;
 }
-TPZCompEl *CreateTriangleElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateTriangleElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem < TPZCompElH1<TPZShapeTriang> >(mesh,gel,index);
-    index = -1;
+		return new TPZCompElWithMem < TPZCompElH1<TPZShapeTriang> >(mesh,gel);
+    
 	return NULL;
 }
-TPZCompEl *CreateCubeElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateCubeElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem <TPZCompElH1<TPZShapeCube> >(mesh,gel,index);
-    index = -1;
+		return new TPZCompElWithMem <TPZCompElH1<TPZShapeCube> >(mesh,gel);
+    
 	return NULL;
 }
-TPZCompEl *CreatePrismElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreatePrismElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem <TPZCompElH1<TPZShapePrism> >(mesh,gel,index);
-    index = -1;
+		return new TPZCompElWithMem <TPZCompElH1<TPZShapePrism> >(mesh,gel);
+    
 	return NULL;
 }
-TPZCompEl *CreatePyramElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreatePyramElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem <TPZCompElH1<TPZShapePiram> >(mesh,gel,index);
-    index = -1;
+		return new TPZCompElWithMem <TPZCompElH1<TPZShapePiram> >(mesh,gel);
+    
 	return NULL;
 }
-TPZCompEl *CreateTetraElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateTetraElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElWithMem <TPZCompElH1<TPZShapeTetra> >(mesh,gel,index);
-    index = -1;
+		return new TPZCompElWithMem <TPZCompElH1<TPZShapeTetra> >(mesh,gel);
+    
 	return NULL;
 }
 
@@ -219,7 +219,7 @@ void TPZCreateApproximationSpace::BuildMesh(TPZCompMesh &cmesh, const TPZVec<int
         
         if(!gel->Reference() && gel->NumInterfaces() == 0)
         {
-            CreateCompEl(gel,cmesh,index);
+            CreateCompEl(gel,cmesh);
             if (fCreateHybridMesh) {
                 cmesh.ElementVec()[index]->Reference()->ResetReference();
             }
@@ -297,7 +297,7 @@ void TPZCreateApproximationSpace::BuildMesh(TPZCompMesh &cmesh, const std::set<i
             
             if(!gel->Reference() && gel->NumInterfaces() == 0)
             {
-                CreateCompEl(gel,cmesh,index);
+                index = CreateCompEl(gel,cmesh)->Index();
                 if (fCreateHybridMesh) {
                     cmesh.ElementVec()[index]->Reference()->ResetReference();
                 }
@@ -750,32 +750,32 @@ void TPZCreateApproximationSpace::SetAllCreateFunctionsMultiphysicElemWithMem()
 /*
  * @brief Create a computational element using the function pointer for the topology
  */
-TPZCompEl *TPZCreateApproximationSpace::CreateCompEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index) const
+TPZCompEl *TPZCreateApproximationSpace::CreateCompEl(TPZGeoEl *gel, TPZCompMesh &mesh) const
 {
     switch (gel->Type()) {
         case EPoint:
-            return fp[EPoint](gel,mesh,index);
+            return fp[EPoint](gel,mesh);
             break;
         case EOned:
-            return fp[EOned](gel,mesh,index);
+            return fp[EOned](gel,mesh);
             break;
         case EQuadrilateral:
-            return fp[EQuadrilateral](gel,mesh,index);
+            return fp[EQuadrilateral](gel,mesh);
             break;
         case ETriangle:
-            return fp[ETriangle](gel,mesh,index);
+            return fp[ETriangle](gel,mesh);
             break;
         case EPiramide:
-            return fp[EPiramide](gel,mesh,index);
+            return fp[EPiramide](gel,mesh);
             break;
         case EPrisma:
-            return fp[EPrisma](gel,mesh,index);
+            return fp[EPrisma](gel,mesh);
             break;
         case ETetraedro:
-            return fp[ETetraedro](gel,mesh,index);
+            return fp[ETetraedro](gel,mesh);
             break;
         case ECube:
-            return fp[ECube](gel,mesh,index);
+            return fp[ECube](gel,mesh);
             break;
         default:
             DebugStop();
@@ -982,7 +982,6 @@ void TPZCreateApproximationSpace::Hybridize(TPZCompMesh &cmesh,const std::set<in
         TPZGeoEl *gelface = face->Reference();
         gelface = gelface->CreateBCGeoEl(gelface->NSides()-1, matid);
         delete face;
-        int64_t index;
         
         //hp mesh
         TPZInterpolationSpace *leftint = dynamic_cast<TPZInterpolationSpace *>(left.Element());
@@ -996,8 +995,8 @@ void TPZCreateApproximationSpace::Hybridize(TPZCompMesh &cmesh,const std::set<in
 //        cmesh.SetDefaultOrder(neworder);
        
         
-        cmesh.ApproxSpace().CreateCompEl(gelface, cmesh, index);
-        TPZCompEl *newcel = cmesh.ElementVec()[index];
+        TPZCompEl *newcel = cmesh.ApproxSpace().CreateCompEl(gelface, cmesh);
+//        TPZCompEl *newcel = cmesh.ElementVec()[index];
         if(!isconnectedElem){
             gelface->ResetReference();
         }
@@ -1006,8 +1005,8 @@ void TPZCreateApproximationSpace::Hybridize(TPZCompMesh &cmesh,const std::set<in
         TPZGeoEl *leftgelface = gelface->CreateBCGeoEl(gelface->NSides()-1, leftmatid);
         TPZGeoEl *rightgelface = gelface->CreateBCGeoEl(gelface->NSides()-1, rightmatid);
 
-        new TPZInterfaceElement(cmesh,leftgelface,index,left,center);
-        new TPZInterfaceElement(cmesh,rightgelface,index,right,center);
+        new TPZInterfaceElement(cmesh,leftgelface,left,center);
+        new TPZInterfaceElement(cmesh,rightgelface,right,center);
         
 //        TPZInterfaceElement *faceleft = new TPZInterfaceElement(cmesh,leftgelface,index,left,center);
 //        TPZInterfaceElement *faceright = new TPZInterfaceElement(cmesh,rightgelface,index,right,center);

--- a/Mesh/pzcreateapproxspace.h
+++ b/Mesh/pzcreateapproxspace.h
@@ -12,10 +12,11 @@ class TPZGeoEl;
 class TPZCompEl;
 class TPZCompMesh;
 #include <set>
+#include <functional>
 #include "pzvec.h"
 #include "TPZSavable.h"
 
-typedef TPZCompEl *(*TCreateFunction)(TPZGeoEl *el,TPZCompMesh &mesh);
+typedef std::function<TPZCompEl* (TPZGeoEl* el, TPZCompMesh &mesh)> TCreateFunction;
 /*
  * @brief Administer the creation of approximation spaces
  * @author Philippe Devloo
@@ -24,7 +25,7 @@ typedef TPZCompEl *(*TCreateFunction)(TPZGeoEl *el,TPZCompMesh &mesh);
  */
 class TPZCreateApproximationSpace : public TPZSavable {
     /** @brief Function pointer which determines what type of computational element will be created */
-    TPZCompEl *(*fp[8])(TPZGeoEl *el,TPZCompMesh &mesh);
+    TCreateFunction fp[8];
     
     /// @brief boolean indicating if each element should be created disconnected from the others
     /**

--- a/Mesh/pzcreateapproxspace.h
+++ b/Mesh/pzcreateapproxspace.h
@@ -15,7 +15,7 @@ class TPZCompMesh;
 #include "pzvec.h"
 #include "TPZSavable.h"
 
-typedef TPZCompEl *(*TCreateFunction)(TPZGeoEl *el,TPZCompMesh &mesh,int64_t &index);
+typedef TPZCompEl *(*TCreateFunction)(TPZGeoEl *el,TPZCompMesh &mesh);
 /*
  * @brief Administer the creation of approximation spaces
  * @author Philippe Devloo
@@ -24,7 +24,7 @@ typedef TPZCompEl *(*TCreateFunction)(TPZGeoEl *el,TPZCompMesh &mesh,int64_t &in
  */
 class TPZCreateApproximationSpace : public TPZSavable {
     /** @brief Function pointer which determines what type of computational element will be created */
-    TPZCompEl *(*fp[8])(TPZGeoEl *el,TPZCompMesh &mesh,int64_t &index);
+    TPZCompEl *(*fp[8])(TPZGeoEl *el,TPZCompMesh &mesh);
     
     /// @brief boolean indicating if each element should be created disconnected from the others
     /**
@@ -132,7 +132,7 @@ public:
     }
     
     /** @brief Create a computational element using the function pointer for the topology */
-    TPZCompEl *CreateCompEl(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index) const;
+    TPZCompEl *CreateCompEl(TPZGeoEl *gel, TPZCompMesh &mesh) const;
     
 	/** @brief Creates the computational elements, and the degree of freedom nodes */ 
 	/** Only element of material id in the set<int> will be created */

--- a/Mesh/pzelchdiv.cpp
+++ b/Mesh/pzelchdiv.cpp
@@ -31,9 +31,9 @@ using namespace std;
 
 
 template<class TSHAPE>
-TPZCompElHDiv<TSHAPE>::TPZCompElHDiv(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
+TPZCompElHDiv<TSHAPE>::TPZCompElHDiv(TPZCompMesh &mesh, TPZGeoEl *gel) :
 TPZRegisterClassId(&TPZCompElHDiv::ClassId),
-TPZIntelGen<TSHAPE>(mesh,gel,index,1), fSideOrient(TSHAPE::NFacets,1) {
+TPZIntelGen<TSHAPE>(mesh,gel,1), fSideOrient(TSHAPE::NFacets,1) {
 	this->TPZInterpolationSpace::fPreferredOrder = mesh.GetDefaultOrder();
 	int nconflux= TPZCompElHDiv::NConnects();
     this->fConnectIndexes.Resize(nconflux);
@@ -1116,47 +1116,47 @@ template class TPZCompElHDiv<TPZShapePiram>;
 template class TPZCompElHDiv<TPZShapeCube>;
 
 
-TPZCompEl * CreateHDivBoundPointEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-	return new TPZCompElHDivBound2<TPZShapePoint>(mesh,gel,index);
+TPZCompEl * CreateHDivBoundPointEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+	return new TPZCompElHDivBound2<TPZShapePoint>(mesh,gel);
 }
 
-TPZCompEl * CreateHDivBoundLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-	return new TPZCompElHDivBound2< TPZShapeLinear>(mesh,gel,index);
+TPZCompEl * CreateHDivBoundLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+	return new TPZCompElHDivBound2< TPZShapeLinear>(mesh,gel);
 }
 
-TPZCompEl * CreateHDivBoundQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-    return new TPZCompElHDivBound2< TPZShapeQuad>(mesh,gel,index);
+TPZCompEl * CreateHDivBoundQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+    return new TPZCompElHDivBound2< TPZShapeQuad>(mesh,gel);
 }
 
-TPZCompEl * CreateHDivBoundTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-    return new TPZCompElHDivBound2< TPZShapeTriang >(mesh,gel,index);
+TPZCompEl * CreateHDivBoundTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+    return new TPZCompElHDivBound2< TPZShapeTriang >(mesh,gel);
 }
 
-TPZCompEl * CreateHDivLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-    return new TPZCompElHDiv< TPZShapeLinear>(mesh,gel,index);
+TPZCompEl * CreateHDivLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+    return new TPZCompElHDiv< TPZShapeLinear>(mesh,gel);
 }
 
-TPZCompEl * CreateHDivQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-	return new TPZCompElHDiv< TPZShapeQuad>(mesh,gel,index);
+TPZCompEl * CreateHDivQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+	return new TPZCompElHDiv< TPZShapeQuad>(mesh,gel);
 }
 
-TPZCompEl * CreateHDivTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-	return new TPZCompElHDiv< TPZShapeTriang >(mesh,gel,index);
+TPZCompEl * CreateHDivTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+	return new TPZCompElHDiv< TPZShapeTriang >(mesh,gel);
 }
 
-TPZCompEl * CreateHDivCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-	return new TPZCompElHDiv< TPZShapeCube >(mesh,gel,index);
+TPZCompEl * CreateHDivCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+	return new TPZCompElHDiv< TPZShapeCube >(mesh,gel);
 }
 
-TPZCompEl * CreateHDivPrismEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-	return new TPZCompElHDiv< TPZShapePrism>(mesh,gel,index);
+TPZCompEl * CreateHDivPrismEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+	return new TPZCompElHDiv< TPZShapePrism>(mesh,gel);
 }
 
-TPZCompEl * CreateHDivPyramEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-	return new TPZCompElHDiv< TPZShapePiram >(mesh,gel,index);
+TPZCompEl * CreateHDivPyramEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+	return new TPZCompElHDiv< TPZShapePiram >(mesh,gel);
 }
 
-TPZCompEl * CreateHDivTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-	return new TPZCompElHDiv< TPZShapeTetra >(mesh,gel,index);
+TPZCompEl * CreateHDivTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+	return new TPZCompElHDiv< TPZShapeTetra >(mesh,gel);
 }
 

--- a/Mesh/pzelchdiv.h
+++ b/Mesh/pzelchdiv.h
@@ -37,7 +37,7 @@ protected:
 public:
 	
     //Constructors and destructor
-	TPZCompElHDiv(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+	TPZCompElHDiv(TPZCompMesh &mesh, TPZGeoEl *gel);
 	
 	TPZCompElHDiv(TPZCompMesh &mesh, const TPZCompElHDiv<TSHAPE> &copy);
 	
@@ -271,35 +271,35 @@ void TPZCompElHDiv<TSHAPE>::SetCreateFunctions(TPZCompMesh* mesh) {
 
 
 /** @brief Creates computational linear element for HDiv approximate space */
-TPZCompEl *CreateHDivLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational quadrilateral element for HDiv approximate space */
-TPZCompEl *CreateHDivQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational triangular element for HDiv approximate space */
-TPZCompEl *CreateHDivTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational cube element for HDiv approximate space */
-TPZCompEl *CreateHDivCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational prismal element for HDiv approximate space */
-TPZCompEl *CreateHDivPrismEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivPrismEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational pyramidal element for HDiv approximate space */
-TPZCompEl *CreateHDivPyramEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivPyramEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational tetrahedral element for HDiv approximate space */
-TPZCompEl *CreateHDivTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational point element for HDiv approximate space */
-TPZCompEl *CreateHDivBoundPointEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivBoundPointEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational linear element for HDiv approximate space */
-TPZCompEl *CreateHDivBoundLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivBoundLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational quadrilateral element for HDiv approximate space */
-TPZCompEl *CreateHDivBoundQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivBoundQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational triangular element for HDiv approximate space */
-TPZCompEl *CreateHDivBoundTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivBoundTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
-TPZCompEl * CreateRefHDivLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
-TPZCompEl * CreateRefHDivQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
-TPZCompEl * CreateRefHDivTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
-TPZCompEl * CreateRefHDivCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
-TPZCompEl * CreateRefHDivPrismEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
-TPZCompEl * CreateRefHDivPyramEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
-TPZCompEl * CreateRefHDivTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl * CreateRefHDivLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh);
+TPZCompEl * CreateRefHDivQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh);
+TPZCompEl * CreateRefHDivTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh);
+TPZCompEl * CreateRefHDivCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh);
+TPZCompEl * CreateRefHDivPrismEl(TPZGeoEl *gel,TPZCompMesh &mesh);
+TPZCompEl * CreateRefHDivPyramEl(TPZGeoEl *gel,TPZCompMesh &mesh);
+TPZCompEl * CreateRefHDivTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 
 /** @} */

--- a/Mesh/pzelchdivbound2.cpp
+++ b/Mesh/pzelchdivbound2.cpp
@@ -20,9 +20,9 @@ static TPZLogger logger("pz.mesh.TPZCompElHDivBound2");
 #endif
 
 template<class TSHAPE>
-TPZCompElHDivBound2<TSHAPE>::TPZCompElHDivBound2(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
+TPZCompElHDivBound2<TSHAPE>::TPZCompElHDivBound2(TPZCompMesh &mesh, TPZGeoEl *gel) :
 TPZRegisterClassId(&TPZCompElHDivBound2::ClassId),
-TPZIntelGen<TSHAPE>(mesh,gel,index,1), fSideOrient(1){
+TPZIntelGen<TSHAPE>(mesh,gel,1), fSideOrient(1){
 		
 	//int i;
 	this->TPZInterpolationSpace::fPreferredOrder = mesh.GetDefaultOrder();

--- a/Mesh/pzelchdivbound2.h
+++ b/Mesh/pzelchdivbound2.h
@@ -32,7 +32,7 @@ protected:
     TPZManVector<int64_t,1>(1,-1);
 public:
 	
-	TPZCompElHDivBound2(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+	TPZCompElHDivBound2(TPZCompMesh &mesh, TPZGeoEl *gel);
 	
 	TPZCompElHDivBound2(TPZCompMesh &mesh, const TPZCompElHDivBound2<TSHAPE> &copy);
 
@@ -186,13 +186,13 @@ int TPZCompElHDivBound2<TSHAPE>::ClassId() const{
 }
 
 /** @brief Creates computational point element for HDiv approximate space */
-TPZCompEl *CreateRefHDivBoundPointEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateRefHDivBoundPointEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational linear element for HDiv approximate space */
-TPZCompEl *CreateRefHDivBoundLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateRefHDivBoundLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational quadrilateral element for HDiv approximate space */
-TPZCompEl *CreateRefHDivBoundQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateRefHDivBoundQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational triangular element for HDiv approximate space */
-TPZCompEl *CreateRefHDivBoundTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateRefHDivBoundTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @} */
 

--- a/Mesh/pzelctemp.cpp
+++ b/Mesh/pzelctemp.cpp
@@ -17,8 +17,8 @@ static TPZLogger logger("pz.mesh.tpzintelgen");
 #endif
 
 template<class TSHAPE>
-TPZIntelGen<TSHAPE>::TPZIntelGen(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) : TPZRegisterClassId(&TPZIntelGen::ClassId),
-TPZInterpolatedElement(mesh,gel,index){
+TPZIntelGen<TSHAPE>::TPZIntelGen(TPZCompMesh &mesh, TPZGeoEl *gel) : TPZRegisterClassId(&TPZIntelGen::ClassId),
+TPZInterpolatedElement(mesh,gel){
 
 	//  RemoveSideRestraintsII(EInsert);
 	gel->SetReference(this);
@@ -48,8 +48,8 @@ TPZInterpolatedElement(mesh,gel,index){
 }
 
 template<class TSHAPE>
-TPZIntelGen<TSHAPE>::TPZIntelGen(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index, int nocreate) : TPZRegisterClassId(&TPZIntelGen::ClassId),
-TPZInterpolatedElement(mesh,gel,index)
+TPZIntelGen<TSHAPE>::TPZIntelGen(TPZCompMesh &mesh, TPZGeoEl *gel, int nocreate) : TPZRegisterClassId(&TPZIntelGen::ClassId),
+TPZInterpolatedElement(mesh,gel)
 {
 	fPreferredOrder = -1;
 }

--- a/Mesh/pzelctemp.h
+++ b/Mesh/pzelctemp.h
@@ -26,9 +26,9 @@ protected:
 	
 public:
 	
-	TPZIntelGen(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+	TPZIntelGen(TPZCompMesh &mesh, TPZGeoEl *gel);
 	
-	TPZIntelGen(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index, int nocreate);
+	TPZIntelGen(TPZCompMesh &mesh, TPZGeoEl *gel, int nocreate);
 	
 	TPZIntelGen(TPZCompMesh &mesh, const TPZIntelGen<TSHAPE> &copy);
 	

--- a/Mesh/pzelementgroup.cpp
+++ b/Mesh/pzelementgroup.cpp
@@ -165,9 +165,8 @@ void TPZElementGroup::ReorderConnects(TPZManVector<int64_t> &connects)
 TPZCompEl *TPZElementGroup::ClonePatchEl(TPZCompMesh &mesh,
                                 std::map<int64_t,int64_t> & gl2lcConMap,
                                 std::map<int64_t,int64_t> & gl2lcElMap) const
-{
-    int64_t index;
-    TPZElementGroup *result = new TPZElementGroup(mesh,index);
+{    
+    TPZElementGroup *result = new TPZElementGroup(mesh);
     int nel = fElGroup.size();
     for (int el=0; el<nel; el++) {
         TPZCompEl *cel = fElGroup[el]->ClonePatchEl(mesh,gl2lcConMap,gl2lcElMap);

--- a/Mesh/pzelementgroup.h
+++ b/Mesh/pzelementgroup.h
@@ -29,8 +29,8 @@ public:
     
     TPZElementGroup();
     
-    TPZElementGroup(TPZCompMesh &mesh, int64_t &index) : TPZRegisterClassId(&TPZElementGroup::ClassId),
-    TPZCompEl(mesh,0,index), fElGroup(), fConnectIndexes()
+    TPZElementGroup(TPZCompMesh &mesh) : TPZRegisterClassId(&TPZElementGroup::ClassId),
+    TPZCompEl(mesh,0), fElGroup(), fConnectIndexes()
     {
         
     }

--- a/Mesh/pzgeoel.cpp
+++ b/Mesh/pzgeoel.cpp
@@ -1092,8 +1092,7 @@ REAL TPZGeoEl::SideArea(int side){
 
 TPZCompEl *TPZGeoEl::CreateBCCompEl(int side,int bc,TPZCompMesh &cmesh) {
 	TPZGeoEl *gel = CreateBCGeoEl(side,bc);
-	int64_t index;
-	return cmesh.CreateCompEl(gel,index);
+	return cmesh.CreateCompEl(gel);
 }
 
 void TPZGeoEl::RemoveConnectivities(){

--- a/Mesh/pzhdivpressure.cpp
+++ b/Mesh/pzhdivpressure.cpp
@@ -24,9 +24,9 @@ using namespace std;
 
 // TESTADO
 template<class TSHAPE>
-TPZCompElHDivPressure<TSHAPE>::TPZCompElHDivPressure(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
+TPZCompElHDivPressure<TSHAPE>::TPZCompElHDivPressure(TPZCompMesh &mesh, TPZGeoEl *gel) :
 TPZRegisterClassId(&TPZCompElHDivPressure::ClassId),
-TPZCompElHDiv<TSHAPE>(mesh,gel,index) {
+TPZCompElHDiv<TSHAPE>(mesh,gel) {
 		
 		if (TSHAPE::Type()==EQuadrilateral) {
 				fPressureOrder = mesh.GetDefaultOrder();
@@ -638,36 +638,36 @@ template class TPZCompElHDivPressure<TPZShapePiram>;
 template class TPZCompElHDivPressure<TPZShapeCube>;
 
 
-//TPZCompEl * CreateHDivPressurePointEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-//		return new TPZCompElHDivPressure<TPZShapePoint>(mesh,gel,index);
+//TPZCompEl * CreateHDivPressurePointEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+//		return new TPZCompElHDivPressure<TPZShapePoint>(mesh,gel);
 //}
 
 
-TPZCompEl * CreateHDivPressureLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-		return new TPZCompElHDivBound2< TPZShapeLinear>(mesh,gel,index);
+TPZCompEl * CreateHDivPressureLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+		return new TPZCompElHDivBound2< TPZShapeLinear>(mesh,gel);
 }
 
-TPZCompEl * CreateHDivPressureQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-		return new TPZCompElHDivPressure< TPZShapeQuad>(mesh,gel,index);
+TPZCompEl * CreateHDivPressureQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+		return new TPZCompElHDivPressure< TPZShapeQuad>(mesh,gel);
 }
 
-TPZCompEl * CreateHDivPressureTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-		return new TPZCompElHDivPressure< TPZShapeTriang >(mesh,gel,index);
+TPZCompEl * CreateHDivPressureTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+		return new TPZCompElHDivPressure< TPZShapeTriang >(mesh,gel);
 }
 
-TPZCompEl * CreateHDivPressureCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-		return new TPZCompElHDivPressure< TPZShapeCube >(mesh,gel,index);
+TPZCompEl * CreateHDivPressureCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+		return new TPZCompElHDivPressure< TPZShapeCube >(mesh,gel);
 }
 
-TPZCompEl * CreateHDivPressurePrismEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-		return new TPZCompElHDivPressure< TPZShapePrism>(mesh,gel,index);
+TPZCompEl * CreateHDivPressurePrismEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+		return new TPZCompElHDivPressure< TPZShapePrism>(mesh,gel);
 }
 
-TPZCompEl * CreateHDivPressurePyramEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-		return new TPZCompElHDivPressure< TPZShapePiram >(mesh,gel,index);
+TPZCompEl * CreateHDivPressurePyramEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+		return new TPZCompElHDivPressure< TPZShapePiram >(mesh,gel);
 }
 
-TPZCompEl * CreateHDivPressureTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-		return new TPZCompElHDivPressure< TPZShapeTetra >(mesh,gel,index);
+TPZCompEl * CreateHDivPressureTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+		return new TPZCompElHDivPressure< TPZShapeTetra >(mesh,gel);
 }
 

--- a/Mesh/pzhdivpressure.h
+++ b/Mesh/pzhdivpressure.h
@@ -26,7 +26,7 @@ class TPZCompElHDivPressure : public TPZCompElHDiv<TSHAPE> {
 	void Append(TPZFMatrix<REAL> &u1, TPZFMatrix<REAL> &u2, TPZFMatrix<REAL> &u12);
 public:
 	
-	TPZCompElHDivPressure(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+	TPZCompElHDivPressure(TPZCompMesh &mesh, TPZGeoEl *gel);
 	
 	TPZCompElHDivPressure(TPZCompMesh &mesh, const TPZCompElHDivPressure<TSHAPE> &copy);
 	
@@ -164,21 +164,21 @@ int TPZCompElHDivPressure<TSHAPE>::ClassId() const{
 }
 
 /** @brief Creates computational point element for HDivPressure approximate space */
-TPZCompEl *CreateHDivPressurePointEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivPressurePointEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational linear element for HDivPressure approximate space */
-TPZCompEl *CreateHDivPressureLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivPressureLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational quadrilateral element for HDivPressure approximate space */
-TPZCompEl *CreateHDivPressureQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivPressureQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational triangular element for HDivPressure approximate space */
-TPZCompEl *CreateHDivPressureTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivPressureTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational cube element for HDivPressure approximate space */
-TPZCompEl *CreateHDivPressureCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivPressureCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational prismal element for HDivPressure approximate space */
-TPZCompEl *CreateHDivPressurePrismEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivPressurePrismEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational pyramidal element for HDivPressure approximate space */
-TPZCompEl *CreateHDivPressurePyramEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivPressurePyramEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 /** @brief Creates computational tetrahedral element for HDivPressure approximate space */
-TPZCompEl *CreateHDivPressureTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateHDivPressureTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @} */
 

--- a/Mesh/pzhdivpressurebound.cpp
+++ b/Mesh/pzhdivpressurebound.cpp
@@ -21,9 +21,9 @@ static TPZLogger logger("pz.mesh.TPZCompElHDivPressureBound");
 
 
 template <class TSHAPE>
-TPZCompElHDivPressureBound<TSHAPE>::TPZCompElHDivPressureBound(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
+TPZCompElHDivPressureBound<TSHAPE>::TPZCompElHDivPressureBound(TPZCompMesh &mesh, TPZGeoEl *gel) :
 TPZRegisterClassId(&TPZCompElHDivPressureBound::ClassId),
-TPZCompElHDivBound2<TSHAPE>(mesh, gel, index){
+TPZCompElHDivBound2<TSHAPE>(mesh, gel){
     
     
     //Creating connect of the pressure's variable

--- a/Mesh/pzhdivpressurebound.h
+++ b/Mesh/pzhdivpressurebound.h
@@ -37,7 +37,7 @@ class TPZCompElHDivPressureBound : public TPZCompElHDivBound2<TSHAPE> {
     
 public:
     
-    TPZCompElHDivPressureBound(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+    TPZCompElHDivPressureBound(TPZCompMesh &mesh, TPZGeoEl *gel);
     
     
     /** @brief Default constructor */

--- a/Mesh/pzintel.cpp
+++ b/Mesh/pzintel.cpp
@@ -35,8 +35,8 @@ static int logger;
 #include <sstream>
 using namespace std;
 
-TPZInterpolatedElement::TPZInterpolatedElement(TPZCompMesh &mesh, TPZGeoEl *reference, int64_t &index) :
-TPZInterpolationSpace(mesh, reference, index) {
+TPZInterpolatedElement::TPZInterpolatedElement(TPZCompMesh &mesh, TPZGeoEl *reference) :
+TPZInterpolationSpace(mesh, reference) {
 }
 
 TPZInterpolatedElement::TPZInterpolatedElement(TPZCompMesh &mesh, const TPZInterpolatedElement &copy) :
@@ -1462,7 +1462,8 @@ void TPZInterpolatedElement::Divide(int64_t index,TPZVec<int64_t> &sub,int inter
     fMesh->SetDefaultOrder(PreferredSideOrder(ncon - 1));
     for (i = 0; i < nsubelements; i++) {
         cref = pv[i]; //ponteiro para subelemento i
-        fMesh->CreateCompEl(cref, sub[i]);
+        TPZCompEl* cel = fMesh->CreateCompEl(cref);
+        sub[i] = cel->Index();
         // e' assumido que CreateCompEl inseri o elemento comp no vetor de elementos da malha
     }
     if (interpolatesolution) {

--- a/Mesh/pzintel.h
+++ b/Mesh/pzintel.h
@@ -55,7 +55,7 @@ public:
 	 * @param reference reference object to which this element will refer
 	 * @param index index in the vector of elements of mesh where this element was inserted
 	 */
-	TPZInterpolatedElement(TPZCompMesh &mesh, TPZGeoEl *reference, int64_t &index);
+	TPZInterpolatedElement(TPZCompMesh &mesh, TPZGeoEl *reference);
 	
 	/**
 	 * @brief Constructor aimed at creating a copy of an interpolated element within a new mesh

--- a/Mesh/pzinterpolationspace.cpp
+++ b/Mesh/pzinterpolationspace.cpp
@@ -41,14 +41,8 @@ TPZInterpolationSpace::TPZInterpolationSpace(TPZCompMesh &mesh, const TPZInterpo
 	fPreferredOrder = copy.fPreferredOrder;
 }
 
-TPZInterpolationSpace::TPZInterpolationSpace(TPZCompMesh &mesh, const TPZInterpolationSpace &copy, int64_t &index)
-: TPZCompEl(mesh, copy, index)
-{
-	fPreferredOrder = copy.fPreferredOrder;
-}
-
-TPZInterpolationSpace::TPZInterpolationSpace(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index)
-: TPZCompEl(mesh,gel,index)
+TPZInterpolationSpace::TPZInterpolationSpace(TPZCompMesh &mesh, TPZGeoEl *gel)
+: TPZCompEl(mesh,gel)
 {
 	fPreferredOrder = mesh.GetDefaultOrder();
 }
@@ -777,7 +771,6 @@ TPZInterfaceElement * TPZInterpolationSpace::CreateInterface(int side, bool Betw
 	if(size){
 		//Interface has the same material of the neighbour with lesser dimension.
 		//It makes the interface have the same material of boundary conditions (TPZCompElDisc with interface dimension)
-		int64_t index;
 		
 		TPZCompEl *list0 = list[0].Element();
 		int list0side = list[0].Side();
@@ -812,8 +805,7 @@ TPZInterfaceElement * TPZInterpolationSpace::CreateInterface(int side, bool Betw
             }
             TPZCompElSide thiscompelside(this, thisside);
             TPZCompElSide neighcompelside(list0, neighside);
-            int64_t index;
-            newcreatedinterface = new TPZInterfaceElement(*fMesh,gel,index,thiscompelside,neighcompelside);
+            newcreatedinterface = new TPZInterfaceElement(*fMesh,gel,thiscompelside,neighcompelside);
             
         } else 
         {
@@ -830,7 +822,7 @@ TPZInterfaceElement * TPZInterpolationSpace::CreateInterface(int side, bool Betw
                 //a normal aponta para fora do contorno
                 TPZCompElSide thiscompelside(this, thisside);
                 TPZCompElSide neighcompelside(list0, neighside);
-                newcreatedinterface = new TPZInterfaceElement(*fMesh,gel,index,thiscompelside,neighcompelside);
+                newcreatedinterface = new TPZInterfaceElement(*fMesh,gel,thiscompelside,neighcompelside);
             } else {
                 const int matid = this->Material()->Id();
                 TPZGeoEl *gel = ref->CreateBCGeoEl(side,matid); //isto acertou as vizinhanas da interface geometrica com o atual
@@ -838,7 +830,7 @@ TPZInterfaceElement * TPZInterpolationSpace::CreateInterface(int side, bool Betw
                 //caso contrario ou caso ambos sejam de volume
                 TPZCompElSide thiscompelside(this, thisside);
                 TPZCompElSide neighcompelside(list0, neighside);
-                newcreatedinterface = new TPZInterfaceElement(*fMesh,gel,index,neighcompelside,thiscompelside);
+                newcreatedinterface = new TPZInterfaceElement(*fMesh,gel,neighcompelside,thiscompelside);
             }
 		}
 		
@@ -921,9 +913,7 @@ TPZInterfaceElement * TPZInterpolationSpace::CreateInterface(int side, bool Betw
 			}
 		}
         TPZInterfaceElement * newcreatedinterface = NULL;
-        
-		int64_t index;
-		
+        		
         if(Dimension() == lowcel->Dimension()){///faces internas
             
             const int matid = this->Mesh()->Reference()->InterfaceMaterial(lowcel->Material()->Id(), this->Material()->Id() );
@@ -932,8 +922,7 @@ TPZInterfaceElement * TPZInterpolationSpace::CreateInterface(int side, bool Betw
             
             TPZCompElSide lowcelcompelside(lowcel, neighside);
             TPZCompElSide thiscompelside(this, thisside);
-            int64_t index;
-            newcreatedinterface = new TPZInterfaceElement(*fMesh,gel,index,lowcelcompelside,thiscompelside);
+            newcreatedinterface = new TPZInterfaceElement(*fMesh,gel,lowcelcompelside,thiscompelside);
         }
         else{
             
@@ -947,7 +936,7 @@ TPZInterfaceElement * TPZInterpolationSpace::CreateInterface(int side, bool Betw
                 //para que o elemento esquerdo seja de volume
                 TPZCompElSide thiscompelside(this, thisside);
                 TPZCompElSide lowcelcompelside(lowcel, neighside);
-                newcreatedinterface = new TPZInterfaceElement(*fMesh,gel,index,thiscompelside,lowcelcompelside);
+                newcreatedinterface = new TPZInterfaceElement(*fMesh,gel,thiscompelside,lowcelcompelside);
             } else {
                 const int matid = this->Material()->Id();
                 TPZGeoEl *gel = ref->CreateBCGeoEl(side,matid);
@@ -969,7 +958,7 @@ TPZInterfaceElement * TPZInterpolationSpace::CreateInterface(int side, bool Betw
                     LOGPZ_DEBUG(logger,sout.str())
                 }
 #endif
-                newcreatedinterface = new TPZInterfaceElement(*fMesh,gel,index,lowcelcompelside,thiscompelside);
+                newcreatedinterface = new TPZInterfaceElement(*fMesh,gel,lowcelcompelside,thiscompelside);
             }
         }		
 		/** GeoBlend verifications ***/

--- a/Mesh/pzinterpolationspace.h
+++ b/Mesh/pzinterpolationspace.h
@@ -37,9 +37,6 @@ virtual int ClassId() const override;
 	/** @brief Puts a copy of the element in the patch mesh */
 	TPZInterpolationSpace(TPZCompMesh &mesh, const TPZInterpolationSpace &copy, std::map<int64_t,int64_t> &gl2lcElMap);
 	
-	/** @brief Copy of the element in the new mesh whit alocated index */
-	TPZInterpolationSpace(TPZCompMesh &mesh, const TPZInterpolationSpace &copy, int64_t &index);
-	
 	/**
 	 * @brief Create a computational element within mesh
 	 * @param mesh mesh wher will be created the element
@@ -47,7 +44,7 @@ virtual int ClassId() const override;
 	 * @param index new elemen index
 	 */
 	/** Inserts the element within the data structure of the mesh */
-	TPZInterpolationSpace(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+	TPZInterpolationSpace(TPZCompMesh &mesh, TPZGeoEl *gel);
 	
     /**
 	 * @name data access methods

--- a/Mesh/pzmultiphysicscompel.cpp
+++ b/Mesh/pzmultiphysicscompel.cpp
@@ -71,8 +71,8 @@ TPZMultiphysicsCompEl<TGeometry>::TPZMultiphysicsCompEl(TPZCompMesh &mesh,
 
 
 template <class TGeometry>
-TPZMultiphysicsCompEl<TGeometry>::TPZMultiphysicsCompEl(TPZCompMesh &mesh, TPZGeoEl *ref, int64_t &index) :TPZRegisterClassId(&TPZMultiphysicsCompEl::ClassId),
-TPZMultiphysicsElement(mesh, ref, index), fElementVec(0) {
+TPZMultiphysicsCompEl<TGeometry>::TPZMultiphysicsCompEl(TPZCompMesh &mesh, TPZGeoEl *ref) :TPZRegisterClassId(&TPZMultiphysicsCompEl::ClassId),
+TPZMultiphysicsElement(mesh, ref), fElementVec(0) {
 }
 
 template<class TGeometry>
@@ -1390,85 +1390,85 @@ template class TPZMultiphysicsCompEl<pzgeom::TPZGeoPyramid>;
  */
 
 
-TPZCompEl * CreateMultiphysicsPointEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoPoint>(mesh, gel, index);
+TPZCompEl * CreateMultiphysicsPointEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoPoint>(mesh, gel);
 }
 
-TPZCompEl * CreateMultiphysicsLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoLinear>(mesh,gel,index);
+TPZCompEl * CreateMultiphysicsLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoLinear>(mesh,gel);
 }
 
-TPZCompEl * CreateMultiphysicsTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoTriangle >(mesh,gel,index);
+TPZCompEl * CreateMultiphysicsTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoTriangle >(mesh,gel);
 }
 
-TPZCompEl * CreateMultiphysicsQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoQuad>(mesh,gel,index);
+TPZCompEl * CreateMultiphysicsQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoQuad>(mesh,gel);
 }
 
-TPZCompEl * CreateMultiphysicsCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoCube >(mesh,gel,index);
+TPZCompEl * CreateMultiphysicsCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoCube >(mesh,gel);
 }
 
-TPZCompEl * CreateMultiphysicsPrismEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoPrism>(mesh,gel,index);
+TPZCompEl * CreateMultiphysicsPrismEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoPrism>(mesh,gel);
 }
 
-TPZCompEl * CreateMultiphysicsTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoTetrahedra>(mesh,gel,index);
+TPZCompEl * CreateMultiphysicsTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoTetrahedra>(mesh,gel);
 }
 
-TPZCompEl * CreateMultiphysicsPyramEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
-    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoPyramid >(mesh,gel,index);
+TPZCompEl * CreateMultiphysicsPyramEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
+    return new TPZMultiphysicsCompEl<pzgeom::TPZGeoPyramid >(mesh,gel);
 }
 
 //--------------------- WITH MEMORY ----------------------
 
-TPZCompEl *CreateMultiphysicsPointElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateMultiphysicsPointElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
     //	if(!gel->Reference() && gel->NumInterfaces() == 0)
-    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoPoint> >(mesh,gel,index) ;
+    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoPoint> >(mesh,gel) ;
     //	index = -1;
     //	return NULL;
 }
-TPZCompEl *CreateMultiphysicsLinearElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateMultiphysicsLinearElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
     //	if(!gel->Reference() && gel->NumInterfaces() == 0)
-    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoLinear> >(mesh,gel,index);
+    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoLinear> >(mesh,gel);
     //	index = -1;
     //	return NULL;
 }
-TPZCompEl *CreateMultiphysicsQuadElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateMultiphysicsQuadElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
     //	if(!gel->Reference() && gel->NumInterfaces() == 0)
-    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoQuad> >(mesh,gel,index);
+    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoQuad> >(mesh,gel);
     //	index = -1;
     //	return NULL;
 }
-TPZCompEl *CreateMultiphysicsTriangleElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateMultiphysicsTriangleElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
     //	if(!gel->Reference() && gel->NumInterfaces() == 0)
-    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoTriangle > >(mesh,gel,index);
+    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoTriangle > >(mesh,gel);
     //	index = -1;
     //	return NULL;
 }
-TPZCompEl *CreateMultiphysicsCubeElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateMultiphysicsCubeElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
     //	if(!gel->Reference() && gel->NumInterfaces() == 0)
-    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoCube > >(mesh,gel,index);
+    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoCube > >(mesh,gel);
     //	index = -1;
     //	return NULL;
 }
-TPZCompEl *CreateMultiphysicsPrismElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateMultiphysicsPrismElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
     //	if(!gel->Reference() && gel->NumInterfaces() == 0)
-    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoPrism> >(mesh,gel,index);
+    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoPrism> >(mesh,gel);
     //	index = -1;
     //	return NULL;
 }
-TPZCompEl *CreateMultiphysicsPyramElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateMultiphysicsPyramElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
     //	if(!gel->Reference() && gel->NumInterfaces() == 0)
-    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoPyramid > >(mesh,gel,index);
+    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoPyramid > >(mesh,gel);
     //	index = -1;
     //	return NULL;
 }
-TPZCompEl *CreateMultiphysicsTetraElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *CreateMultiphysicsTetraElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh) {
     //	if(!gel->Reference() && gel->NumInterfaces() == 0)
-    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoTetrahedra> >(mesh,gel,index);
+    return new TPZCompElWithMem < TPZMultiphysicsCompEl<pzgeom::TPZGeoTetrahedra> >(mesh,gel);
     //	index = -1;
     //	return NULL;
 }

--- a/Mesh/pzmultiphysicscompel.h
+++ b/Mesh/pzmultiphysicscompel.h
@@ -53,7 +53,7 @@ public:
 	 * @param gel geometric element for which the computational element will be created
 	 * @param index new elemen index
 	 */
-	TPZMultiphysicsCompEl(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+	TPZMultiphysicsCompEl(TPZCompMesh &mesh, TPZGeoEl *gel);
 	/** @brief Default constructor */
 	TPZMultiphysicsCompEl();
   
@@ -344,54 +344,54 @@ public:
 
 
 /** @brief Creates computational point element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsPointEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsPointEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @brief Creates computational linear element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @brief Creates computational quadrilateral element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @brief Creates computational triangular element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @brief Creates computational cube element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @brief Creates computational prismal element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsPrismEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsPrismEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @brief Creates computational pyramidal element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsPyramEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsPyramEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @brief Creates computational tetrahedral element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 //--------------------- WITH MEMORY ----------------------
 
 /** @brief Creates computational point element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsPointElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsPointElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @brief Creates computational linear element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsLinearElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsLinearElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @brief Creates computational quadrilateral element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsQuadElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsQuadElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @brief Creates computational triangular element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsTriangleElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsTriangleElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @brief Creates computational cube element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsCubeElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsCubeElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @brief Creates computational prismal element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsPrismElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsPrismElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @brief Creates computational pyramidal element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsPyramElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsPyramElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 /** @brief Creates computational tetrahedral element for Multiphysics approximate space */
-TPZCompEl *CreateMultiphysicsTetraElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index);
+TPZCompEl *CreateMultiphysicsTetraElWithMem(TPZGeoEl *gel,TPZCompMesh &mesh);
 
 #include "pzcmesh.h"
 

--- a/Mesh/pzmultiphysicselement.cpp
+++ b/Mesh/pzmultiphysicselement.cpp
@@ -147,8 +147,6 @@ TPZMultiphysicsInterfaceElement * TPZMultiphysicsElement::CreateInterface(int si
             }
         }
 		
-		int64_t index;
-		
 		
 		TPZGeoEl *gel = ref->CreateBCGeoEl(side,matid); //isto acertou as vizinhanas da interface geometrica com o atual
 		if(!gel){
@@ -169,22 +167,22 @@ TPZMultiphysicsInterfaceElement * TPZMultiphysicsElement::CreateInterface(int si
 			TPZCompElSide thiscompelside(this, thisside.Side());
 			TPZCompElSide neighcompelside(list[is]);
             if (!withmem) {
-                newcreatedinterface = new TPZMultiphysicsInterfaceElement(*fMesh,gel,index,thiscompelside,neighcompelside);
+                newcreatedinterface = new TPZMultiphysicsInterfaceElement(*fMesh,gel,thiscompelside,neighcompelside);
             }
             else
             {
-                newcreatedinterface = new TPZCompElWithMem<TPZMultiphysicsInterfaceElement>(*fMesh,gel,index,thiscompelside,neighcompelside);
+                newcreatedinterface = new TPZCompElWithMem<TPZMultiphysicsInterfaceElement>(*fMesh,gel,thiscompelside,neighcompelside);
             }
 		} else {
 			//caso contrario ou caso ambos sejam de volume
 			TPZCompElSide thiscompelside(this, thisside.Side());
 			TPZCompElSide neighcompelside(list[is]);
             if (!withmem) {
-                newcreatedinterface = new TPZMultiphysicsInterfaceElement(*fMesh,gel,index,neighcompelside,thiscompelside);
+                newcreatedinterface = new TPZMultiphysicsInterfaceElement(*fMesh,gel,neighcompelside,thiscompelside);
             }
             else
             {
-                newcreatedinterface = new TPZCompElWithMem<TPZMultiphysicsInterfaceElement>(*fMesh,gel,index,neighcompelside,thiscompelside);
+                newcreatedinterface = new TPZCompElWithMem<TPZMultiphysicsInterfaceElement>(*fMesh,gel,neighcompelside,thiscompelside);
             }
 		}
 		
@@ -246,7 +244,6 @@ TPZMultiphysicsInterfaceElement * TPZMultiphysicsElement::CreateInterface(int si
 		//int lowside = lower.Side();
 		//existem esquerdo e direito: this e lower
 		TPZGeoEl *gel = ref->CreateBCGeoEl(side,matid);
-		int64_t index;
 		
         bool withmem = fMesh->ApproxSpace().NeedsMemory();
         
@@ -255,11 +252,11 @@ TPZMultiphysicsInterfaceElement * TPZMultiphysicsElement::CreateInterface(int si
 			TPZCompElSide thiscompelside(this, thisside.Side());
 			TPZCompElSide lowcelcompelside(lower);
             if (!withmem) {
-                newcreatedinterface = new TPZMultiphysicsInterfaceElement(*fMesh,gel,index,thiscompelside,lowcelcompelside);
+                newcreatedinterface = new TPZMultiphysicsInterfaceElement(*fMesh,gel,thiscompelside,lowcelcompelside);
             }
             else
             {
-                newcreatedinterface = new TPZCompElWithMem<TPZMultiphysicsInterfaceElement>(*fMesh,gel,index,thiscompelside,lowcelcompelside);
+                newcreatedinterface = new TPZCompElWithMem<TPZMultiphysicsInterfaceElement>(*fMesh,gel,thiscompelside,lowcelcompelside);
             }
 		} else {
 			TPZCompElSide thiscompelside(this, thisside.Side());
@@ -279,11 +276,11 @@ TPZMultiphysicsInterfaceElement * TPZMultiphysicsElement::CreateInterface(int si
 #endif
             if (!withmem)
             {
-                newcreatedinterface = new TPZMultiphysicsInterfaceElement(*fMesh,gel,index,lowcelcompelside,thiscompelside);
+                newcreatedinterface = new TPZMultiphysicsInterfaceElement(*fMesh,gel,lowcelcompelside,thiscompelside);
             }
             else
             {
-                newcreatedinterface = new TPZCompElWithMem<TPZMultiphysicsInterfaceElement>(*fMesh,gel,index,lowcelcompelside,thiscompelside);
+                newcreatedinterface = new TPZCompElWithMem<TPZMultiphysicsInterfaceElement>(*fMesh,gel,lowcelcompelside,thiscompelside);
             }
 		}
 		

--- a/Mesh/pzmultiphysicselement.h
+++ b/Mesh/pzmultiphysicselement.h
@@ -44,7 +44,7 @@ public:
 	 * @param ref geometric element reference
 	 * @param index Index of the element created
 	 */
-	TPZMultiphysicsElement(TPZCompMesh &mesh, TPZGeoEl *ref, int64_t &index) : TPZCompEl(mesh, ref, index)
+	TPZMultiphysicsElement(TPZCompMesh &mesh, TPZGeoEl *ref) : TPZCompEl(mesh, ref)
 	{
 	}
   

--- a/Mesh/pzreducedspace.cpp
+++ b/Mesh/pzreducedspace.cpp
@@ -35,12 +35,6 @@ TPZReducedSpace::~TPZReducedSpace()
     
 }
 
-/** @brief Puts a copy of the element in the referred mesh */
-TPZReducedSpace::TPZReducedSpace(TPZCompMesh &mesh, const TPZReducedSpace &copy) : TPZRegisterClassId(&TPZReducedSpace::ClassId),
-TPZInterpolationSpace(mesh,copy)
-{
-    
-}
 
 /** @brief Puts a copy of the element in the patch mesh */
 TPZReducedSpace::TPZReducedSpace(TPZCompMesh &mesh, const TPZReducedSpace &copy, std::map<int64_t,int64_t> &gl2lcElMap) : TPZRegisterClassId(&TPZReducedSpace::ClassId),
@@ -53,8 +47,8 @@ TPZInterpolationSpace(mesh,copy,gl2lcElMap)
 }
 
 /** @brief Copy of the element in the new mesh whit alocated index */
-TPZReducedSpace::TPZReducedSpace(TPZCompMesh &mesh, const TPZReducedSpace &copy, int64_t &index) : TPZRegisterClassId(&TPZReducedSpace::ClassId),
-TPZInterpolationSpace(mesh,copy,index)
+TPZReducedSpace::TPZReducedSpace(TPZCompMesh &mesh, const TPZReducedSpace &copy) : TPZRegisterClassId(&TPZReducedSpace::ClassId),
+TPZInterpolationSpace(mesh,copy)
 {
     PZError<<__PRETTY_FUNCTION__;
     PZError<<" should be reimplemented without TPZCompMeshReferred\n";
@@ -69,8 +63,8 @@ TPZInterpolationSpace(mesh,copy,index)
  * @param index new elemen index
  */
 /** Inserts the element within the data structure of the mesh */
-TPZReducedSpace::TPZReducedSpace(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) : TPZRegisterClassId(&TPZReducedSpace::ClassId),
-TPZInterpolationSpace(mesh,gel,index)
+TPZReducedSpace::TPZReducedSpace(TPZCompMesh &mesh, TPZGeoEl *gel) : TPZRegisterClassId(&TPZReducedSpace::ClassId),
+TPZInterpolationSpace(mesh,gel)
 {
     std::cout << "Creating reduced with dim " << gel->Dimension() << '\n';
 }
@@ -441,9 +435,9 @@ void TPZReducedSpace::ReallyComputeSolution(TPZMaterialDataT<STATE>& data)
     
 }
 
-static TPZCompEl * CreateReducedElement(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index)
+static TPZCompEl * CreateReducedElement(TPZGeoEl *gel,TPZCompMesh &mesh)
 {
-    return new TPZReducedSpace(mesh,gel,index);
+    return new TPZReducedSpace(mesh,gel);
 }
 
 void TPZReducedSpace::SetAllCreateFunctionsReducedSpace(TPZCompMesh *cmesh)

--- a/Mesh/pzreducedspace.h
+++ b/Mesh/pzreducedspace.h
@@ -29,18 +29,14 @@ public:
 	
 	/** @brief Puts a copy of the element in the patch mesh */
 	TPZReducedSpace(TPZCompMesh &mesh, const TPZReducedSpace &copy, std::map<int64_t,int64_t> &gl2lcElMap);
-	
-	/** @brief Copy of the element in the new mesh returning the alocated index */
-	TPZReducedSpace(TPZCompMesh &mesh, const TPZReducedSpace &copy, int64_t &index);
-	
+		
 	/**
 	 * @brief Create a computational element within mesh
 	 * @param mesh mesh where will be created the element
 	 * @param gel geometrical element to insert
-	 * @param index new elemen index
 	 */
 	/** Inserts the element within the data structure of the mesh */
-	TPZReducedSpace(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+	TPZReducedSpace(TPZCompMesh &mesh, TPZGeoEl *gel);
 	
     static void SetAllCreateFunctionsReducedSpace(TPZCompMesh *cmesh);
 

--- a/Mesh/pzsubcmesh.cpp
+++ b/Mesh/pzsubcmesh.cpp
@@ -44,7 +44,7 @@ static TPZLogger logger2("pz.mesh.tpzcompmesh");
 static int logger;
 #endif
 
-TPZSubCompMesh::TPZSubCompMesh(TPZCompMesh &mesh, int64_t &index) : TPZRegisterClassId(&TPZSubCompMesh::ClassId), TPZCompMesh(mesh.Reference()), TPZCompEl(mesh,0,index),
+TPZSubCompMesh::TPZSubCompMesh(TPZCompMesh &mesh) : TPZRegisterClassId(&TPZSubCompMesh::ClassId), TPZCompMesh(mesh.Reference()), TPZCompEl(mesh,0),
 fSingularConnect(-1) {
     SetDimModel(mesh.Dimension());
 	fAnalysis = NULL;

--- a/Mesh/pzsubcmesh.h
+++ b/Mesh/pzsubcmesh.h
@@ -83,7 +83,7 @@ public:
 	 * @param mesh reference mesh
 	 * @param index reference mesh element index to transfer to submesh
 	 */
-	TPZSubCompMesh(TPZCompMesh &mesh, int64_t &index);
+	TPZSubCompMesh(TPZCompMesh &mesh);
 	/** @brief Default constructor */
 	TPZSubCompMesh();
 	/** @brief Destructor. */

--- a/Post/pzcompelpostproc.h
+++ b/Post/pzcompelpostproc.h
@@ -52,7 +52,7 @@ public:
     
     virtual ~TPZCompElPostProc();
     
-    TPZCompElPostProc(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index);
+    TPZCompElPostProc(TPZCompMesh &mesh, TPZGeoEl *gel);
     
     TPZCompElPostProc(TPZCompMesh &mesh, const TPZCompElPostProc<TCOMPEL> &copy);
     
@@ -162,8 +162,8 @@ inline TPZCompElPostProc<TCOMPEL>::~TPZCompElPostProc() {
 }
 
 template<class TCOMPEL>
-inline TPZCompElPostProc<TCOMPEL>::TPZCompElPostProc(TPZCompMesh &mesh, TPZGeoEl *gel, int64_t &index) :
-TCOMPEL(mesh, gel, index){
+inline TPZCompElPostProc<TCOMPEL>::TPZCompElPostProc(TPZCompMesh &mesh, TPZGeoEl *gel) :
+TCOMPEL(mesh, gel){
     TPZCompElPostProc<TCOMPEL>::InitializeShapeFunctions();
 }
 

--- a/Post/pzpostprocanalysis.cpp
+++ b/Post/pzpostprocanalysis.cpp
@@ -173,7 +173,6 @@ void TPZPostProcAnalysis::AutoBuildDisc()
 	TPZAdmChunkVector<TPZGeoEl *> &elvec = Mesh()->Reference()->ElementVec();
 	int64_t i, nelem = elvec.NElements();
 	int neltocreate = 0;
-	int64_t index;
     
     // build a data structure indicating which geometric elements will be post processed
     fpMainMesh->LoadReferences();
@@ -220,8 +219,7 @@ void TPZPostProcAnalysis::AutoBuildDisc()
             matnotfound.insert(matid);
             continue;
         }
-        Mesh()->CreateCompEl(gel,index);
-        TPZCompEl *cel = Mesh()->ElementVec()[index];
+        TPZCompEl *cel = Mesh()->CreateCompEl(gel);
         TPZCompElPostProcBase *celpost = dynamic_cast<TPZCompElPostProcBase *>(cel);
         if(!celpost) DebugStop();
         TPZCompEl *celref = it->second;
@@ -399,51 +397,51 @@ template class TPZRestoreClass<TPZCompElPostProc< TPZCompElH1<TPZShapePiram> >>;
 template class TPZRestoreClass<TPZCompElPostProc< TPZCompElH1<TPZShapeTetra> >>;
 template class TPZRestoreClass<TPZCompElPostProc< TPZCompElDisc >>;
 
-TPZCompEl *TPZPostProcAnalysis::CreatePointEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *TPZPostProcAnalysis::CreatePointEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc< TPZCompElH1<TPZShapePoint> >(mesh,gel,index);
+		return new TPZCompElPostProc< TPZCompElH1<TPZShapePoint> >(mesh,gel);
 	return NULL;
 }
-TPZCompEl *TPZPostProcAnalysis::CreateLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *TPZPostProcAnalysis::CreateLinearEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc<TPZCompElH1<TPZShapeLinear> >(mesh,gel,index);
+		return new TPZCompElPostProc<TPZCompElH1<TPZShapeLinear> >(mesh,gel);
 	return NULL;
 }
-TPZCompEl *TPZPostProcAnalysis::CreateQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *TPZPostProcAnalysis::CreateQuadEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc<TPZCompElH1<TPZShapeQuad> >(mesh,gel,index);
+		return new TPZCompElPostProc<TPZCompElH1<TPZShapeQuad> >(mesh,gel);
 	return NULL;
 }
-TPZCompEl *TPZPostProcAnalysis::CreateTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *TPZPostProcAnalysis::CreateTriangleEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc<TPZCompElH1<TPZShapeTriang> >(mesh,gel,index);
+		return new TPZCompElPostProc<TPZCompElH1<TPZShapeTriang> >(mesh,gel);
 	return NULL;
 }
-TPZCompEl *TPZPostProcAnalysis::CreateCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *TPZPostProcAnalysis::CreateCubeEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc<TPZCompElH1<TPZShapeCube> >(mesh,gel,index);
+		return new TPZCompElPostProc<TPZCompElH1<TPZShapeCube> >(mesh,gel);
 	return NULL;
 }
-TPZCompEl *TPZPostProcAnalysis::CreatePrismEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *TPZPostProcAnalysis::CreatePrismEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc< TPZCompElH1<TPZShapePrism> >(mesh,gel,index);
+		return new TPZCompElPostProc< TPZCompElH1<TPZShapePrism> >(mesh,gel);
 	return NULL;
 }
-TPZCompEl *TPZPostProcAnalysis::CreatePyramEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *TPZPostProcAnalysis::CreatePyramEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc<TPZCompElH1<TPZShapePiram> >(mesh,gel,index);
+		return new TPZCompElPostProc<TPZCompElH1<TPZShapePiram> >(mesh,gel);
 	return NULL;
 }
-TPZCompEl *TPZPostProcAnalysis::CreateTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh,int64_t &index) {
+TPZCompEl *TPZPostProcAnalysis::CreateTetraEl(TPZGeoEl *gel,TPZCompMesh &mesh) {
 	if(!gel->Reference() && gel->NumInterfaces() == 0)
-		return new TPZCompElPostProc<TPZCompElH1<TPZShapeTetra> >(mesh,gel,index);
+		return new TPZCompElPostProc<TPZCompElH1<TPZShapeTetra> >(mesh,gel);
 	return NULL;
 }
 
 
-TPZCompEl * TPZPostProcAnalysis::CreatePostProcDisc(TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index)
+TPZCompEl * TPZPostProcAnalysis::CreatePostProcDisc(TPZGeoEl *gel, TPZCompMesh &mesh)
 {
-	return new TPZCompElPostProc< TPZCompElDisc > (mesh,gel,index);
+	return new TPZCompElPostProc< TPZCompElDisc > (mesh,gel);
 }
 
 /** @brief Returns the unique identifier for reading/writing objects to streams */

--- a/Post/pzpostprocanalysis.h
+++ b/Post/pzpostprocanalysis.h
@@ -92,16 +92,16 @@ protected:
 public:
 
 	
-static TPZCompEl * CreatePostProcDisc(  TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
+static TPZCompEl * CreatePostProcDisc(  TPZGeoEl *gel, TPZCompMesh &mesh);
 	
-static TPZCompEl * CreatePointEl( TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
-static TPZCompEl * CreateLinearEl( TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
-static TPZCompEl * CreateQuadEl( TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
-static TPZCompEl * CreateTriangleEl( TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
-static TPZCompEl * CreateCubeEl( TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
-static TPZCompEl * CreatePyramEl( TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
-static TPZCompEl * CreateTetraEl( TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
-static TPZCompEl * CreatePrismEl( TPZGeoEl *gel, TPZCompMesh &mesh, int64_t &index);
+static TPZCompEl * CreatePointEl( TPZGeoEl *gel, TPZCompMesh &mesh);
+static TPZCompEl * CreateLinearEl( TPZGeoEl *gel, TPZCompMesh &mesh);
+static TPZCompEl * CreateQuadEl( TPZGeoEl *gel, TPZCompMesh &mesh);
+static TPZCompEl * CreateTriangleEl( TPZGeoEl *gel, TPZCompMesh &mesh);
+static TPZCompEl * CreateCubeEl( TPZGeoEl *gel, TPZCompMesh &mesh);
+static TPZCompEl * CreatePyramEl( TPZGeoEl *gel, TPZCompMesh &mesh);
+static TPZCompEl * CreateTetraEl( TPZGeoEl *gel, TPZCompMesh &mesh);
+static TPZCompEl * CreatePrismEl( TPZGeoEl *gel, TPZCompMesh &mesh);
 
 };
 

--- a/Pre/TPZBuildSBFem.cpp
+++ b/Pre/TPZBuildSBFem.cpp
@@ -620,9 +620,8 @@ void TPZBuildSBFem::CreateElementGroups(TPZCompMesh &cmesh)
     TPZVec<int64_t> elementgroupindices(numgroups);
     
     for (int64_t el=0; el<numgroups; el++) {
-        int64_t index;
-        new TPZSBFemElementGroup(cmesh,index);
-        elementgroupindices[el] = index;
+        TPZCompEl* cel = new TPZSBFemElementGroup(cmesh);
+        elementgroupindices[el] = cel->Index();
     }
     
     

--- a/Pre/TPZBuildSBFemMultiphysics.cpp
+++ b/Pre/TPZBuildSBFemMultiphysics.cpp
@@ -472,9 +472,9 @@ void TPZBuildSBFemMultiphysics::CreateSBFemVolumePressure(TPZCompMesh & cmeshpre
         {
             DebugStop();
         }
-
-        int64_t index;
-        auto cel = CreateSBFemPressureCompEl(cmeshpressure, gelcollapsed, index);
+        
+        auto cel = CreateSBFemPressureCompEl(cmeshpressure, gelcollapsed);
+        int64_t index = cel->Index();
 
         // Getting the TPZSBFemVolumeHdiv compel
         auto celsbfem = cmeshpressure.Element(index);
@@ -580,8 +580,7 @@ void TPZBuildSBFemMultiphysics::CreateCompElFlux(TPZCompMesh &cmeshflux, set<int
             DebugStop();
         }
 
-        int64_t index;
-        auto celhdivc = new TPZCompElHDivSBFem<pzshape::TPZShapeLinear>(cmeshflux, gel1d, gelsidecollapsed, index);
+        auto celhdivc = new TPZCompElHDivSBFem<pzshape::TPZShapeLinear>(cmeshflux, gel1d, gelsidecollapsed);
         geltocel[gel1d->Index()] = celhdivc;
 
         previouspartition = partition;
@@ -621,15 +620,14 @@ void TPZBuildSBFemMultiphysics::CreateCompElFlux(TPZCompMesh &cmeshflux, set<int
         {
             DebugStop();
         }
+        
 
-        int64_t index;
-
-        auto hdivboundleft = new TPZCompElHDivBound2<pzshape::TPZShapeLinear>(cmeshflux,gelsideleft.Element(),index);
+        auto hdivboundleft = new TPZCompElHDivBound2<pzshape::TPZShapeLinear>(cmeshflux,gelsideleft.Element());
         celhdivc->SetConnectIndex(3,hdivboundleft->ConnectIndex(0));
         celhdivc->SetCompElFlux(hdivboundleft);
         gelsideleft.Element()->ResetReference();
 
-        auto hdivboundright = new TPZCompElHDivBound2<pzshape::TPZShapeLinear>(cmeshflux,gelsideright.Element(),index);
+        auto hdivboundright = new TPZCompElHDivBound2<pzshape::TPZShapeLinear>(cmeshflux,gelsideright.Element());
         celhdivc->SetConnectIndex(4,hdivboundright->ConnectIndex(0));
         gelsideright.Element()->ResetReference();
     }
@@ -667,9 +665,9 @@ void TPZBuildSBFemMultiphysics::CreateSBFemVolumeFlux(TPZCompMesh & cmesh, set<i
         {
             DebugStop();
         }
-
-        int64_t index;
-        auto cel = CreateSBFemFluxCompEl(cmesh, gelcollapsed, index);
+        
+        auto cel = CreateSBFemFluxCompEl(cmesh, gelcollapsed);
+        const int64_t index = cel->Index();
 
         // Getting the TPZSBFemVolumeHdiv compel
         auto celsbfem = cmesh.Element(index);
@@ -773,7 +771,7 @@ void TPZBuildSBFemMultiphysics::AddInterfaceElements(TPZMultiphysicsCompMesh & c
 #ifdef PZDEBUG
         if(gelsideleft.Element()->MaterialId() != fLeftFlux) DebugStop();
 #endif
-        int64_t index;
+        
 
         TPZCompElSide celsidedifpr = gelsidedifpr.Reference();
         TPZCompElSide celsideleft = gelsideleft.Reference();
@@ -785,7 +783,7 @@ void TPZBuildSBFemMultiphysics::AddInterfaceElements(TPZMultiphysicsCompMesh & c
         }
 #endif
         TPZGeoElBC gelbc(gelsideleft, fInterface);
-        TPZMultiphysicsInterfaceElement *intl = new TPZMultiphysicsInterfaceElement(cmeshm, gelbc.CreatedElement(),index,celsidedifpr,celsideleft);
+        TPZMultiphysicsInterfaceElement *intl = new TPZMultiphysicsInterfaceElement(cmeshm, gelbc.CreatedElement(),celsidedifpr,celsideleft);
         fElementPartition[gelbc.CreatedElement()->Index()] = fElementPartition[gelsidedifpr.Element()->Index()];
     }
 
@@ -806,7 +804,6 @@ void TPZBuildSBFemMultiphysics::AddInterfaceElements(TPZMultiphysicsCompMesh & c
             if (gelsideaverpr.Element() == gelsideright.Element()) DebugStop();
 #endif
         }
-        int64_t index;
 
         TPZCompElSide celsideaverpr = gelsideaverpr.Reference();
         TPZCompElSide celsideright = gelsideright.Reference();
@@ -817,7 +814,7 @@ void TPZBuildSBFemMultiphysics::AddInterfaceElements(TPZMultiphysicsCompMesh & c
         }
 #endif
         TPZGeoElBC gelbc(gelsideright, fInterface);
-        auto intr = new TPZMultiphysicsInterfaceElement(cmeshm, gelbc.CreatedElement(),index,celsideright,celsideaverpr);
+        auto intr = new TPZMultiphysicsInterfaceElement(cmeshm, gelbc.CreatedElement(),celsideright,celsideaverpr);
         fElementPartition[gelbc.CreatedElement()->Index()] = fElementPartition[gelsideright.Element()->Index()];
     }
 }
@@ -984,9 +981,9 @@ void TPZBuildSBFemMultiphysics::CreateSBFemMultiphysicsElGroups(TPZMultiphysicsC
     
     for (int64_t el=0; el<numgroups; el++)
     {
-        int64_t index;
-        new TPZSBFemMultiphysicsElGroup(cmesh,index);
-        elementgroupindices[el] = index;
+        
+        TPZCompEl* cel = new TPZSBFemMultiphysicsElGroup(cmesh);
+        elementgroupindices[el] = cel->Index();
     }
     int dim = cmesh.Dimension();
     for (auto cel : cmesh.ElementVec())

--- a/Pre/TPZHybridizeHDiv.cpp
+++ b/Pre/TPZHybridizeHDiv.cpp
@@ -127,8 +127,7 @@ std::tuple<int64_t, int> TPZHybridizeHDiv::SplitConnects(const TPZCompElSide &le
         intelleft->LoadElementReference();
         intelleft->SetPreferredOrder(sideorder);
         TPZGeoElBC gbc(gleft, fHDivWrapMatid);
-        int64_t index;
-        wrap1 = fluxmesh->ApproxSpace().CreateCompEl(gbc.CreatedElement(), *fluxmesh, index);
+        wrap1 = fluxmesh->ApproxSpace().CreateCompEl(gbc.CreatedElement(), *fluxmesh);
         if(cleft.Order() != sideorder)
         {
             DebugStop();
@@ -148,8 +147,7 @@ std::tuple<int64_t, int> TPZHybridizeHDiv::SplitConnects(const TPZCompElSide &le
         int rightprevorder = cright.Order();
         intelright->SetPreferredOrder(cright.Order());
         TPZGeoElBC gbc(gright, fHDivWrapMatid);
-        int64_t index;
-        wrap2 = fluxmesh->ApproxSpace().CreateCompEl(gbc.CreatedElement(), *fluxmesh, index);
+        wrap2 = fluxmesh->ApproxSpace().CreateCompEl(gbc.CreatedElement(), *fluxmesh);
         if(cright.Order() != rightprevorder)
         {
             DebugStop();
@@ -264,8 +262,7 @@ std::tuple<int64_t, int> TPZHybridizeHDiv::SplitConnects(const TPZCompElSide &le
         intelleft->LoadElementReference();
         intelleft->SetPreferredOrder(sideorder);
         TPZGeoElBC gbc(gleft, fHDivWrapMatid); // creates geoelbc for side
-        int64_t index;
-        wrapleft = fluxmesh->ApproxSpace().CreateCompEl(gbc.CreatedElement(), *fluxmesh, index);
+        wrapleft = fluxmesh->ApproxSpace().CreateCompEl(gbc.CreatedElement(), *fluxmesh);
         if(cleft.Order() != sideorder)
         {
             DebugStop();
@@ -289,8 +286,7 @@ std::tuple<int64_t, int> TPZHybridizeHDiv::SplitConnects(const TPZCompElSide &le
         
         TPZGeoElSide gelside(celside.Reference());
         TPZGeoElBC gbc(gelside,fHDivWrapMatid);
-        int64_t index;
-        TPZCompEl* wrap = fluxmesh->ApproxSpace().CreateCompEl(gbc.CreatedElement(), *fluxmesh, index);
+        TPZCompEl* wrap = fluxmesh->ApproxSpace().CreateCompEl(gbc.CreatedElement(), *fluxmesh);
         wrapvec[i++] = wrap;
         if (con.Order() != prevorder)
             DebugStop();
@@ -380,8 +376,7 @@ bool TPZHybridizeHDiv::HybridizeInterface(TPZCompElSide& celsideleft, TPZInterpo
     int order;
     std::tie(elindex, order) = pindexporder;
     TPZGeoEl *gel = gmesh->Element(elindex);
-    int64_t celindex;
-    TPZCompEl *cel = pressuremesh->ApproxSpace().CreateCompEl(gel, *pressuremesh, celindex);
+    TPZCompEl *cel = pressuremesh->ApproxSpace().CreateCompEl(gel, *pressuremesh);
     TPZInterpolatedElement *intel = dynamic_cast<TPZInterpolatedElement *> (cel);
     TPZCompElDisc *intelDisc = dynamic_cast<TPZCompElDisc *> (cel);
     if (intel){
@@ -453,8 +448,7 @@ void TPZHybridizeHDiv::HybridizeInternalSides(TPZVec<TPZCompMesh *> &meshvec_Hyb
         int order;
         std::tie(elindex, order) = pindex;
         TPZGeoEl *gel = gmesh->Element(elindex);
-        int64_t celindex;
-        TPZCompEl *cel = pressuremesh->ApproxSpace().CreateCompEl(gel, *pressuremesh, celindex);
+        TPZCompEl *cel = pressuremesh->ApproxSpace().CreateCompEl(gel, *pressuremesh);
         TPZInterpolatedElement *intel = dynamic_cast<TPZInterpolatedElement *> (cel);
         TPZCompElDisc *intelDisc = dynamic_cast<TPZCompElDisc *> (cel);
         if (intel){
@@ -501,8 +495,8 @@ void TPZHybridizeHDiv::CreateInterfaceElementsForGeoEl(TPZCompMesh *cmesh_Hybrid
             if (celneigh->NConnects() != 1) {
                 DebugStop();
             }
-            int64_t index;
-            TPZMultiphysicsInterfaceElement *intface = new TPZMultiphysicsInterfaceElement(*cmesh_Hybrid, gbc.CreatedElement(), index, celside, celstackside);
+            
+            TPZMultiphysicsInterfaceElement *intface = new TPZMultiphysicsInterfaceElement(*cmesh_Hybrid, gbc.CreatedElement(), celside, celstackside);
             count++;
         }
     }
@@ -526,9 +520,8 @@ void TPZHybridizeHDiv::CreateInterfaceElementsForGeoEl(TPZCompMesh *cmesh_Hybrid
         clarge = glarge.Reference();
         if(!clarge) DebugStop();
         TPZGeoElBC gbc(gelside, fInterfaceMatid.second);
-
-        int64_t index;
-        TPZMultiphysicsInterfaceElement *intface = new TPZMultiphysicsInterfaceElement(*cmesh_Hybrid, gbc.CreatedElement(), index, celside, clarge);
+        
+        TPZMultiphysicsInterfaceElement *intface = new TPZMultiphysicsInterfaceElement(*cmesh_Hybrid, gbc.CreatedElement(), celside, clarge);
         count++;
     }
     
@@ -570,8 +563,8 @@ void TPZHybridizeHDiv::CreateInterfaceElements(TPZCompMesh *cmesh_Hybrid, TPZVec
                 if (celneigh->NConnects() != 1) {
                     DebugStop();
                 }
-                int64_t index;
-                TPZMultiphysicsInterfaceElement *intface = new TPZMultiphysicsInterfaceElement(*cmesh_Hybrid, gbc.CreatedElement(), index, celside, celstackside);
+                
+                TPZMultiphysicsInterfaceElement *intface = new TPZMultiphysicsInterfaceElement(*cmesh_Hybrid, gbc.CreatedElement(), celside, celstackside);
                 count++;
             }
         }
@@ -595,9 +588,8 @@ void TPZHybridizeHDiv::CreateInterfaceElements(TPZCompMesh *cmesh_Hybrid, TPZVec
             clarge = glarge.Reference();
             if(!clarge) DebugStop();
             TPZGeoElBC gbc(gelside, fInterfaceMatid.second);
-
-            int64_t index;
-            TPZMultiphysicsInterfaceElement *intface = new TPZMultiphysicsInterfaceElement(*cmesh_Hybrid, gbc.CreatedElement(), index, celside, clarge);
+            
+            TPZMultiphysicsInterfaceElement *intface = new TPZMultiphysicsInterfaceElement(*cmesh_Hybrid, gbc.CreatedElement(), celside, clarge);
             count++;
         }
         if (count != 2 && count != 0) {
@@ -730,8 +722,7 @@ void TPZHybridizeHDiv::GroupandCondenseElements(TPZCompMesh *cmesh) {
         if(groupnum == -1) continue;
         auto iter = groupmap.find(groupnum);
         if (groupmap.find(groupnum) == groupmap.end()) {
-            int64_t index;
-            TPZElementGroup *elgr = new TPZElementGroup(*cmesh,index);
+            TPZElementGroup *elgr = new TPZElementGroup(*cmesh);
             groupmap[groupnum] = elgr;
             elgr->AddElement(cmesh->Element(el));
         }
@@ -766,8 +757,7 @@ void TPZHybridizeHDiv::GroupandCondenseElements(TPZCompMesh *cmesh, int lagrange
         if(groupnum == -1) continue;
         auto iter = groupmap.find(groupnum);
         if (groupmap.find(groupnum) == groupmap.end()) {
-            int64_t index;
-            TPZElementGroup *elgr = new TPZElementGroup(*cmesh,index);
+            TPZElementGroup *elgr = new TPZElementGroup(*cmesh);
             groupmap[groupnum] = elgr;
             elgr->AddElement(cmesh->Element(el));
         }

--- a/Pre/pzbuildmultiphysicsmesh.cpp
+++ b/Pre/pzbuildmultiphysicsmesh.cpp
@@ -617,9 +617,8 @@ void TPZBuildMultiphysicsMesh::BuildHybridMesh(TPZCompMesh *cmesh, std::set<int>
                 DebugStop();
             }
             
-            TPZGeoEl *interfaceEl = gel->CreateBCGeoEl(is, interfacematid);
-            int64_t index;
-            new TPZInterfaceElement(*cmesh,interfaceEl,index,left,right);
+            TPZGeoEl *interfaceEl = gel->CreateBCGeoEl(is, interfacematid);            
+            new TPZInterfaceElement(*cmesh,interfaceEl,left,right);
             
         }
 	}
@@ -840,15 +839,14 @@ void TPZBuildMultiphysicsMesh::AddWrap(TPZMultiphysicsElement *mfcel, int matske
         TPZConnect &conside = intel->Connect(loccon);
         int sideorder = conside.Order();
         intel->Mesh()->SetDefaultOrder(sideorder);
-        
-        int64_t index;
+                
         TPZInterpolationSpace *bound;
         MElementType elType = gel->Type(side);
         switch(elType)
         {
             case(EOned)://line
             {
-                bound = new TPZCompElHDivBound2<pzshape::TPZShapeLinear>(* intel->Mesh(),gelbound,index);
+                bound = new TPZCompElHDivBound2<pzshape::TPZShapeLinear>(* intel->Mesh(),gelbound);
                 int sideorient = intel->GetSideOrient(side);
                 TPZCompElHDivBound2<pzshape::TPZShapeLinear> *hdivbound = dynamic_cast< TPZCompElHDivBound2<pzshape::TPZShapeLinear> *>(bound);
                 hdivbound->SetSideOrient(pzshape::TPZShapeLinear::NSides-1,sideorient);
@@ -856,7 +854,7 @@ void TPZBuildMultiphysicsMesh::AddWrap(TPZMultiphysicsElement *mfcel, int matske
             }
             case(ETriangle)://triangle
             {
-                bound = new TPZCompElHDivBound2<pzshape::TPZShapeTriang>(* intel->Mesh(),gelbound,index);
+                bound = new TPZCompElHDivBound2<pzshape::TPZShapeTriang>(* intel->Mesh(),gelbound);
                 int sideorient = intel->GetSideOrient(side);
                 TPZCompElHDivBound2<pzshape::TPZShapeTriang> *hdivbound = dynamic_cast< TPZCompElHDivBound2<pzshape::TPZShapeTriang> *>(bound);
                 hdivbound->SetSideOrient(pzshape::TPZShapeTriang::NSides-1,sideorient);
@@ -864,7 +862,7 @@ void TPZBuildMultiphysicsMesh::AddWrap(TPZMultiphysicsElement *mfcel, int matske
             }
             case(EQuadrilateral)://quadrilateral
             {
-                bound = new TPZCompElHDivBound2<pzshape::TPZShapeQuad>(* intel->Mesh(),gelbound,index);
+                bound = new TPZCompElHDivBound2<pzshape::TPZShapeQuad>(* intel->Mesh(),gelbound);
                 int sideorient = intel->GetSideOrient(side);
                 TPZCompElHDivBound2<pzshape::TPZShapeQuad> *hdivbound = dynamic_cast< TPZCompElHDivBound2<pzshape::TPZShapeQuad> *>(bound);
                 hdivbound->SetSideOrient(pzshape::TPZShapeQuad::NSides-1,sideorient);
@@ -891,7 +889,7 @@ void TPZBuildMultiphysicsMesh::AddWrap(TPZMultiphysicsElement *mfcel, int matske
         bound->SetConnectIndex(0, sideconnectindex);
         //bound->Print(std::cout);
         
-        TPZCompEl *newMFBound = multiMesh->CreateCompEl(gelbound, index);
+        TPZCompEl *newMFBound = multiMesh->CreateCompEl(gelbound);
         TPZMultiphysicsElement *locMF = dynamic_cast<TPZMultiphysicsElement *>(newMFBound);
         
         locMF->AddElement(bound, 0);

--- a/SubStruct/pzdohrstructmatrix.cpp
+++ b/SubStruct/pzdohrstructmatrix.cpp
@@ -1229,7 +1229,8 @@ void  TPZDohrStructMatrix<TVar,TPar>::SubStructure(int nsub )
 #ifdef PZDEBUG
         std::cout << '^'; std::cout.flush();
 #endif
-        submeshes[isub] = new TPZSubCompMesh(*(this->fMesh),index);
+        submeshes[isub] = new TPZSubCompMesh(*(this->fMesh));
+        index = submeshes[isub]->Index();
         if (index < domain_index.NElements()) {
             domain_index[index] = -1;
         }

--- a/SubStruct/tpzgensubstruct.cpp
+++ b/SubStruct/tpzgensubstruct.cpp
@@ -210,9 +210,8 @@ void TPZGenSubStruct::SubStructure()
 					nelstack = 1;
 				}
 			}
-			int64_t index;
 			TPZCompMesh *cmesh = fCMesh.operator->();
-			TPZSubCompMesh *submesh = new TPZSubCompMesh(*cmesh,index);
+			TPZSubCompMesh *submesh = new TPZSubCompMesh(*cmesh);
 			std::cout << '*';
 			std::cout.flush();
 			int sub;

--- a/UnitTest_PZ/TestHDivCollapsed/TestHDivCollapsed.cpp
+++ b/UnitTest_PZ/TestHDivCollapsed/TestHDivCollapsed.cpp
@@ -499,13 +499,12 @@ void CreateFractureHDivCollapsedEl(TPZCompMesh* cmesh) {
         if (hassubel) { // the mesh can be uniformly refined
             continue;
         }
-        int64_t index;
         TPZInterpolationSpace* hdivcollapsed = nullptr;
         if (gmeshdim == 2){
-            hdivcollapsed = new TPZCompElHDivCollapsed<pzshape::TPZShapeLinear>(*cmesh,gel,index);
+            hdivcollapsed = new TPZCompElHDivCollapsed<pzshape::TPZShapeLinear>(*cmesh,gel);
         }
         else {
-            hdivcollapsed = new TPZCompElHDivCollapsed<pzshape::TPZShapeQuad>(*cmesh,gel,index);
+            hdivcollapsed = new TPZCompElHDivCollapsed<pzshape::TPZShapeQuad>(*cmesh,gel);
         }
         
     }

--- a/UnitTest_PZ/TestMesh/TestKernelHDiv.cpp
+++ b/UnitTest_PZ/TestMesh/TestKernelHDiv.cpp
@@ -268,7 +268,6 @@ TPZCompMesh * CreateFluxCMesh(TPZGeoMesh *fGeoMesh, int fDimension, int fDefault
 
         if(!gel) DebugStop();
         auto type = gel -> Type();
-        int64_t index;
         auto matid = gel->MaterialId();
 
         using namespace pzgeom;
@@ -276,7 +275,7 @@ TPZCompMesh * CreateFluxCMesh(TPZGeoMesh *fGeoMesh, int fDimension, int fDefault
 
         if (type == EPoint){
             if (fDimension == 3) continue;
-            new TPZCompElH1<TPZShapePoint>(*cmesh,gel,index);
+            new TPZCompElH1<TPZShapePoint>(*cmesh,gel);
             TPZMaterial *mat = cmesh->FindMaterial(matid);
             TPZNullMaterial<> *nullmat = dynamic_cast<TPZNullMaterial<> *>(mat);
             // nullmat->SetDimension(0);
@@ -285,9 +284,9 @@ TPZCompMesh * CreateFluxCMesh(TPZGeoMesh *fGeoMesh, int fDimension, int fDefault
             if (allMat.find(matid) == allMat.end()) continue;
             
             if (fShapeType == EHDivKernel || fShapeType == EHCurlNoGrads){
-                new TPZCompElKernelHDivBC<TPZShapeLinear>(*cmesh,gel,index);
+                new TPZCompElKernelHDivBC<TPZShapeLinear>(*cmesh,gel);
             } else if (fShapeType == EHDivConstant) {
-                new TPZCompElHDivConstantBC<TPZShapeLinear>(*cmesh,gel,index);
+                new TPZCompElHDivConstantBC<TPZShapeLinear>(*cmesh,gel);
             } else {
                 DebugStop();
             }
@@ -298,9 +297,9 @@ TPZCompMesh * CreateFluxCMesh(TPZGeoMesh *fGeoMesh, int fDimension, int fDefault
         } else if (type == EQuadrilateral){
             if (fDimension == 2){
                 if (fShapeType == EHDivKernel || fShapeType == EHCurlNoGrads){
-                    new TPZCompElKernelHDiv<TPZShapeQuad>(*cmesh,gel,index);
+                    new TPZCompElKernelHDiv<TPZShapeQuad>(*cmesh,gel);
                 } else if (fShapeType == EHDivConstant) {
-                    new TPZCompElHDivConstant<TPZShapeQuad>(*cmesh,gel,index);
+                    new TPZCompElHDivConstant<TPZShapeQuad>(*cmesh,gel);
                 } else {
                     DebugStop();
                 }
@@ -310,9 +309,9 @@ TPZCompMesh * CreateFluxCMesh(TPZGeoMesh *fGeoMesh, int fDimension, int fDefault
             } else if (fDimension == 3){
                 if (allMat.find(matid) == allMat.end()) continue;
                 if (fShapeType == EHDivKernel || fShapeType == EHCurlNoGrads){
-                    new TPZCompElKernelHDivBC3D<TPZShapeQuad>(*cmesh,gel,index,fShapeType);
+                    new TPZCompElKernelHDivBC3D<TPZShapeQuad>(*cmesh,gel,fShapeType);
                 } else if (fShapeType == EHDivConstant) {
-                    new TPZCompElHDivConstantBC<TPZShapeQuad>(*cmesh,gel,index);
+                    new TPZCompElHDivConstantBC<TPZShapeQuad>(*cmesh,gel);
                 } else {
                     DebugStop();
                 }
@@ -324,9 +323,9 @@ TPZCompMesh * CreateFluxCMesh(TPZGeoMesh *fGeoMesh, int fDimension, int fDefault
         } else if(type == ETriangle) {
             if (fDimension == 2){
                 if (fShapeType == EHDivKernel){
-                    new TPZCompElKernelHDiv<TPZShapeTriang>(*cmesh,gel,index);
+                    new TPZCompElKernelHDiv<TPZShapeTriang>(*cmesh,gel);
                 } else if (fShapeType == EHDivConstant){
-                    new TPZCompElHDivConstant<TPZShapeTriang>(*cmesh,gel,index);
+                    new TPZCompElHDivConstant<TPZShapeTriang>(*cmesh,gel);
                 } else {
                     DebugStop();
                 }
@@ -336,9 +335,9 @@ TPZCompMesh * CreateFluxCMesh(TPZGeoMesh *fGeoMesh, int fDimension, int fDefault
             } else if (fDimension == 3){
                 if (allMat.find(matid) == allMat.end()) continue;
                 if (fShapeType == EHDivKernel || fShapeType == EHCurlNoGrads){
-                    new TPZCompElKernelHDivBC3D<TPZShapeTriang>(*cmesh,gel,index,fShapeType);
+                    new TPZCompElKernelHDivBC3D<TPZShapeTriang>(*cmesh,gel,fShapeType);
                 } else if (fShapeType == EHDivConstant) {
-                    new TPZCompElHDivConstantBC<TPZShapeTriang>(*cmesh,gel,index);
+                    new TPZCompElHDivConstantBC<TPZShapeTriang>(*cmesh,gel);
                 } else {
                     DebugStop();
                 }
@@ -349,9 +348,9 @@ TPZCompMesh * CreateFluxCMesh(TPZGeoMesh *fGeoMesh, int fDimension, int fDefault
             }
         } else if(type == ETetraedro) {
             if (fShapeType == EHDivKernel || fShapeType == EHCurlNoGrads){
-                new TPZCompElKernelHDiv3D<TPZShapeTetra>(*cmesh,gel,index,fShapeType);
+                new TPZCompElKernelHDiv3D<TPZShapeTetra>(*cmesh,gel,fShapeType);
             } else if (fShapeType == EHDivConstant){
-                new TPZCompElHDivConstant<TPZShapeTetra>(*cmesh,gel,index);
+                new TPZCompElHDivConstant<TPZShapeTetra>(*cmesh,gel);
             } else {
                 DebugStop();
             }
@@ -360,9 +359,9 @@ TPZCompMesh * CreateFluxCMesh(TPZGeoMesh *fGeoMesh, int fDimension, int fDefault
             nullmat->SetDimension(3);
         } else if(type == ECube) {
             if (fShapeType == EHDivKernel || fShapeType == EHCurlNoGrads){
-                new TPZCompElKernelHDiv3D<TPZShapeCube>(*cmesh,gel,index,fShapeType);
+                new TPZCompElKernelHDiv3D<TPZShapeCube>(*cmesh,gel,fShapeType);
             } else if (fShapeType == EHDivConstant){
-                new TPZCompElHDivConstant<TPZShapeCube>(*cmesh,gel,index);
+                new TPZCompElHDivConstant<TPZShapeCube>(*cmesh,gel);
             } else {
                 DebugStop();
             }
@@ -371,9 +370,9 @@ TPZCompMesh * CreateFluxCMesh(TPZGeoMesh *fGeoMesh, int fDimension, int fDefault
             nullmat->SetDimension(3);
         } else if(type == EPrisma) {
             if (fShapeType == EHDivKernel || fShapeType == EHCurlNoGrads){
-                new TPZCompElKernelHDiv3D<TPZShapePrism>(*cmesh,gel,index,fShapeType);
+                new TPZCompElKernelHDiv3D<TPZShapePrism>(*cmesh,gel,fShapeType);
             } else if (fShapeType == EHDivConstant){
-                new TPZCompElHDivConstant<TPZShapePrism>(*cmesh,gel,index);
+                new TPZCompElHDivConstant<TPZShapePrism>(*cmesh,gel);
             } else {
                 DebugStop();
             }

--- a/cmake/EnableMKL.cmake
+++ b/cmake/EnableMKL.cmake
@@ -18,7 +18,7 @@ function(enable_mkl target)
   message(STATUS "Setting MKL threading model: ${MKL_THREAD_MODEL}")
   
   #do NOT change this lib unless you know what you are doing
-  target_link_libraries(${target} PUBLIC mkl::mkl_intel_32bit_${MKL_THREAD_MODEL}_dyn)
+  target_link_libraries(${target} PRIVATE mkl::mkl_intel_32bit_${MKL_THREAD_MODEL}_dyn)
 
   if(MKL_THREAD_MODEL STREQUAL "tbb")
     include(cmake/EnableTBB.cmake)
@@ -29,8 +29,8 @@ function(enable_mkl target)
   #if(APPLE)
  #     target_link_libraries(${target} PRIVATE ${_mkl_core_lib})
   #endif()
-  target_include_directories(${target} PUBLIC ${MKL_INCLUDE_DIR})
-  target_compile_definitions(${target} PUBLIC USING_MKL)
+  target_include_directories(${target} PRIVATE ${MKL_INCLUDE_DIR})
+  target_compile_definitions(${target} PRIVATE USING_MKL)
   target_compile_definitions(${target} INTERFACE PZ_USING_MKL)
 
   set(USING_LAPACK ON CACHE PATH "Whether the LAPACK library will be linked in" FORCE)

--- a/cmake/EnableMKL.cmake
+++ b/cmake/EnableMKL.cmake
@@ -18,7 +18,7 @@ function(enable_mkl target)
   message(STATUS "Setting MKL threading model: ${MKL_THREAD_MODEL}")
   
   #do NOT change this lib unless you know what you are doing
-  target_link_libraries(${target} PRIVATE mkl::mkl_intel_32bit_${MKL_THREAD_MODEL}_dyn)
+  target_link_libraries(${target} PUBLIC mkl::mkl_intel_32bit_${MKL_THREAD_MODEL}_dyn)
 
   if(MKL_THREAD_MODEL STREQUAL "tbb")
     include(cmake/EnableTBB.cmake)
@@ -29,8 +29,8 @@ function(enable_mkl target)
   #if(APPLE)
  #     target_link_libraries(${target} PRIVATE ${_mkl_core_lib})
   #endif()
-  target_include_directories(${target} PRIVATE ${MKL_INCLUDE_DIR})
-  target_compile_definitions(${target} PRIVATE USING_MKL)
+  target_include_directories(${target} PUBLIC ${MKL_INCLUDE_DIR})
+  target_compile_definitions(${target} PUBLIC USING_MKL)
   target_compile_definitions(${target} INTERFACE PZ_USING_MKL)
 
   set(USING_LAPACK ON CACHE PATH "Whether the LAPACK library will be linked in" FORCE)


### PR DESCRIPTION
Removed the index argument from TPZCompEl constructor. This argument is actually not necessary since the compel has an attribute TPZCompEl::fIndex that can be accessed through the function TPZCompEl::Index().
This caused several child classes constructors to break and all of these were corrected.