### PR TITLE
fix(mesh): adds solution method to complex tpzinterpolationspace

### DIFF
--- a/Mesh/pzinterpolationspace.cpp
+++ b/Mesh/pzinterpolationspace.cpp
@@ -524,7 +524,9 @@ void TPZInterpolationSpace::CalcResidualInternal(TPZElementMatrixT<TVar> &ef){
 	
 }//CalcResidual
 
-void TPZInterpolationSpace::Solution(TPZVec<REAL> &qsi,int var,TPZVec<STATE> &sol) {
+template<class TVar>
+void TPZInterpolationSpace::SolutionInternal(TPZVec<REAL> &qsi,int var,
+                                             TPZVec<TVar> &sol) {
   //TODOCOMPLEX
 	if(var >= 100) {
 		TPZCompEl::Solution(qsi,var,sol);
@@ -539,13 +541,13 @@ void TPZInterpolationSpace::Solution(TPZVec<REAL> &qsi,int var,TPZVec<STATE> &so
 	}
 	
 	auto* material = 
-    dynamic_cast<TPZMatSingleSpaceT<STATE> *>(this->Material());
+    dynamic_cast<TPZMatSingleSpaceT<TVar> *>(this->Material());
 	if(!material) {
 		sol.Resize(0);
 		return;
 	}
 	//TODOCOMPLEX
-  TPZMaterialDataT<STATE> data;
+  TPZMaterialDataT<TVar> data;
   this->InitMaterialData(data);
 
   ///compute geometric mapping info

--- a/Mesh/pzinterpolationspace.h
+++ b/Mesh/pzinterpolationspace.h
@@ -264,7 +264,12 @@ virtual int ClassId() const override;
 	 * @see TPZMaterial::Solution
 	 */
 	/** The var index is obtained by calling the TPZMaterial::VariableIndex method with a post processing name */
-	virtual void Solution(TPZVec<REAL> &qsi,int var,TPZVec<STATE> &sol) override;
+	void Solution(TPZVec<REAL> &qsi,int var,TPZVec<STATE> &sol) override{
+    SolutionInternal(qsi,var,sol);
+  }
+  void Solution(TPZVec<REAL> &qsi,int var,TPZVec<CSTATE> &sol) override{
+    SolutionInternal(qsi,var,sol);
+  }
 	
 	/**
 	 * @brief Interpolates the solution into the degrees of freedom nodes from the degrees
@@ -367,6 +372,8 @@ protected:
     template<class TVar>
     void ComputeRequiredDataT(TPZMaterialDataT<TVar> &data,
 									 TPZVec<REAL> &qsi);
+    template<class TVar>
+    void SolutionInternal(TPZVec<REAL> &qsi,int var,TPZVec<TVar> &sol);
     /// Preferred polynomial order
 	int fPreferredOrder;
     //@{


### PR DESCRIPTION
There was no complex arithmetic version of `TPZInterpolationSpace::Solution`. This PR addresses this issue.