### PR TITLE
TPZVec move semantics

### DIFF
--- a/UnitTest_PZ/TestVecTypes/VecTypesUnitTest.cpp
+++ b/UnitTest_PZ/TestVecTypes/VecTypesUnitTest.cpp
@@ -97,3 +97,34 @@ TEST_CASE("tpzmanvector_tests","[test_vectypes]") {
         REQUIRE(true);
     }
 }
+
+TEST_CASE("mixedvecs_tests","[test_vectypes]") {
+
+    auto myfunc = []() -> TPZVec<int> {
+        //this vector has not allocated any memory
+        TPZManVector<int,3> myvec = {1,2,3};
+        return std::move(myvec);
+    };
+
+
+    //move ctor
+    try{
+        TPZVec<int> myextvec = myfunc();
+        myextvec[0]++;//just to see if memory is still valid
+    }catch(...){
+        REQUIRE(false);
+    }
+    REQUIRE(true);
+
+    
+    //move assignment operator
+    try{
+        TPZManVector<int,3> manvec = {1,2,3};
+        TPZVec<int> normalvec = {4,5,6};
+        normalvec = std::move(manvec);
+        normalvec[0]++;//just to see if memory is still valid
+    }catch(...){
+        REQUIRE(false);
+    }
+    REQUIRE(true);
+}

--- a/Util/pzmanvector.h
+++ b/Util/pzmanvector.h
@@ -504,7 +504,7 @@ void TPZManVector< T, NumExtAlloc >::Resize(const int64_t newsize, const T& obje
 
         this->fStore = fExtAlloc;
         this->fNElements = newsize;
-        this->fNAlloc = NumExtAlloc;
+        this->fNAlloc = 0;
     } else { // the size is larger than the allocated memory, then this->fNElements
         // is always lower than newsize because fNElemets <=this->fNAllocs
         int64_t i, realsize = ExpandSize(newsize);

--- a/Util/pzvec.h
+++ b/Util/pzvec.h
@@ -19,8 +19,6 @@ inline std::ostream &operator<<(std::ostream &out, const std::pair<int,int> &ele
 	return out;
 }
 
-template<class T, int NumExtAlloc>
-class TPZManVector;
 /**
  * @ingroup util
  * @brief This class implements a simple vector storage scheme for a templated class T. \ref util "Utility"
@@ -72,12 +70,6 @@ public:
      */
     TPZVec(TPZVec<T> &&rval);
     
-    /**
-     * @brief Creates a vector using the move constructor.
-     * No memory is allocated.
-     */
-    template<int NumExtAlloc>
-    TPZVec(TPZManVector<T,NumExtAlloc> &&rval);
 	/** @brief destructor, will delete the storage allocated */
 	virtual ~TPZVec();
 	/**
@@ -633,21 +625,4 @@ class TPZCompMesh;
 extern template class TPZVec<TPZGraphEl *>;
 extern template class TPZVec<TPZGraphNode *>;
 extern template class TPZVec<TPZCompMesh *>;
-
-#include "pzmanvector.h"
-/**
- * @brief Creates a vector using the move constructor.
- * No memory is allocated.
- */
-template<class T>
-template<int NumExtAlloc>
-TPZVec<T>::TPZVec(TPZManVector<T,NumExtAlloc> &&rval)
-{
-    fNElements = rval.fNElements;
-    fStore = new T[fNElements];
-    fNAlloc = fNElements;
-    for(int64_t i=0; i<fNElements; i++)
-        fStore[i]=rval.fStore[i];
-}
-
 #endif


### PR DESCRIPTION
In 422d76601b28d9f4e5fb0b1715e0057c2eb21dc6, it was thought that there was an issue with the move semantics in `TPZVec<T>` when the rval corresponds to a `TPZManVector<T,N>`. That was not the case.

This PR:
- Reverts 422d76601b28d9f4e5fb0b1715e0057c2eb21dc6
- Adds a relevant Unit Test
- Fixes the faulty overload of `TPZManVector<T,N>::Resize` that was updating `TPZManVector<T,N>::fNAlloc` incorrectly thus leading to incorrect assumptions regarding allocated memory.