### PR TITLE
Solution on boundary elements

### DIFF
--- a/Analysis/TPZAnalysis.cpp
+++ b/Analysis/TPZAnalysis.cpp
@@ -865,7 +865,7 @@ void TPZAnalysis::IdentifyPostProcessingMatIds(int dimension, std::set<int> & ma
         TPZMaterial *mat = matit->second;
         auto *lag = dynamic_cast<TPZLagrangeMultiplierBase *> (mat);
         TPZBndCond *bc = dynamic_cast<TPZBndCond *> (mat);
-        if (mat && !bc && !lag && mat->Dimension() == dimension){
+        if (mat && !lag && mat->Dimension() == dimension){
             matids.insert(mat->Id());
         }
     }

--- a/Material/CMakeLists.txt
+++ b/Material/CMakeLists.txt
@@ -25,6 +25,7 @@ set(public_headers
     TPZMatErrorSingleSpace.h
     TPZMatInterfaceSingleSpace.h
     TPZMatTransientSingleSpace.h
+    TPZMatSingleSpaceBCSol.h
     #combined spaces materials
     TPZMatCombinedSpaces.h
     TPZMatErrorCombinedSpaces.h
@@ -57,6 +58,7 @@ set(headers
     TPZMatErrorSingleSpace.h
     TPZMatInterfaceSingleSpace.h
     TPZMatTransientSingleSpace.h
+    TPZMatSingleSpaceBCSol.h
     #combined spaces materials
     TPZMatCombinedSpaces.h
     TPZMatErrorCombinedSpaces.h
@@ -83,6 +85,7 @@ set(sources
     TPZMatErrorSingleSpace.cpp
     TPZMatInterfaceSingleSpace.cpp
     TPZMatTransientSingleSpace.cpp
+    TPZMatSingleSpaceBCSol.cpp
     #combined spaces materials
     TPZMatCombinedSpaces.cpp
     TPZMatErrorCombinedSpaces.cpp

--- a/Material/Projection/TPZHCurlProjection.cpp
+++ b/Material/Projection/TPZHCurlProjection.cpp
@@ -129,10 +129,24 @@ int TPZHCurlProjection<TVar>::VariableIndex(const std::string &name) const{
 template<class TVar>
 int TPZHCurlProjection<TVar>::NSolutionVariables(int var) const{
 	if(var == ESolution) return fDim;
-    if (var == ECurl) return fCurlDim;
+  if (var == ECurl) return fCurlDim;
     
 	
-    return TPZMaterial::NSolutionVariables(var);
+  return TPZMaterial::NSolutionVariables(var);
+}
+
+template<class TVar>
+int TPZHCurlProjection<TVar>::NSolutionVariablesBC(int var) const{
+    if(fDim ==3){
+        if(var == ESolution) return 2;
+        if(var == ECurl) return 1;
+    }else{
+        if(var == ESolution) return 1;
+        //no idea on how to plot the curl in 1d bound els
+    }
+    
+	
+  return TPZMaterial::NSolutionVariables(var);
 }
 
 template<class TVar>
@@ -155,6 +169,16 @@ void TPZHCurlProjection<TVar>::Solution(const TPZMaterialDataT<TVar> &data,
             PZError<<"\nCouldnt identify solution index. Aborting...\n";
             DebugStop();
     }
+}
+
+template<class TVar>
+void TPZHCurlProjection<TVar>::SolutionBC(const TPZMaterialDataT<TVar> &data,
+                                          int var, TPZVec<TVar> &solOut)
+{
+    const int dim = this->Dimension();
+    this->SetDimension(dim-1);
+    this->Solution(data,var,solOut);
+    this->SetDimension(dim);
 }
 
 template<class TVar>

--- a/Material/Projection/TPZHCurlProjection.h
+++ b/Material/Projection/TPZHCurlProjection.h
@@ -74,6 +74,9 @@ public:
 	
 	/** @brief It returns the variable index associated with the name */
 	int VariableIndex(const std::string &name) const override;
+
+  int VariableIndexBC(const std::string &name) const override
+  {return VariableIndex(name);}
 	
 	int NSolutionVariables(int var) const override;
   

--- a/Material/Projection/TPZHCurlProjection.h
+++ b/Material/Projection/TPZHCurlProjection.h
@@ -76,13 +76,16 @@ public:
 	int VariableIndex(const std::string &name) const override;
 	
 	int NSolutionVariables(int var) const override;
+  
+  int NSolutionVariablesBC(int var) const override;
 
-    void Solution(const TPZMaterialDataT<TVar> &data,
-                  int var, TPZVec<TVar> &solOut) override;
-    
-    void GetSolDimensions(uint64_t &u_len,
-                          uint64_t &du_row,
-                          uint64_t &du_col) const override;
+  void Solution(const TPZMaterialDataT<TVar> &data,
+                int var, TPZVec<TVar> &solOut) override;
+  void SolutionBC(const TPZMaterialDataT<TVar> &data,
+                int var, TPZVec<TVar> &solOut) override;
+  void GetSolDimensions(uint64_t &u_len,
+                        uint64_t &du_row,
+                        uint64_t &du_col) const override;
 
     void Errors(const TPZMaterialDataT<TVar> &data,
                 TPZVec<REAL> &errors) override;

--- a/Material/Projection/TPZHCurlProjection.h
+++ b/Material/Projection/TPZHCurlProjection.h
@@ -8,7 +8,7 @@
 #define TPZHCURLPROJECTION_H
 
 #include "TPZMatBase.h"
-#include "TPZMatSingleSpace.h"
+#include "TPZMatSingleSpaceBCSol.h"
 #include "TPZMatErrorSingleSpace.h"
 
 /**
@@ -25,10 +25,10 @@
  */
 template<class TVar=STATE>
 class  TPZHCurlProjection :
-    public TPZMatBase<TVar,TPZMatSingleSpaceT<TVar>,
-                      TPZMatErrorSingleSpace<TVar>>
+    public TPZMatBase<TVar,TPZMatSingleSpaceBCSol<TVar>,
+                      TPZMatErrorSingleSpace<TVar>  >
 {
-	using TBase = TPZMatBase<TVar,TPZMatSingleSpaceT<TVar>,TPZMatErrorSingleSpace<TVar>>;
+	using TBase = TPZMatBase<TVar,TPZMatSingleSpaceBCSol<TVar>,TPZMatErrorSingleSpace<TVar>>;
 public:
     //! Default constructor
     TPZHCurlProjection();

--- a/Material/TPZBndCondBase.h
+++ b/Material/TPZBndCondBase.h
@@ -4,7 +4,6 @@
 #include "TPZBndCondT.h"
 
 
-
 /**
  * @brief This class ensures that the boundary condition material is compatible
  * with any given interfaces.
@@ -41,11 +40,8 @@ class TPZBndCondBase :
     [[nodiscard]] int NStateVariables() const final
     {return this->fMaterial->NStateVariables();}
 
-    [[nodiscard]] int NSolutionVariables(int var) const final
-    { return this->fMaterial->NSolutionVariablesBC(var);}
-    /** @brief Returns the variable index associated with a given name */
-    [[nodiscard]] int VariableIndex(const std::string &name) const final
-    { return this->fMaterial->VariableIndexBC(name);}
+
+
     
     [[nodiscard]] int Id() const override {
         return TPZMaterial::Id();

--- a/Material/TPZBndCondBase.h
+++ b/Material/TPZBndCondBase.h
@@ -45,7 +45,7 @@ class TPZBndCondBase :
     { return this->fMaterial->NSolutionVariablesBC(var);}
     /** @brief Returns the variable index associated with a given name */
     [[nodiscard]] int VariableIndex(const std::string &name) const final
-    { return this->fMaterial->VariableIndex(name);}
+    { return this->fMaterial->VariableIndexBC(name);}
     
     [[nodiscard]] int Id() const override {
         return TPZMaterial::Id();

--- a/Material/TPZBndCondBase.h
+++ b/Material/TPZBndCondBase.h
@@ -36,10 +36,17 @@ class TPZBndCondBase :
     void SetMaterial(TPZMaterial *) final;
     
     [[nodiscard]] int Dimension() const final
-    {return this->fMaterial->Dimension();}
+    {return this->fMaterial->Dimension() - 1;}
+    
     [[nodiscard]] int NStateVariables() const final
     {return this->fMaterial->NStateVariables();}
 
+    [[nodiscard]] int NSolutionVariables(int var) const final
+    { return this->fMaterial->NSolutionVariablesBC(var);}
+    /** @brief Returns the variable index associated with a given name */
+    [[nodiscard]] int VariableIndex(const std::string &name) const final
+    { return this->fMaterial->VariableIndex(name);}
+    
     [[nodiscard]] int Id() const override {
         return TPZMaterial::Id();
     }

--- a/Material/TPZMatCombinedSpaces.cpp
+++ b/Material/TPZMatCombinedSpaces.cpp
@@ -10,6 +10,31 @@ int TPZMatCombinedSpaces::ClassId() const{
     return Hash("TPZMatCombinedSpaces");
 }
 
+/** @brief Returns the variable index associated with a given name */
+
+int TPZMatCombinedSpaces::VariableIndex(const std::string &name) const
+{
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<" should be implemented in your material";
+    PZError<<" for any sort of post processing of the FEM solution\n";
+    PZError<<"Aborting...\n";
+    DebugStop();
+}
+    
+    /** 
+	 * @brief Returns the number of variables associated with the variable indexed by var. 
+	 * @param var Index variable into the solution, is obtained by calling VariableIndex
+	 */
+
+int TPZMatCombinedSpaces::NSolutionVariables(int var) const
+{
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<" should be implemented in your material";
+    PZError<<" for any sort of post processing of the FEM solution\n";
+    PZError<<"Aborting...\n";
+    DebugStop();
+}
+
 template<class TVar>
 void TPZMatCombinedSpacesT<TVar>::FillDataRequirements(TPZVec<TPZMaterialDataT<TVar>> &datavec) const
 {
@@ -122,6 +147,7 @@ void TPZMatCombinedSpacesBC<TVar>::ContributeBC(const TPZVec<TPZMaterialDataT<TV
     PZError<< "should not be called! Aborting...\n";
     DebugStop();
 }
+
 
 template<class TVar>
 void TPZMatCombinedSpacesBC<TVar>::Solution(const TPZVec<TPZMaterialDataT<TVar>> &datavec, int var,

--- a/Material/TPZMatCombinedSpaces.h
+++ b/Material/TPZMatCombinedSpaces.h
@@ -42,6 +42,24 @@ public:
     [[nodiscard]]virtual int IntegrationRuleOrder(const TPZVec<int> &elPMaxOrder) const = 0;
     
     [[nodiscard]] int ClassId() const override;
+
+        /** @name PostProcess
+     * @{
+     */
+    
+    /** @brief Returns the variable index associated with a given name */
+    [[nodiscard]] virtual int VariableIndex(const std::string &name) const;
+    
+    /** 
+	 * @brief Returns the number of variables associated with the variable indexed by var. 
+	 * @param var Index variable into the solution, is obtained by calling VariableIndex
+	 */
+    [[nodiscard]] virtual int NSolutionVariables(int var) const;
+
+    /**
+     * @}
+     */
+
 };
 
 template<class TVar>

--- a/Material/TPZMatSingleSpace.cpp
+++ b/Material/TPZMatSingleSpace.cpp
@@ -58,6 +58,17 @@ void TPZMatSingleSpaceT<TVar>::Solution(const TPZMaterialDataT<TVar> &data, int 
 }
 
 template<class TVar>
+void TPZMatSingleSpaceT<TVar>::SolutionBC(const TPZMaterialDataT<TVar> &data, int var,
+         TPZVec<TVar> &sol){
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<" should be implemented in your material\n"
+           <<" for any sort of post processing of the FEM solution\n"
+           <<" over the boundaries\n"
+           <<"Aborting..."<<std::endl;
+    DebugStop();
+}
+
+template<class TVar>
 int TPZMatSingleSpaceT<TVar>::IntegrationRuleOrder(const int elPMaxOrder) const
 {
     auto *tmp = dynamic_cast<const TPZMaterialT<TVar>*>(this);
@@ -114,9 +125,7 @@ void TPZMatSingleSpaceBC<TVar>::Solution(const TPZMaterialDataT<TVar> &data,
                                          int var,
                                          TPZVec<TVar> &sol)
 {
-    PZError<<__PRETTY_FUNCTION__;
-    PZError<< "should not be called! Aborting...\n";
-    DebugStop();
+    fMatSingleSpace->SolutionBC(data,var,sol);
 }
 
 template<class TVar>

--- a/Material/TPZMatSingleSpace.cpp
+++ b/Material/TPZMatSingleSpace.cpp
@@ -57,16 +57,43 @@ void TPZMatSingleSpaceT<TVar>::Solution(const TPZMaterialDataT<TVar> &data, int 
     DebugStop();
 }
 
-template<class TVar>
-void TPZMatSingleSpaceT<TVar>::SolutionBC(const TPZMaterialDataT<TVar> &data, int var,
-         TPZVec<TVar> &sol){
+   
+/** @brief Returns the variable index associated with a given name */
+
+int TPZMatSingleSpace::VariableIndex(const std::string &name) const
+{
     PZError<<__PRETTY_FUNCTION__;
-    PZError<<" should be implemented in your material\n"
-           <<" for any sort of post processing of the FEM solution\n"
-           <<" over the boundaries\n"
-           <<"Aborting..."<<std::endl;
+    PZError<<" should be implemented in your material";
+    PZError<<" for any sort of post processing of the FEM solution\n";
+    PZError<<"Aborting...\n";
     DebugStop();
 }
+    
+    /** 
+	 * @brief Returns the number of variables associated with the variable indexed by var. 
+	 * @param var Index variable into the solution, is obtained by calling VariableIndex
+	 */
+
+int TPZMatSingleSpace::NSolutionVariables(int var) const
+{
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<" should be implemented in your material";
+    PZError<<" for any sort of post processing of the FEM solution\n";
+    PZError<<"Aborting...\n";
+    DebugStop();
+}
+
+
+// template<class TVar>
+// void TPZMatSingleSpaceT<TVar>::SolutionBC(const TPZMaterialDataT<TVar> &data, int var,
+//          TPZVec<TVar> &sol){
+//     PZError<<__PRETTY_FUNCTION__;
+//     PZError<<" should be implemented in your material\n"
+//            <<" for any sort of post processing of the FEM solution\n"
+//            <<" over the boundaries\n"
+//            <<"Aborting..."<<std::endl;
+//     DebugStop();
+// }
 
 template<class TVar>
 int TPZMatSingleSpaceT<TVar>::IntegrationRuleOrder(const int elPMaxOrder) const
@@ -120,13 +147,7 @@ void TPZMatSingleSpaceBC<TVar>::ContributeBC(const TPZMaterialDataT<TVar> &data,
     DebugStop();
 }
 
-template<class TVar>
-void TPZMatSingleSpaceBC<TVar>::Solution(const TPZMaterialDataT<TVar> &data,
-                                         int var,
-                                         TPZVec<TVar> &sol)
-{
-    fMatSingleSpace->SolutionBC(data,var,sol);
-}
+
 
 template<class TVar>
 void TPZMatSingleSpaceBC<TVar>::FillDataRequirements(TPZMaterialData &data) const{

--- a/Material/TPZMatSingleSpace.h
+++ b/Material/TPZMatSingleSpace.h
@@ -28,7 +28,7 @@ class TPZVec;
  * It contains the type-agonstic interfaces that simple (non-multiphysics) 
  * materials should implement.
  */
-class TPZMatSingleSpace : public virtual TPZSavable{
+class TPZMatSingleSpace : public virtual TPZSavable {
 public:
     //! Default constructor
     TPZMatSingleSpace() = default;
@@ -70,6 +70,26 @@ public:
                                   uint64_t &du_row,
                                   uint64_t &du_col) const;
     [[nodiscard]] int ClassId() const override;
+
+    /** @name PostProcess
+     * @{
+     */
+    
+    /** @brief Returns the variable index associated with a given name */
+    [[nodiscard]] virtual int VariableIndex(const std::string &name) const;
+    
+    /** 
+	 * @brief Returns the number of variables associated with the variable indexed by var. 
+	 * @param var Index variable into the solution, is obtained by calling VariableIndex
+	 */
+    [[nodiscard]] virtual int NSolutionVariables(int var) const;
+
+
+
+    /**
+     * @}
+     */
+
 };
 
 
@@ -161,16 +181,6 @@ public:
     virtual void Solution(const TPZMaterialDataT<TVar> &data, int var,
                           TPZVec<TVar> &sol);
 
-    /** @brief Returns the solution associated with a given index
-        on boundary elements.
-        This method should be implemented if any computations 
-        on the solution are to be done.
-        @param[in] data Stores all the input data.
-        @param[in] var Index of the queried solution
-        @param[out] sol FEM Solution at the integration point
-    */
-    virtual void SolutionBC(const TPZMaterialDataT<TVar> &data, int var,
-                          TPZVec<TVar> &sol);    
     [[nodiscard]] int IntegrationRuleOrder(const int elPMaxOrder) const override;
     
     [[nodiscard]] int ClassId() const override;
@@ -198,9 +208,6 @@ public:
     void ContributeBC(const TPZMaterialDataT<TVar> &data, REAL weight,
                       TPZFMatrix<TVar> &ek, TPZFMatrix<TVar> &ef,
                       TPZBndCondT<TVar> &bc) override;
-    /** @brief This method should never be called. Throws.*/
-    void Solution(const TPZMaterialDataT<TVar> &data, int var,
-                  TPZVec<TVar> &sol) override;
     /** @brief Forward the call to TPZMatSingleSpaceT::FillBoundaryConditionDataRequirements*/
     void FillDataRequirements(TPZMaterialData &data) const override;
     

--- a/Material/TPZMatSingleSpace.h
+++ b/Material/TPZMatSingleSpace.h
@@ -160,7 +160,17 @@ public:
     */
     virtual void Solution(const TPZMaterialDataT<TVar> &data, int var,
                           TPZVec<TVar> &sol);
-    
+
+    /** @brief Returns the solution associated with a given index
+        on boundary elements.
+        This method should be implemented if any computations 
+        on the solution are to be done.
+        @param[in] data Stores all the input data.
+        @param[in] var Index of the queried solution
+        @param[out] sol FEM Solution at the integration point
+    */
+    virtual void SolutionBC(const TPZMaterialDataT<TVar> &data, int var,
+                          TPZVec<TVar> &sol);    
     [[nodiscard]] int IntegrationRuleOrder(const int elPMaxOrder) const override;
     
     [[nodiscard]] int ClassId() const override;

--- a/Material/TPZMatSingleSpaceBCSol.cpp
+++ b/Material/TPZMatSingleSpaceBCSol.cpp
@@ -1,0 +1,52 @@
+#include "TPZMatSingleSpaceBCSol.h"
+#include "TPZMaterial.h"
+#include "Hash/TPZHash.h"
+
+    template<class TVar>
+    int TPZMatSingleSpaceBCSol<TVar>::ClassId() const
+    {
+        return Hash("TPZMatSingleSpaceBCSol");
+    }
+
+    // template<class TVar>
+    // void TPZMatSingleSpaceBCSol<TVar>::Read(TPZStream&,void*)
+    // {
+
+    // }
+    // template<class TVar>
+    // void TPZMatSingleSpaceBCSol<TVar>::Write(TPZStream&,int) const
+    // {
+
+    // }
+
+    template<class TVar>
+    int TPZMatSingleSpaceBCSolBC<TVar>::ClassId() const
+    {
+        return Hash("TPZBndCondPostProcessInterface");
+    }
+
+    template<class TVar>
+    void TPZMatSingleSpaceBCSolBC<TVar>::Read(TPZStream&,void*)
+    {
+
+    }
+
+    template<class TVar>
+    void TPZMatSingleSpaceBCSolBC<TVar>::Write(TPZStream&,int) const
+    {
+
+    }
+
+  template<class TVar>
+  void TPZMatSingleSpaceBCSolBC<TVar>::SetMaterialImpl(TPZMaterial* mat){
+    fMatBndCondPPInterface = dynamic_cast<TPZMatSingleSpaceBCSol<TVar>*>(mat);
+    TPZMatSingleSpaceBC<TVar>::SetMaterialImpl(mat);
+  }
+
+template class TPZMatSingleSpaceBCSol<STATE>;
+template class TPZMatSingleSpaceBCSol<CSTATE>;
+
+
+
+template class TPZMatSingleSpaceBCSolBC<STATE>;
+template class TPZMatSingleSpaceBCSolBC<CSTATE>;

--- a/Material/TPZMatSingleSpaceBCSol.h
+++ b/Material/TPZMatSingleSpaceBCSol.h
@@ -1,0 +1,108 @@
+/**
+ * @file TPZBCPostProcessing.h
+ * @brief Header file for defining a boundary condition post processing interface.\n
+ * It defines the interface for post processing data associated with a boundary condition
+ */
+
+#ifndef TPZBCPOSTPROCESSINGINTERFACE_H
+#define TPZBCPOSTPROCESSINGINTERFACE_H
+
+#include "TPZSavable.h"
+#include "TPZMatTypes.h"
+#include "TPZMatSingleSpace.h"
+
+class TPZMaterial;
+class TPZBndCond;
+
+template<class T>
+class TPZMaterialDataT;
+template<class T>
+class TPZFMatrix;
+template<class T>
+class TPZBndCondT;
+template<class T>
+class TPZVec;
+
+
+
+/**
+ * @ingroup matsinglespaces
+ * @brief This class is a fundamental part of the TPZMaterial group.
+ * It contains the type-agnostic interfaces that singe space materials
+ * should implement.
+ */
+template<class TVar>
+class TPZMatSingleSpaceBCSolBC;
+
+template<class TVar>
+class TPZMatSingleSpaceBCSol : public TPZMatSingleSpaceT<TVar>
+{
+public:
+    using TInterfaceBC = TPZMatSingleSpaceBCSolBC<TVar>;
+
+public:
+//declare all the virtual methods and etc as usual
+    //@{
+    //! Read and Write methods
+    virtual int ClassId() const override;
+    //@}
+      /** @brief Returns the variable index associated with a given name (for boundary)*/
+    [[nodiscard]] virtual int VariableIndexBC(const std::string &name) const = 0;
+    /** 
+	 * @brief Returns the number of variables associated with the variable indexed by var for a boundary material. 
+	 * @param var Index variable into the solution, is obtained by calling VariableIndex
+	 */
+    [[nodiscard]] virtual int NSolutionVariablesBC(int var) const = 0;
+
+    /** @brief Returns the solution associated with a given index
+        on boundary elements.
+        This method should be implemented if any computations 
+        on the solution are to be done.
+        @param[in] data Stores all the input data.
+        @param[in] var Index of the queried solution
+        @param[out] sol FEM Solution at the integration point
+    */
+    virtual void SolutionBC(const TPZMaterialDataT<TVar> &data, int var,
+                          TPZVec<TVar> &sol) = 0;    
+
+};
+
+template<class TVar>
+class TPZMatSingleSpaceBCSolBC : public TPZMatSingleSpaceBC<TVar>
+{
+
+public:
+
+//declare all the virtual methods and etc as usual
+    //@{
+    //! Read and Write methods
+    virtual int ClassId() const override;
+	/** @brief Writes this object to the TPZStream buffer. Include the classid if `withclassid = true` */
+	virtual void Write(TPZStream &buf, int withclassid) const override;
+	
+	/** @brief Reads an objects from the TPZStream buffer. */
+	virtual void Read(TPZStream &buf, void *context) override;
+
+    /** @brief This method should never be called. Throws.*/
+    void Solution(const TPZMaterialDataT<TVar> &data, int var,
+                  TPZVec<TVar> &sol) override
+    {
+        fMatBndCondPPInterface->SolutionBC(data,var,sol);
+    }
+	/** @brief It returns the variable index associated with the name */
+	int VariableIndex(const std::string &name) const override
+    {
+        return fMatBndCondPPInterface->VariableIndexBC(name);
+    }
+	int NSolutionVariables(int var) const override
+    {
+        return fMatBndCondPPInterface->NSolutionVariablesBC(var);
+    }
+  
+
+protected:
+  TPZMatSingleSpaceBCSol<TVar> *fMatBndCondPPInterface{nullptr};
+  void SetMaterialImpl(TPZMaterial* mat);
+
+};
+#endif

--- a/Material/TPZMaterial.cpp
+++ b/Material/TPZMaterial.cpp
@@ -24,6 +24,14 @@ int TPZMaterial::NSolutionVariables(int index) const{
 	return 0;
 }
 
+int TPZMaterial::NSolutionVariablesBC(int index) const{
+	PZError<<__PRETTY_FUNCTION__;
+	PZError<<" Implement me in your material for post processing solutions\n"
+				 <<" over boundary elements\n"<<std::endl;
+	DebugStop();
+	return 0;
+}
+
 TPZMaterial* TPZMaterial::NewMaterial() const{
 	PZError<<__PRETTY_FUNCTION__;
 	PZError<<" should not be called. Implement me! Aborting...\n";

--- a/Material/TPZMaterial.cpp
+++ b/Material/TPZMaterial.cpp
@@ -17,6 +17,20 @@ int TPZMaterial::VariableIndex(const std::string &name) const{
 	return -1;
 }
 
+int TPZMaterial::VariableIndexBC(const std::string &name) const{
+	std::cout << __PRETTY_FUNCTION__ << " Variable " << name << " not found\n";
+	
+#ifdef PZ_LOG2
+	{
+		std::stringstream sout;
+		sout << "Variable " << name << " not found";
+		LOGPZ_ERROR(logger,sout.str())
+	}
+#endif
+	return -1;
+}
+
+
 int TPZMaterial::NSolutionVariables(int index) const{
 	PZError<<__PRETTY_FUNCTION__;
 	PZError<<" Implement me in your material for post processing solutions.\n";

--- a/Material/TPZMaterial.cpp
+++ b/Material/TPZMaterial.cpp
@@ -1,10 +1,16 @@
 #include "TPZMaterial.h"
 #include "TPZMaterialData.h"
 #include "TPZStream.h"
+#include "TPZMatSingleSpace.h"
+#include "TPZMatCombinedSpaces.h"
 
 #include <string>
 
 int TPZMaterial::VariableIndex(const std::string &name) const{
+	const TPZMatSingleSpace * matsingle = dynamic_cast<const TPZMatSingleSpace *>(this);
+	if(matsingle) return matsingle->VariableIndex(name);
+	const TPZMatCombinedSpaces *matcomb = dynamic_cast<const TPZMatCombinedSpaces *>(this);
+	if(matcomb) return matcomb->VariableIndex(name);
 	std::cout << __PRETTY_FUNCTION__ << " Variable " << name << " not found\n";
 	
 #ifdef PZ_LOG2
@@ -17,34 +23,19 @@ int TPZMaterial::VariableIndex(const std::string &name) const{
 	return -1;
 }
 
-int TPZMaterial::VariableIndexBC(const std::string &name) const{
-	std::cout << __PRETTY_FUNCTION__ << " Variable " << name << " not found\n";
-	
-#ifdef PZ_LOG2
-	{
-		std::stringstream sout;
-		sout << "Variable " << name << " not found";
-		LOGPZ_ERROR(logger,sout.str())
-	}
-#endif
-	return -1;
-}
 
 
 int TPZMaterial::NSolutionVariables(int index) const{
+	const TPZMatSingleSpace * matsingle = dynamic_cast<const TPZMatSingleSpace *>(this);
+	if(matsingle) return matsingle->NSolutionVariables(index);
+	const TPZMatCombinedSpaces *matcomb = dynamic_cast<const TPZMatCombinedSpaces *>(this);
+	if(matcomb) return matcomb->NSolutionVariables(index);
 	PZError<<__PRETTY_FUNCTION__;
 	PZError<<" Implement me in your material for post processing solutions.\n";
 	DebugStop();
 	return 0;
 }
 
-int TPZMaterial::NSolutionVariablesBC(int index) const{
-	PZError<<__PRETTY_FUNCTION__;
-	PZError<<" Implement me in your material for post processing solutions\n"
-				 <<" over boundary elements\n"<<std::endl;
-	DebugStop();
-	return 0;
-}
 
 TPZMaterial* TPZMaterial::NewMaterial() const{
 	PZError<<__PRETTY_FUNCTION__;

--- a/Material/TPZMaterial.h
+++ b/Material/TPZMaterial.h
@@ -85,8 +85,6 @@ public:
     /** @brief Returns the variable index associated with a given name */
     [[nodiscard]] virtual int VariableIndex(const std::string &name) const;
 
-    /** @brief Returns the variable index associated with a given name (for boundary)*/
-    [[nodiscard]] virtual int VariableIndexBC(const std::string &name) const;
     
     /** 
 	 * @brief Returns the number of variables associated with the variable indexed by var. 
@@ -94,11 +92,6 @@ public:
 	 */
     [[nodiscard]] virtual int NSolutionVariables(int var) const;
 
-    /** 
-	 * @brief Returns the number of variables associated with the variable indexed by var for a boundary material. 
-	 * @param var Index variable into the solution, is obtained by calling VariableIndex
-	 */
-    [[nodiscard]] virtual int NSolutionVariablesBC(int var) const;
 
 
     /**

--- a/Material/TPZMaterial.h
+++ b/Material/TPZMaterial.h
@@ -84,6 +84,9 @@ public:
     
     /** @brief Returns the variable index associated with a given name */
     [[nodiscard]] virtual int VariableIndex(const std::string &name) const;
+
+    /** @brief Returns the variable index associated with a given name (for boundary)*/
+    [[nodiscard]] virtual int VariableIndexBC(const std::string &name) const;
     
     /** 
 	 * @brief Returns the number of variables associated with the variable indexed by var. 

--- a/Material/TPZMaterial.h
+++ b/Material/TPZMaterial.h
@@ -91,6 +91,12 @@ public:
 	 */
     [[nodiscard]] virtual int NSolutionVariables(int var) const;
 
+    /** 
+	 * @brief Returns the number of variables associated with the variable indexed by var for a boundary material. 
+	 * @param var Index variable into the solution, is obtained by calling VariableIndex
+	 */
+    [[nodiscard]] virtual int NSolutionVariablesBC(int var) const;
+
 
     /**
      * @}


### PR DESCRIPTION
This PR adds support for visualization of the solution on boundary elements for materials deriving from `TPZMatSingleSpace`.
For this, the following methods were created:
- `[[nodiscard]] virtual int TPZMaterial::NSolutionVariablesBC(int var) const`
- `    virtual void TPZMaterialSingleSpaceT::SolutionBC(const TPZMaterialDataT<TVar> &data, int var,
                          TPZVec<TVar> &sol) `
- `[[nodiscard]] int TPZBndCondBase::NSolutionVariables(int var) const final`
- `[[nodiscard]] int TPZBndCondBase::VariableIndex(const std::string &name) const final`
Apart from this, one check was removed in `TPZAnalysis.cpp`.


For seeing it in action, check the updated target `HCurlProjection` of `NeoPZExamples` : https://github.com/labmec/NeoPZExamples/blob/main/Tutorial/Projections/HCurlProjection.cpp