### PR TITLE
fixes TPZAutoPointer<T> memory leak

### DIFF
--- a/Matrix/pzfmatrix.cpp
+++ b/Matrix/pzfmatrix.cpp
@@ -1037,7 +1037,7 @@ template <class TVar>
 int TPZFMatrix<TVar>::Resize(const int64_t newRows,const int64_t newCols) {
     if ( newRows == this->Rows() && newCols == this->Cols() ) return( 1 );
     int64_t newsize = ((int64_t)newRows)*newCols;
-    TVar * newElem;
+    TVar * newElem{nullptr};
     if(fGiven && fElem != fGiven && newsize <= fSize)
     {
         newElem = fGiven;

--- a/SpecialMaps/tpzarc3d.h
+++ b/SpecialMaps/tpzarc3d.h
@@ -180,7 +180,7 @@ namespace pzgeom
         {
             
             /** Computing Axes */
-            TPZManVector< T > Vpc(3), Vpa(3), Vpb(3), Vt(3), OUTv(3);
+            TPZManVector< T > Vpc(3,0.), Vpa(3,0.), Vpb(3,0.), Vt(3,0.), OUTv(3,0.);
             
             TPZManVector< T > middle(1, 0.);
             X(coord,middle,OUTv);

--- a/Util/TPZSemaphore.h
+++ b/Util/TPZSemaphore.h
@@ -17,7 +17,7 @@ class TPZSemaphore
 {
 private:
 	/** @brief Counter of the times the semaphore is locked */
-	int fCounter;
+	int fCounter{0};
 	/** @brief Mutex for the thread */
 	mutable std::mutex fMutex;
 	/** @brief Condition for the thread must to be waiting */

--- a/Util/tpzautopointer.h
+++ b/Util/tpzautopointer.h
@@ -40,9 +40,9 @@ class TPZAutoPointer {
     struct TPZReference
     {
         /** @brief Pointer to T object */
-        T *fPointer;
+        T *fPointer{nullptr};
         /** @brief Reference counter*/
-        std::atomic_int fCounter;
+        std::atomic_int fCounter{0};
         
         TPZReference()
         {
@@ -104,7 +104,7 @@ class TPZAutoPointer {
     };
     
 	/** @brief The object which contains the pointer and the reference count */
-	TPZReference *fRef;
+	TPZReference *fRef{nullptr};
     
 public:
 	/** @brief Creates an reference counted null pointer */

--- a/Util/tpzautopointer.h
+++ b/Util/tpzautopointer.h
@@ -278,7 +278,7 @@ public:
 private:
     /** @brief Method for deleting the reference*/
     inline void Release(){
-        if(fRef && fRef->fCounter) {
+        if(fRef && ! fRef->fCounter) {
             delete fRef;
         }
         fRef = nullptr;


### PR DESCRIPTION
- `TPZAutoPointer<T>` was not releasing memory as needed since last refactor
- some other changes regarding conditionals depending on uninitialized variables were performed