### PR TITLE
Materials for Analysis of Planar Waveguide Scattering

### DIFF
--- a/Material/Electromagnetics/CMakeLists.txt
+++ b/Material/Electromagnetics/CMakeLists.txt
@@ -3,15 +3,21 @@
 set(public_headers
     TPZWaveguideModalAnalysis.h
     TPZWaveguideModalAnalysisPML.h
+    TPZPlanarWGScattering.h
+    TPZPlanarWGScatteringPML.h
     )
 
 set(headers
     TPZWaveguideModalAnalysis.h
     TPZWaveguideModalAnalysisPML.h
+    TPZPlanarWGScattering.h
+    TPZPlanarWGScatteringPML.h
    )
 set(sources
     TPZWaveguideModalAnalysis.cpp
     TPZWaveguideModalAnalysisPML.cpp
+    TPZPlanarWGScattering.cpp
+    TPZPlanarWGScatteringPML.cpp
    )
 
 install(FILES ${public_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Material/Electromagnetics)

--- a/Material/Electromagnetics/TPZPlanarWGScattering.cpp
+++ b/Material/Electromagnetics/TPZPlanarWGScattering.cpp
@@ -1,0 +1,239 @@
+#include "TPZPlanarWGScattering.h"
+#include "TPZMaterialDataT.h"
+#include <pzaxestools.h>
+using namespace std::complex_literals;
+
+
+TPZPlanarWGScattering::TPZPlanarWGScattering() : TBase()
+{
+  
+}
+
+TPZPlanarWGScattering::TPZPlanarWGScattering(int id, const CSTATE ur,const CSTATE er,
+                                             const STATE lambda, const ModeType mode,
+                                             const REAL &scale) :
+  TBase(id), fScaleFactor(scale), fMode(mode)
+{
+  SetWavelength(lambda);
+  SetPermeability(ur);
+  SetPermittivity(er);
+}
+
+  
+
+TPZPlanarWGScattering * TPZPlanarWGScattering::NewMaterial() const
+{
+  return new TPZPlanarWGScattering(*this);
+}
+
+void TPZPlanarWGScattering::SetWavelength(STATE lambda)
+{
+    if (lambda <0){
+        PZError<<__PRETTY_FUNCTION__;
+        PZError<<"Setting negative wavelength. Aborting..\n";
+        DebugStop();
+    }
+    fLambda = lambda;
+}
+
+
+TPZVec<CSTATE>
+TPZPlanarWGScattering::GetPermeability([[maybe_unused]] const TPZVec<REAL> &x) const
+{ return {fUr,fUr,fUr};}
+
+ void TPZPlanarWGScattering::SetPermeability(const CSTATE ur)
+{
+    if (std::real(ur) <0){
+        PZError<<__PRETTY_FUNCTION__;
+        PZError<<"Setting negative permeability. Aborting..\n";
+        DebugStop();
+    }
+    fUr = ur;
+}
+
+TPZVec<CSTATE>
+TPZPlanarWGScattering::GetPermittivity([[maybe_unused]] const TPZVec<REAL> &x) const
+{ return {fEr,fEr,fEr};}
+
+void TPZPlanarWGScattering::SetPermittivity(const CSTATE er)
+{
+    if (std::real(er) <0){
+        PZError<<__PRETTY_FUNCTION__;
+        PZError<<"Setting negative permeability. Aborting..\n";
+        DebugStop();
+    }
+    fEr = er;
+}
+
+void TPZPlanarWGScattering::Contribute(const TPZMaterialDataT<CSTATE> &data,
+                                       REAL weight,
+                                       TPZFMatrix<CSTATE> &ek,
+                                       TPZFMatrix<CSTATE> &ef)
+{
+  auto er = GetPermittivity(data.x);
+  auto ur = GetPermeability(data.x);
+  CSTATE cGx{0}, cGy{0}, cS{0};
+  switch(fMode){
+  case ModeType::TE:
+    cGx = 1./ur[1];
+    cGy = 1./ur[0];
+    cS = er[2];
+    break;
+  case ModeType::TM:
+    cGx = er[1];
+    cGy = er[0];
+    cS = 1./ur[2];
+    break;
+  }
+  ContributeInternal(cGx, cGy, cS, data, weight, ek, ef);
+}
+
+void
+TPZPlanarWGScattering::ContributeInternal(const CSTATE cGradX,
+                                          const CSTATE cGradY,
+                                          const CSTATE cScal,
+                                          const TPZMaterialDataT<CSTATE> &data,
+                                          REAL weight,
+                                          TPZFMatrix<CSTATE> &ek,
+                                          TPZFMatrix<CSTATE> &ef)
+{
+  const int nshape = data.phi.Rows();
+  const auto &phi = data.phi;
+
+  //antigo
+  // const auto &dphix = data.dphix;
+  //novo
+  TPZFNMatrix<3,REAL> dphix(3, phi.Rows(), 0.);
+  {
+    const TPZFMatrix<REAL> &dphidaxes = data.dphix;
+    TPZAxesTools<REAL>::Axes2XYZ(dphidaxes, dphix, data.axes);
+  }
+  
+  const STATE k0 = fScaleFactor * 2*M_PI/fLambda;
+  const auto er = GetPermittivity(data.x);
+  const auto ur = GetPermeability(data.x);
+	for(int i = 0; i < nshape; i++){
+		for(int j = 0; j < nshape; j++){
+      const STATE gradX = dphix.GetVal(0,i) * dphix.GetVal(0,j);
+      const STATE gradY = dphix.GetVal(1,i) * dphix.GetVal(1,j);
+      const STATE phiIphiJ = phi.GetVal(i,0) * phi.GetVal(j,0);
+      CSTATE stiff = 0;
+      stiff += gradX * cGradX + gradY * cGradY;
+      stiff -= k0*k0*cScal*phiIphiJ;
+      ek(i, j) += weight * stiff;
+		}//for j
+	}//for i
+
+}
+
+void TPZPlanarWGScattering::ContributeBC(const TPZMaterialDataT<CSTATE> &data,
+                                         REAL weight,
+                                         TPZFMatrix<CSTATE> &ek,
+                                         TPZFMatrix<CSTATE> &ef,
+                                         TPZBndCondT<CSTATE> &bc)
+{
+  CSTATE cGradX{-1};
+  switch(fMode){
+  case ModeType::TE:
+    cGradX = 1./GetPermeability(data.x)[1];
+    break;
+  case ModeType::TM:
+    cGradX = GetPermittivity(data.x)[1];
+    break;
+  }
+   ContributeBCInternal(cGradX, data, weight, ek, ef, bc);
+}
+
+
+void
+TPZPlanarWGScattering::ContributeBCInternal(const CSTATE coeffGradX,
+                                            const TPZMaterialDataT<CSTATE> &data,
+                                            REAL weight,
+                                            TPZFMatrix<CSTATE> &ek,
+                                            TPZFMatrix<CSTATE> &ef,
+                                            TPZBndCondT<CSTATE> &bc)
+{
+  const auto &phi = data.phi;
+  const auto& BIG = TPZMaterial::fBigNumber;
+    
+  const CSTATE v1 = bc.Val1()(0,0);
+  const CSTATE v2 = bc.Val2()[0];
+  constexpr STATE tol = std::numeric_limits<STATE>::epsilon();
+  if(std::abs(v2) > tol){
+    PZError<<__PRETTY_FUNCTION__;
+    PZError<<"\nThis method supports only homogeneous boundary conditions.\n";
+    std::cout<<"Stopping now..."<<std::endl;
+    DebugStop();
+  }
+  switch ( bc.Type() )
+    {
+    case 0:{
+      const int nshape=phi.Rows();
+      for(int i = 0 ; i<nshape ; i++){
+        ef(i,0) += weight * BIG * v2 * phi(i,0);
+        for(int j=0;j<nshape;j++){
+          const STATE stiff = phi(i,0) * phi(j,0) * BIG ;
+          ek(i,j) += stiff*weight;
+        }
+      }
+      break;
+    }
+    case 1:
+      ///PMC condition just adds zero to both matrices. nothing to do here....
+      break;
+    case 2:{
+      ///Source term
+      TPZFNMatrix<9,CSTATE> dummy;
+      TPZManVector<CSTATE,2> res(2);
+      bc.ForcingFunctionBC()(data.x,res,dummy);
+      const auto Am = res[0];//amplitude
+      const auto beta = res[1];//beta
+      const int nshape=phi.Rows();
+      for(int i = 0 ; i<nshape ; i++){
+        const CSTATE load = (phi(i,0) * coeffGradX) * -2i * beta * Am;
+        ef(i,0) += weight * load;
+      }
+      break;
+    }
+    default:
+      PZError<<__PRETTY_FUNCTION__;
+      PZError<<"\nThis module supports only dirichlet and neumann boundary conditions.\n";
+      PZError<<"Stopping now..."<<std::endl;
+      DebugStop();
+      break;
+    }
+}
+//! Variable index of a given solution
+int TPZPlanarWGScattering::VariableIndex(const std::string &name) const
+{
+  if( strcmp(name.c_str(), "Field_re") == 0) return 0;
+  if( strcmp(name.c_str(), "Field_abs") == 0) return 1;
+  return TPZMaterial::VariableIndex(name);
+}
+//! Number of variables associated with a given solution
+int TPZPlanarWGScattering::NSolutionVariables(int var) const
+{
+  switch(var){
+  case 0: //field (real part)
+    return 1;
+  case 1: //field (abs val)
+    return 1;
+  default:
+    return TPZMaterial::NSolutionVariables(var);
+  }
+}
+//! Computes the solution at an integration point
+void TPZPlanarWGScattering::Solution(const TPZMaterialDataT<CSTATE> &data,
+              int var, TPZVec<CSTATE> &solout)
+{
+  switch(var){
+  case 0:
+    solout[0] = std::real(data.sol[0][0]);
+    break;
+  case 1:
+    solout[0] = std::abs(data.sol[0][0]);
+    break;
+  default:
+    TBase::Solution(data,var,solout);
+  } 
+}

--- a/Material/Electromagnetics/TPZPlanarWGScattering.h
+++ b/Material/Electromagnetics/TPZPlanarWGScattering.h
@@ -1,0 +1,112 @@
+/**
+ * @file TPZPlanarWGScattering.h
+ * @brief Header file for class TPZPlanarWGScattering.\n
+ */
+
+#ifndef TPZPLANARSCATTERING_H
+#define TPZPLANARSCATTERING_H
+
+
+#include "TPZMatBase.h"
+#include "TPZMatSingleSpace.h"
+/**
+ * @ingroup material
+ * @brief This class implements the weak statement for the scattering analysis of planar waveguides using H1 elements.
+ * It can either approximate TE or TM modes of a 2D waveguide with a 1D cross-section.
+ * Currently, only sources aligned with the y direction of a 2D domain can be used.
+ * @note Formulation taken from: 
+ Yasuhide Tsuji and Masanori Koshiba, "Finite Element Method Using Port Truncation by Perfectly Matched Layer Boundary Conditions for Optical Waveguide Discontinuity Problems," J. Lightwave Technol. 20, 463- (2002) 
+*/
+class  TPZPlanarWGScattering :
+  public TPZMatBase<CSTATE,TPZMatSingleSpaceT<CSTATE>>
+{
+  using TBase = TPZMatBase<CSTATE,TPZMatSingleSpaceT<CSTATE>>;
+public:
+  //! Sets for which mode type the problem will be solved.
+  enum class ModeType{TE, TM};
+  /**
+     @brief Constructor taking a few material parameters
+     @param[in] id Material identifier.
+     @param[in] ur Relative permeability.
+     @param[in] er Relative permittivity.
+     @param[in] scale Scale for geometric domain.
+     @note the `scale` param might help with floating point arithmetics on really small domains.
+  */
+  TPZPlanarWGScattering(int id, const CSTATE ur,const CSTATE er,
+                        const STATE lambda,
+                        const ModeType mode,
+                        const REAL &scale = 1.);
+
+  TPZPlanarWGScattering * NewMaterial() const override;
+    
+  std::string Name() const override { return "TPZPlanarWGScattering"; }
+  
+  /** @brief Returns the integrable dimension of the material */
+  int Dimension() const override {return 2;}
+
+  [[nodiscard]] int NStateVariables() const override{return 1;}  
+
+  /**
+     @name ParamMethods
+     @{
+  */
+  //! Sets the wavelength being analysed
+  void SetWavelength(STATE lambda);
+  //! Gets the current wavelength
+  [[nodiscard]] inline STATE GetWavelength() const{ return fLambda;}
+  //! Sets the permeability of the material
+  void SetPermeability(const CSTATE ur);
+  //! Gets the permeability of the material
+  virtual TPZVec<CSTATE> GetPermeability([[maybe_unused]] const TPZVec<REAL> &x) const;
+  //! Sets the permittivity of the material
+  void SetPermittivity(const CSTATE er);
+  //! Gets the permittivity of the material
+  virtual TPZVec<CSTATE> GetPermittivity([[maybe_unused]] const TPZVec<REAL> &x) const;
+  /**@}*/
+  /**
+     @name ContributeMethods
+     @{
+  */
+  void Contribute(const TPZMaterialDataT<CSTATE> &data, REAL weight,
+                  TPZFMatrix<CSTATE> &ek, TPZFMatrix<CSTATE> &ef) override;
+    
+  void ContributeBC(const TPZMaterialDataT<CSTATE> &data, REAL weight,
+                    TPZFMatrix<CSTATE> &ek, TPZFMatrix<CSTATE> &ef,
+                    TPZBndCondT<CSTATE> &bc) override;
+  /**@}*/
+  /**
+     @name SolutionMethods
+     @{*/
+  //! Variable index of a given solution
+  int VariableIndex(const std::string &name) const override;
+  //! Number of variables associated with a given solution
+  int NSolutionVariables(int var) const override;
+  //! Computes the solution at an integration point
+  void Solution(const TPZMaterialDataT<CSTATE> &data,
+                int var, TPZVec<CSTATE> &solout) override;
+  /**@}*/
+protected:
+  //! Actual Contribute method (both TE/TM)
+  void ContributeInternal(const CSTATE cGradX, const CSTATE cGradY, const CSTATE cScal,
+                          const TPZMaterialDataT<CSTATE> &data, REAL weight,
+                          TPZFMatrix<CSTATE> &ek, TPZFMatrix<CSTATE> &ef);
+  //! Actual ContributeBC method (both TE/TM)
+  void ContributeBCInternal(const CSTATE coeffGradX,
+                    const TPZMaterialDataT<CSTATE> &data, REAL weight,
+                    TPZFMatrix<CSTATE> &ek, TPZFMatrix<CSTATE> &ef,
+                    TPZBndCondT<CSTATE> &bc);
+  //! Mode type being solved
+  ModeType fMode{ModeType::TE};
+  //! Relative magnetic permeability
+  CSTATE fUr{1};
+  //! Relative electric permittivity
+  CSTATE fEr{1};
+  //! Wavelength being analysed
+  STATE fLambda{1.55e-9};
+  //! Scale factor for the domain (helps with floating point arithmetic on small domains)
+  const REAL fScaleFactor{1.};
+
+  TPZPlanarWGScattering();
+};
+
+#endif

--- a/Material/Electromagnetics/TPZPlanarWGScattering.h
+++ b/Material/Electromagnetics/TPZPlanarWGScattering.h
@@ -14,6 +14,9 @@
  * @brief This class implements the weak statement for the scattering analysis of planar waveguides using H1 elements.
  * It can either approximate TE or TM modes of a 2D waveguide with a 1D cross-section.
  * Currently, only sources aligned with the y direction of a 2D domain can be used.
+ * This source is implemented through a ForcingFunctionBCType. The matrix-type
+ * parameter is not used, and the vector-type is expected to contain source-value
+ * in the first position and beta-value in the second position.
  * @note Formulation taken from: 
  Yasuhide Tsuji and Masanori Koshiba, "Finite Element Method Using Port Truncation by Perfectly Matched Layer Boundary Conditions for Optical Waveguide Discontinuity Problems," J. Lightwave Technol. 20, 463- (2002) 
 */

--- a/Material/Electromagnetics/TPZPlanarWGScatteringPML.cpp
+++ b/Material/Electromagnetics/TPZPlanarWGScatteringPML.cpp
@@ -1,0 +1,110 @@
+#include "TPZPlanarWGScatteringPML.h"
+#include "TPZMaterialDataT.h"
+
+using namespace std::complex_literals;
+
+TPZPlanarWGScatteringPML::TPZPlanarWGScatteringPML(
+    const int id, const TPZPlanarWGScattering &mat):
+    TPZPlanarWGScattering(mat)
+{
+    this->SetId(id);
+}
+
+void TPZPlanarWGScatteringPML::SetAttX(const REAL pmlBegin,
+                                           const STATE alpha,
+                                           const REAL d)
+{
+    if(d < 0){ // pml width must be positive
+        PZError<<__PRETTY_FUNCTION__;
+        PZError<<"PML width is invalid : "<<d<<std::endl;
+        DebugStop();
+    }
+    if(alpha < 0){//for the attenuation to happen this value must be positive
+        PZError<<__PRETTY_FUNCTION__;
+        PZError<<"alpha max is invalid : "<<alpha<<std::endl;
+        DebugStop();
+    }
+    fAttX = true;
+    fPmlBeginX = pmlBegin;
+    fAlphaMaxX = alpha;
+    fDX = d;
+}
+
+void TPZPlanarWGScatteringPML::SetAttY(const REAL pmlBegin,
+                                           const STATE alpha,
+                                           REAL d)
+{
+    if(d < 0){ // pml width must be positive
+        PZError<<__PRETTY_FUNCTION__;
+        PZError<<"PML width is invalid : "<<d<<std::endl;
+        DebugStop();
+    }
+    if(alpha < 0){//for the attenuation to happen this value must be positive
+        PZError<<__PRETTY_FUNCTION__;
+        PZError<<"alpha max is invalid : "<<alpha<<std::endl;
+        DebugStop();
+    }
+    fAttY = true;
+    fPmlBeginY = pmlBegin;
+    fAlphaMaxY = alpha;
+    fDY = d;
+}
+
+TPZPlanarWGScatteringPML * TPZPlanarWGScatteringPML::NewMaterial() const
+{
+    return new TPZPlanarWGScatteringPML;
+}
+
+void TPZPlanarWGScatteringPML::ComputeSParameters(const TPZVec<REAL> &x,
+                                                  CSTATE &sx,
+                                                  CSTATE &sy,
+                                                  CSTATE &sz) const
+{
+    /*****************CALCULATE S PML PARAMETERS*************************
+     * In the current application, the waveguide's cross section is always
+     * in the xy-plane. Therefore, in the propagation problem of the planar
+     * waveguide, the domain is the yz-plane (assuming symmetry in the 
+     * x-direction).
+     */
+    if(fAttX){
+        const auto distx = (x[0]-fPmlBeginX) / fDX;
+        sx = 1. - 1i * fAlphaMaxX * distx * distx;
+    }
+    if(fAttY){
+        const auto disty = (x[1]-fPmlBeginY) / fDY;
+        sy = 1. - 1i * fAlphaMaxY * disty * disty;
+    }
+}
+
+TPZVec<CSTATE> TPZPlanarWGScatteringPML::GetPermittivity(
+  const TPZVec<REAL> &x) const
+{
+    auto er = TPZPlanarWGScattering::GetPermittivity(x);
+    CSTATE sx{1}, sy{1}, sz{1};
+    ComputeSParameters(x,sx,sy,sz);
+
+    er[0] *= sy * sz / sx;
+    er[1] *= sz * sx / sy;
+    er[2] *= sx * sy / sz;
+    return er;
+}
+
+TPZVec<CSTATE> TPZPlanarWGScatteringPML::GetPermeability(
+  const TPZVec<REAL> &x) const
+{
+    auto ur = TPZPlanarWGScattering::GetPermeability(x);
+    CSTATE sx{1}, sy{1}, sz{1};
+    ComputeSParameters(x,sx,sy,sz);
+    
+    ur[0] *= sy * sz / sx;
+    ur[1] *= sz * sx / sy;
+    ur[2] *= sx * sy / sz;
+    return ur;
+}
+
+int TPZPlanarWGScatteringPML::IntegrationRuleOrder(const int elPMaxOrder) const
+{
+    const int integrationorder = 2+2*elPMaxOrder;
+
+    return  integrationorder;
+}

--- a/Material/Electromagnetics/TPZPlanarWGScatteringPML.h
+++ b/Material/Electromagnetics/TPZPlanarWGScatteringPML.h
@@ -1,0 +1,51 @@
+/**
+
+ * @file TPZPlanarWGScattering.h
+ * @brief Header file for class TPZPlanarWGScattering.\n
+ */
+
+#ifndef TPZPLANARSCATTERINGPML_H
+#define TPZPLANARSCATTERINGPML_H
+
+
+#include "TPZPlanarWGScattering.h"
+
+class  TPZPlanarWGScatteringPML :
+  public TPZPlanarWGScattering
+{
+protected:
+  bool fAttX{false};
+  REAL fPmlBeginX{-1};
+  bool fAttY{false};
+  REAL fPmlBeginY{-1};
+    
+  STATE fAlphaMaxX{-1};
+  STATE fAlphaMaxY{-1};
+  STATE fDX{-1};
+  STATE fDY{-1};
+  TPZPlanarWGScatteringPML() = default;
+
+  void ComputeSParameters(const TPZVec<REAL> &x, CSTATE&sx, CSTATE&sy, CSTATE &sz) const;
+public:
+  
+  //! Creates PML based on another domain region
+  TPZPlanarWGScatteringPML(const int id,
+                               const TPZPlanarWGScattering &mat);
+  //! Sets information regarding the attenuation of the PML in the x-direction
+  void SetAttX(const REAL pmlBegin, const STATE alpha, const REAL d);
+  //! Sets information regarding the attenuation of the PML in the y-direction
+  void SetAttY(const REAL pmlBegin, const STATE alpha, const REAL d);
+
+  //! Gets the permeability of the material
+  TPZVec<CSTATE> GetPermeability(const TPZVec<REAL> &x) const override;
+  //! Gets the permittivity of the material
+  TPZVec<CSTATE> GetPermittivity(const TPZVec<REAL> &x) const override;
+    
+  TPZPlanarWGScatteringPML * NewMaterial() const override;
+    
+  std::string Name() const override { return "TPZPlanarWGScatteringPML";}
+
+  int IntegrationRuleOrder(const int elPMaxOrder) const override;
+};
+
+#endif

--- a/docs/material/electromagnetics.inc
+++ b/docs/material/electromagnetics.inc
@@ -2,12 +2,13 @@ Electromagnetics Group
 ----------------------
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
 .. contents:: Table of Contents
    :local:
       
-This group has materials related to electromagnetic problems.
+This group has materials related to electromagnetic problems. For usage of these
+materials, the reader is referred to the `wgma library <http://github.com/labmec/wgma>`_
 
 
 Modal Analysis of Waveguides
@@ -98,4 +99,75 @@ This class implements a rectangular PML to be used with TPZWaveguideModalAnalysi
    :members:
 
 
+Scattering Analysis of Planar Waveguides
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following classes implement a :math:`H^1(\Omega)` formulation for the scattering analysis of planar waveguides. 
+
+Assuming that
+
+- the computational domain is in the :math:`yz` plane
+- the direction of no variation of the waveguide is :math:`x`
+- at the incidence plane :math:`z=z'`, denoted by :math:`\Gamma`
+  there is a source :math:`f_s: f_s(y)` that propagates with :math:`e^{-j\beta(z-z')}`
+  in the :math:`+z` direction and with :math:`e^{j\beta(z-z')}`
+  in the :math:`-z` direction (such as a mode field obtained by a
+  previous one-dimensional modal analysis, ffor instance),
+
+this material implements:
+
+Find non-trivial :math:`\{\phi\} \in [\mathbb{C}]^N` such that:
+
+.. math::
+   [A]\{\phi\} = [f]\text{,}
+
+where
+
+.. math::
+   [A]_{ij} &= \int_{\Omega}
+   \left[
+   c_z \frac{\partial \phi_i}{\partial z}\frac{\partial \phi_j}{\partial z}
+   +
+   c_y \frac{\partial \phi_i}{\partial y}\frac{\partial \phi_j}{\partial y}  
+   - k_0 c_s \phi_i \phi_j\right] \,d\Omega\\
+   [f]_i &= -2 \int_{\Gamma}c_z \phi_i -j \beta f_s(y)\,d\Gamma\,
+
+where we have, for both TE and TM modes, the following meanings:
+
++---------------+-------------------------+------------------------------+
+|               | TE                      | TM                           |
++===============+=========================+==============================+
+| :math:`\phi`  | :math:`E_x`             | :math:`H_x`                  |
++---------------+-------------------------+------------------------------+
+| :math:`c_z`   | :math:`\mu_{r,yy}^{-1}` | :math:`\epsilon_{r,yy}^{-1}` |
++---------------+-------------------------+------------------------------+
+| :math:`c_y`   | :math:`\mu_{r,zz}^{-1}` | :math:`\epsilon_{r,zz}^{-1}` |
++---------------+-------------------------+------------------------------+
+| :math:`c_s`   | :math:`\mu_{r,xx}^{-1}` | :math:`\epsilon_{r,xx}^{-1}` |
++---------------+-------------------------+------------------------------+
+
+Note that the media are isotropic everywhere except in the PML regions,
+which justify the subscripts in the table above.
+
+This formulation was presented originally in this work :footcite:`koshiba02`, and it
+is specially interesting when analysing waveguide discontinuities.
+
+
+.. note::
+   For simplicity, in the implementation, the computational domain is assumed
+   to be in the :math:`xy` plane (source propagates in the :math:`x` direction).
+
+TPZPlanarWGScattering
+"""""""""""""""""""""
+Implements the scattering analysis of a planar waveguide.
+
+.. doxygenclass:: TPZPlanarWGScattering
+   :members:
+      
+TPZPlanarWGScatteringPML
+""""""""""""""""""""""""
+Implements a PML for the planar waveguide scattering analysis.
+
+.. doxygenclass:: TPZPlanarWGScatteringPML
+   :members:
 .. footbibliography::

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -9,6 +9,22 @@
   journal = {{IEEE} Transactions on Microwave Theory and Techniques}
 }
 
+@article{koshiba02,
+author = {Yasuhide Tsuji and Masanori Koshiba},
+journal = {J. Lightwave Technol.},
+keywords = {Finite element method; Optical directional couplers; Photonic crystals; Propagation methods; Waveguide gratings; Waveguides},
+number = {3},
+pages = {463},
+publisher = {OSA},
+title = {Finite Element Method Using Port Truncation by Perfectly Matched Layer Boundary Conditions for Optical Waveguide Discontinuity Problems},
+volume = {20},
+month = {Mar},
+year = {2002},
+url = {http://opg.optica.org/jlt/abstract.cfm?URI=jlt-20-3-463}
+}
+
+
+
 @mastersthesis{orlandini2018,
 title={A study on the construction of {$H(curl,\Omega)$}- elements and their application on waveguide problem},
 author={Francisco T. Orlandini},


### PR DESCRIPTION
The materials `TPZPlanarWGScattering` and `TPZPlanarWGScatteringPML` were added (and the corresponding sphinx documentation updated).

These materials allow the scattering analysis of planar waveguides.