### PR TITLE
Post processing speedup

### DIFF
--- a/Mesh/pzcompel.h
+++ b/Mesh/pzcompel.h
@@ -364,7 +364,10 @@ public:
 	virtual void ComputeError(int errorid, TPZVec<REAL> &error){
 		PZError << "Error at " << __PRETTY_FUNCTION__ << " - Method not implemented.\n";
 	}
-	
+
+  //! Gets the list of elements for post-processing
+  virtual void GetCompElList(TPZStack<TPZCompEl*>& stck)
+  {stck.Push(this);}
 	/**
 	 * @brief Creates corresponding graphical element(s) if the dimension matches
 	 * graphical elements are used to generate output files

--- a/Mesh/pzcondensedcompel.h
+++ b/Mesh/pzcondensedcompel.h
@@ -214,7 +214,11 @@ public:
     {
         fReferenceCompEl->CreateGraphicalElement(graphmesh, dimension);
     }
-    
+
+
+    //! Gets the list of elements for post-processing
+  void GetCompElList(TPZStack<TPZCompEl *> &stck) override
+    { fReferenceCompEl->GetCompElList(stck);}
 
     int ComputeIntegrationOrder() const override {
         std::cout << "This method should not be called. " << __PRETTY_FUNCTION__ << std::endl;

--- a/Mesh/pzelementgroup.h
+++ b/Mesh/pzelementgroup.h
@@ -234,7 +234,15 @@ public:
 									std::map<int64_t,int64_t> & gl2lcElMap) const override;
 
 public:
-    
+
+    void GetCompElList(TPZStack<TPZCompEl*> &stck) override
+    {
+        for(auto cel : fElGroup){
+            if(cel){
+                cel->GetCompElList(stck);
+            }
+        }
+    }
 
     int NumberOfCompElementsInsideThisCompEl() override{
         int nel  = 0;

--- a/Mesh/pzelementgroup.h
+++ b/Mesh/pzelementgroup.h
@@ -235,6 +235,14 @@ public:
 
 public:
     
+
+    int NumberOfCompElementsInsideThisCompEl() override{
+        int nel  = 0;
+        for (auto fg : fElGroup){
+            nel += fg->NumberOfCompElementsInsideThisCompEl();
+        }
+        return nel;
+    }
     /**
 	 * @brief Creates corresponding graphical element(s) if the dimension matches
 	 * graphical elements are used to generate output files

--- a/Mesh/pzsubcmesh.cpp
+++ b/Mesh/pzsubcmesh.cpp
@@ -1954,6 +1954,16 @@ void TPZSubCompMesh::CreateGraphicalElement(TPZGraphMesh & graphmesh, int dimens
 	}
 }
 
+int TPZSubCompMesh::NumberOfCompElementsInsideThisCompEl()
+{
+  int nel = 0;
+  for(auto cel : fElementVec){
+    if(cel){
+      nel += cel->NumberOfCompElementsInsideThisCompEl();
+    }
+  }
+  return nel;
+}
 /**
  * Verifies if any element needs to be computed corresponding to the material ids
  */

--- a/Mesh/pzsubcmesh.cpp
+++ b/Mesh/pzsubcmesh.cpp
@@ -1964,6 +1964,15 @@ int TPZSubCompMesh::NumberOfCompElementsInsideThisCompEl()
   }
   return nel;
 }
+
+void TPZSubCompMesh::GetCompElList(TPZStack<TPZCompEl*> &stck){
+  for(auto cel : fElementVec){
+    if(cel){
+      cel->GetCompElList(stck);
+    }
+  }
+}
+
 /**
  * Verifies if any element needs to be computed corresponding to the material ids
  */

--- a/Mesh/pzsubcmesh.h
+++ b/Mesh/pzsubcmesh.h
@@ -340,6 +340,9 @@ public:
 
 
   int NumberOfCompElementsInsideThisCompEl() override;
+
+  //! Gets the list of elements for post-processing
+  void GetCompElList(TPZStack<TPZCompEl*> &stack) override;
 	/** @brief Returns the connection index i. */
 	virtual int64_t ConnectIndex(int i) const override;
 	

--- a/Mesh/pzsubcmesh.h
+++ b/Mesh/pzsubcmesh.h
@@ -338,6 +338,8 @@ public:
 	 */
 	virtual void CreateGraphicalElement(TPZGraphMesh & graphmesh, int dimension) override;
 
+
+  int NumberOfCompElementsInsideThisCompEl() override;
 	/** @brief Returns the connection index i. */
 	virtual int64_t ConnectIndex(int i) const override;
 	

--- a/Post/CMakeLists.txt
+++ b/Post/CMakeLists.txt
@@ -34,7 +34,8 @@ set(headers
     #post proc
     pzpostprocanalysis.h
     pzcompelpostproc.h
-    pzpostprocmat.h    
+    pzpostprocmat.h
+    TPZVTKGenerator.h
     )
 
 set(sources
@@ -63,6 +64,7 @@ set(sources
     pzgradientreconstruction.cpp
     pzpostprocanalysis.cpp
     pzpostprocmat.cpp
+    TPZVTKGenerator.cpp
     )
 
 install(FILES ${headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Post)

--- a/Post/TPZVTKGenerator.cpp
+++ b/Post/TPZVTKGenerator.cpp
@@ -151,10 +151,10 @@ TPZVTKGenerator::TPZVTKGenerator(TPZCompMesh* cmesh,
       dynamic_cast<TPZBndCond *>(matp);
     //we skip boundary materials
     if(matp && !bnd){
+      if(matp->Dimension() != fPostProcDim) {continue;}
       bool foundAllVars{true};
       for(int i = 0; (i < nvars) && foundAllVars; i++){
-        const auto &name = fields[i];
-        if(matp->Dimension() != fPostProcDim) {continue;}
+        const auto &name = fields[i];        
         const auto index = matp->VariableIndex(name);
         foundAllVars = foundAllVars && (index > -1) ;
       }

--- a/Post/TPZVTKGenerator.cpp
+++ b/Post/TPZVTKGenerator.cpp
@@ -565,8 +565,15 @@ bool TPZVTKGenerator::IsValidEl(TPZCompEl *cel)
   const auto gel = cel->Reference();
   const auto geldim = gel->Dimension();
   if(geldim != fPostProcDim){return false;}
-  //only its children elements will be post-processed
-  if(gel->HasSubElement()){return false;}
+
+  
+  /* the condition below is not always applicable.
+     for instance, if one uses the same geometric mesh, 
+     with several refinements, but with one comp mesh for each
+     refinement level.
+     anyway, i will leave this here in case it provides a hint for debugging*/
+  
+  // if(gel->HasSubElement()){return false;}
 
   switch (gel->Type()){
     case EPoint:

--- a/Post/TPZVTKGenerator.cpp
+++ b/Post/TPZVTKGenerator.cpp
@@ -74,11 +74,11 @@ void ComputeFieldAtEl(TPZCompEl *cel,
           field[pos++] =  0.0;
         }
       }else{
-        for (int d = 0; d < fdim; ++d){
+        for (int d = 0; d < sz; ++d){
           field[pos++] = sol[d];
         }
         for (int d = sz; d < fdim; ++d){
-          field[pos++] = sol[d];
+          field[pos++] = 0.0;
         }
       }
     }

--- a/Post/TPZVTKGenerator.cpp
+++ b/Post/TPZVTKGenerator.cpp
@@ -1,0 +1,716 @@
+#include "TPZVTKGenerator.h"
+#include "pzcmesh.h"
+#include "pzvec_extras.h"
+#include "TPZMaterial.h"
+#include "TPZSimpleTimer.h"
+#include "pzinterpolationspace.h"
+#include "TPZMatSingleSpace.h"
+#include "TPZMatCombinedSpaces.h"
+#include "TPZMaterialDataT.h"
+#include "pzmultiphysicselement.h"
+
+/*********************************************************************/
+/* File:   TPZVTKGenerator.cpp                                       */
+/* Author: Francisco Orlandini                                       */
+/* Date:   5. July 2022                                              */
+/* Adapted from: NGSolve's vtkoutput.hpp                             */
+/*********************************************************************/
+
+
+template<class TVar>
+class TPZPostProcEl{
+public:
+  TPZPostProcEl(TPZCompEl *cel);
+  void InitData();
+  void ComputeRequiredData(TPZVec<REAL> &qsi);
+  void Solution(const TPZVec<REAL> &qsi, const int id, TPZVec<TVar> &sol);
+private:
+  bool fIsMultiphysics{false};
+  TPZCompEl *fCel{nullptr};
+  TPZMaterialDataT<TVar> fMatdata;
+  TPZManVector<TPZMaterialDataT<TVar>,10> fDatavec; 
+};
+
+template<class TVar>
+void ComputeFieldAtEl(TPZCompEl *cel,
+                      const TPZVec<std::array<REAL,3>> &ref_vertices,
+                      TPZVec<TPZAutoPointer<TPZVTKField>>& fields){
+  TPZManVector<TVar,9> sol;
+
+  const auto celdim = cel->Dimension();
+
+  TPZPostProcEl<TVar> graphel(cel);
+  graphel.InitData();
+  TPZManVector<REAL,3> qsi(celdim,0);
+  for (const auto &ip : ref_vertices){
+    //copy to tpzvec with appropriate size
+    for(int ix = 0; ix < celdim; ix++){qsi[ix] = ip[ix];}
+
+    graphel.ComputeRequiredData(qsi);
+    for (int i = 0; i < fields.size(); i++){
+      auto &field = *(fields[i]);
+      auto fdim = field.Dimension();
+      sol.Resize(fdim);
+      graphel.Solution(qsi, field.Id(), sol);
+      const auto sz = sol.size();
+      if constexpr (std::is_same_v<TVar,CSTATE>){
+        for (int d = 0; d < sz; ++d){
+          AppendToVec(field, std::real(sol[d]));
+        }
+        for (int d = sz; d < fdim; ++d){
+          AppendToVec(field, 0.0);
+        }
+      }else{
+        for (int d = 0; d < fdim; ++d){
+          AppendToVec(field, sol[d]);
+        }
+        for (int d = sz; d < fdim; ++d){
+          AppendToVec(field, 0.0);
+        }
+      }
+    }
+  }
+}
+
+
+TPZVTKField::TPZVTKField(TPZVTKField::Type type, int id, std::string aname) :
+  fType( type), fId(id), fName(aname) { ; }
+
+
+TPZVTKGenerator::TPZVTKGenerator(TPZAutoPointer<TPZCompMesh> cmesh,
+                                    const TPZVec<std::string> fields,
+                                    std::string filename,
+                                    int vtkres)
+  : fCMesh(cmesh), fFilename(filename), fSubdivision(vtkres)
+{
+
+  //let us init the field ids
+  const int nvars = fields.size();
+
+  fFields.resize(nvars);
+  auto * matp = (fCMesh->MaterialVec().begin())->second;
+
+  for(int i = 0; i < nvars; i++){
+    const auto &name = fields[i];
+    const auto index = matp->VariableIndex(name);
+    const auto dim = matp->NSolutionVariables(index);
+    const TPZVTKField::Type type = [dim](){
+      switch(dim){
+      case 1:
+        return TPZVTKField::Type::scal;
+      case 2:
+      case 3:
+        return TPZVTKField::Type::vec;
+      case 9:
+        return TPZVTKField::Type::tens;
+      default:
+        PZError<<"TPZVTKGenerator:\n"
+               <<"field dim "<<dim
+               <<" not supported. It should be either "
+               <<"\t1 (scalar)\n"
+               <<"\t3 (vector)\n"
+               <<"\t9 (tensor)\n";
+        DebugStop();
+        return TPZVTKField::Type::scal;
+      }
+    }();
+    fFields[i] = new TPZVTKField(type,index,name);
+  }
+}
+
+/// Empty all fields, points and cells
+void TPZVTKGenerator::ResetArrays()
+{
+  fPoints.Resize(0);
+  fCells.Resize(0);
+  for(auto field : fFields){
+    field->Resize(0);
+  }
+}
+
+
+void TPZVTKGenerator::FillReferenceLine(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems)
+{
+  const int r = 1 << fSubdivision;
+
+  const REAL h = 2.0 / r;
+  constexpr REAL init = -1;
+  for (int i = 0; i <= r; ++i){
+    AppendToVec(ref_coords,std::array<REAL,3>{init + i * h, 0});
+    AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(EOned), 2, i, i+1});
+  }
+}
+
+
+void TPZVTKGenerator::FillReferenceTrig(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems)
+{
+  if (fSubdivision == 0){
+    AppendToVec(ref_coords,std::array<REAL,3>{0.0, 0.0, 0.0});
+    AppendToVec(ref_coords,std::array<REAL,3>{1.0, 0.0, 0.0});
+    AppendToVec(ref_coords,std::array<REAL,3>{0.0, 1.0, 0.0});
+    AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(ETriangle),3, 0, 1, 2});
+  }
+  else{
+    const int r = 1 << fSubdivision;
+    const int s = r + 1;
+
+    const REAL h = 1.0 / r;
+
+    int pidx = 0;
+    for (int i = 0; i <= r; ++i)
+      for (int j = 0; i + j <= r; ++j){
+        AppendToVec(ref_coords,std::array<REAL,3>{j * h, i * h});
+      }
+
+    pidx = 0;
+
+    for (int i = 0; i <= r; ++i)
+      for (int j = 0; i + j <= r; ++j, pidx++)
+      {
+        // int pidx_curr = pidx;
+        if (i + j == r)
+          continue;
+        int pidx_incr_i = pidx + 1;
+        int pidx_incr_j = pidx + s - i;
+
+        AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(ETriangle), 3, pidx, pidx_incr_i, pidx_incr_j});
+        int pidx_incr_ij = pidx_incr_j + 1;
+
+        if (i + j + 1 < r){
+          AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(ETriangle), 3, pidx_incr_i, pidx_incr_ij, pidx_incr_j});
+        }
+      }
+  }
+}
+/// Fill principil lattices (points and connections on subdivided reference simplex) in 2D
+void TPZVTKGenerator::FillReferenceQuad(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems)
+{
+  if (fSubdivision == 0)
+    {
+      AppendToVec(ref_coords,std::array<REAL,3>{-1.0, -1.0, 0.0});
+      AppendToVec(ref_coords,std::array<REAL,3>{ 1.0, -1.0, 0.0});
+      AppendToVec(ref_coords,std::array<REAL,3>{ 1.0,  1.0, 0.0});
+      AppendToVec(ref_coords,std::array<REAL,3>{-1.0,  1.0, 0.0});
+      AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS+2>{TPZVTK::CellType(EQuadrilateral), 4, 0, 1, 2, 3});
+    }
+  else
+    {
+      const int r = 1 << fSubdivision;
+      // const int s = r + 1;
+
+      const REAL h = 2.0 / r;
+      constexpr REAL init{-1};
+      int pidx = 0;
+      for (int i = 0; i <= r; ++i)
+        for (int j = 0; j <= r; ++j)
+          {
+            AppendToVec(ref_coords,std::array<REAL,3>{init + j * h, init + i * h});
+          }
+
+      for (int i = 0; i < r; ++i)
+        {
+          int incr_i = r + 1;
+          pidx = i * incr_i;
+          for (int j = 0; j < r; ++j, pidx++)
+            {
+              AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(EQuadrilateral),4, pidx, pidx + 1, pidx + incr_i + 1, pidx + incr_i});
+            }
+        }
+    }
+}
+
+/// Fill principil lattices (points and connections on subdivided reference simplex) in 3D
+void TPZVTKGenerator::FillReferenceTet(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems)
+{
+  if (fSubdivision == 0)
+    {
+      AppendToVec(ref_coords,std::array<REAL,3>{0.0, 0.0, 0.0});
+      AppendToVec(ref_coords,std::array<REAL,3>{1.0, 0.0, 0.0});
+      AppendToVec(ref_coords,std::array<REAL,3>{0.0, 1.0, 0.0});
+      AppendToVec(ref_coords,std::array<REAL,3>{0.0, 0.0, 1.0});
+      AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(ETetraedro),4, 0, 1, 2, 3});
+    }
+  else
+    {
+      const int r = 1 << fSubdivision;
+      const int s = r + 1;
+
+      const REAL h = 1.0 / r;
+
+      int pidx = 0;
+      for (int i = 0; i <= r; ++i)
+        for (int j = 0; i + j <= r; ++j)
+          for (int k = 0; i + j + k <= r; ++k)
+            {
+              AppendToVec(ref_coords,std::array<REAL,3>{i * h, j * h, k * h});
+            }
+
+      for (int i = 0; i <= r; ++i)
+        for (int j = 0; i + j <= r; ++j)
+          for (int k = 0; i + j + k <= r; ++k, pidx++)
+            {
+              if (i + j + k == r)
+                continue;
+              // int pidx_curr = pidx;
+              int pidx_incr_k = pidx + 1;
+              int pidx_incr_j = pidx + s - i - j;
+              int pidx_incr_i = pidx + (s - i) * (s + 1 - i) / 2 - j;
+
+              int pidx_incr_kj = pidx_incr_j + 1;
+
+              int pidx_incr_ij = pidx + (s - i) * (s + 1 - i) / 2 - j + s - (i + 1) - j;
+              int pidx_incr_ki = pidx + (s - i) * (s + 1 - i) / 2 - j + 1;
+              int pidx_incr_kij = pidx + (s - i) * (s + 1 - i) / 2 - j + s - (i + 1) - j + 1;
+
+              AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(ETetraedro), 4, pidx, pidx_incr_k, pidx_incr_j, pidx_incr_i});
+              if (i + j + k + 1 == r)
+                continue;
+
+              AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(ETetraedro), 4, pidx_incr_k, pidx_incr_kj, pidx_incr_j, pidx_incr_i});
+              AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(ETetraedro), 4, pidx_incr_k, pidx_incr_kj, pidx_incr_ki, pidx_incr_i});
+
+              AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(ETetraedro), 4, pidx_incr_j, pidx_incr_i, pidx_incr_kj, pidx_incr_ij});
+              AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(ETetraedro), 4, pidx_incr_i, pidx_incr_kj, pidx_incr_ij, pidx_incr_ki});
+
+              if (i + j + k + 2 != r)
+                AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(ETetraedro), 4, pidx_incr_kj, pidx_incr_ij, pidx_incr_ki, pidx_incr_kij});
+            }
+    }
+}
+
+/// Fill principil lattices (points and connections on subdivided reference hexahedron) in 3D
+void TPZVTKGenerator::FillReferenceHex(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems)
+{
+  if (fSubdivision == 0)
+    {
+      AppendToVec(ref_coords,std::array<REAL,3>{-1.0, -1.0, -1.0});
+      AppendToVec(ref_coords,std::array<REAL,3>{ 1.0, -1.0, -1.0});
+      AppendToVec(ref_coords,std::array<REAL,3>{ 1.0,  1.0, -1.0});
+      AppendToVec(ref_coords,std::array<REAL,3>{-1.0,  1.0, -1.0});
+      AppendToVec(ref_coords,std::array<REAL,3>{-1.0, -1.0,  1.0});
+      AppendToVec(ref_coords,std::array<REAL,3>{ 1.0, -1.0,  1.0});
+      AppendToVec(ref_coords,std::array<REAL,3>{ 1.0,  1.0,  1.0});
+      AppendToVec(ref_coords,std::array<REAL,3>{-1.0,  1.0,  1.0});
+      AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(ECube),8,0,1,2,3,4,5,6,7});
+    }
+  else
+    {
+      const int r = 1 << fSubdivision;
+      // const int s = r + 1;
+
+      const REAL h = 2.0 / r;
+      constexpr REAL init{-1};
+      int pidx = 0;
+      for (int i = 0; i <= r; ++i)
+        for (int j = 0; j <= r; ++j)
+          for (int k = 0; k <= r; ++k)
+            {
+              AppendToVec(ref_coords,std::array<REAL,3>{init + k * h,
+                                                        init + j * h,
+                                                        init + i * h});
+            }
+
+      for (int i = 0; i < r; ++i)
+        {
+          int incr_i = (r + 1) * (r + 1);
+          for (int j = 0; j < r; ++j)
+            {
+              int incr_j = r + 1;
+              pidx = i * incr_i + j * incr_j;
+              for (int k = 0; k < r; ++k, pidx++)
+                {
+                  AppendToVec(ref_elems,
+                              std::array<int,TPZVTK::MAX_PTS + 2>
+                              {TPZVTK::CellType(ECube), 8, pidx, pidx + 1, pidx + incr_j + 1, pidx + incr_j,
+                               pidx + incr_i, pidx + incr_i + 1, pidx + incr_i
+                               + incr_j + 1, pidx + incr_j + incr_i});
+                }
+            }
+        }
+    }
+}
+
+
+void TPZVTKGenerator::FillReferencePrism(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems)
+{
+  if (fSubdivision == 0){
+    AppendToVec(ref_coords,std::array<REAL,3>{0.0, 0.0, -1.0});
+    AppendToVec(ref_coords,std::array<REAL,3>{1.0, 0.0, -1.0});
+    AppendToVec(ref_coords,std::array<REAL,3>{0.0, 1.0, -1.0});
+    AppendToVec(ref_coords,std::array<REAL,3>{0.0, 0.0,  1.0});
+    AppendToVec(ref_coords,std::array<REAL,3>{1.0, 0.0,  1.0});
+    AppendToVec(ref_coords,std::array<REAL,3>{0.0, 1.0,  1.0});
+    std::array<int,TPZVTK::MAX_PTS + 2> elem;
+    elem[0] = TPZVTK::CellType(EPrisma);
+    elem[1] = 6;
+    for (int i = 0; i < MElementType_NNodes(EPrisma); i++){
+      elem[i + 2] = i;
+    }
+    AppendToVec(ref_elems,elem);
+  }
+  else{
+    const int r = 1 << fSubdivision;
+    const int s = r + 1;
+
+    const REAL h = 1.0 / r;
+    const REAL hz = 2.0 /r;
+    constexpr REAL initz = -1;
+    int pidx = 0;
+    for (int k = 0; k <= r; k++)
+      for (int i = 0; i <= r; ++i)
+        for (int j = 0; i + j <= r; ++j)
+          {
+            AppendToVec(ref_coords,std::array<REAL,3>{j * h,
+                                                      i * h,
+                                                      initz + k * hz});
+          }
+
+    pidx = 0;
+    for (int k = 0; k < r; k++)
+      {
+        int incr_k = (r + 2) * (r + 1) / 2;
+        pidx = k * incr_k;
+        for (int i = 0; i <= r; ++i)
+          for (int j = 0; i + j <= r; ++j, pidx++)
+            {
+              // int pidx_curr = pidx;
+              if (i + j == r)
+                continue;
+              int pidx_incr_i = pidx + 1;
+              int pidx_incr_j = pidx + s - i;
+
+              AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(EPrisma), 6,
+                                                                        pidx, pidx_incr_i, pidx_incr_j, pidx + incr_k, pidx_incr_i + incr_k, pidx_incr_j + incr_k, 0, 0});
+
+              int pidx_incr_ij = pidx_incr_j + 1;
+
+              if (i + j + 1 < r)
+                AppendToVec(ref_elems,std::array<int,TPZVTK::MAX_PTS + 2>{TPZVTK::CellType(EPrisma), 6,
+                                                                          pidx_incr_i, pidx_incr_ij, pidx_incr_j, pidx_incr_i + incr_k, pidx_incr_ij + incr_k, pidx_incr_j + incr_k, 0, 0});
+            }
+      }
+  }
+}
+
+
+void TPZVTKGenerator::PrintPointsLegacy()
+{
+  TPZSimpleTimer timer("PrintPts");
+  
+  (*fFileout) << "POINTS " << fPoints.size() << " float" << std::endl;
+  for(const auto &p : fPoints){
+    for(const auto &x : p){
+      *fFileout << x<<'\t';
+    }
+    *fFileout << std::endl;
+  }
+}
+
+/// output of cells in form vertices
+void TPZVTKGenerator::PrintCellsLegacy()
+{
+  TPZSimpleTimer timer("PrintCells");
+  
+  // count number of data for cells, one + number of vertices
+  int ndata = 0;
+  for (auto &c : fCells){
+    ndata++;
+    ndata += c[1];
+  }
+  *fFileout << "CELLS " << fCells.size() << " " << ndata << std::endl;
+  for (const auto &c : fCells){
+    const int nv = c[1];
+    *fFileout << nv << '\t';
+    for (int i = 0; i < nv; i++)
+      *fFileout << c[i + 2] << '\t';
+    *fFileout << std::endl;
+  }
+}
+
+/// output of cell types
+void TPZVTKGenerator::PrintCellTypesLegacy(int meshdim)
+{
+  TPZSimpleTimer timer("PrintCellTypes");
+  
+  *fFileout << "CELL_TYPES " << fCells.size() << std::endl;
+
+  for (const auto &c : fCells){
+    *fFileout << c[0] << '\n';
+  }
+  *fFileout << "CELL_DATA " << fCells.size() << std::endl;
+  *fFileout << "POINT_DATA " << fPoints.size() << std::endl;
+}
+
+/// output of field data (coefficient values)
+void TPZVTKGenerator::PrintFieldDataLegacy()
+{
+  TPZSimpleTimer timer("PrintField");
+  
+  for (auto field : fFields){
+    *fFileout << field->TypeName() <<' ' << field->Name()
+              << " float " << std::endl;
+    if(field->GetType() == TPZVTKField::Type::scal){
+      *fFileout << "LOOKUP_TABLE default" << std::endl;
+      for (const auto &v : *field)
+      {*fFileout << v << ' ';}
+      *fFileout << '\n';
+    }else{
+      //both tensor and vector should be written as
+      //(1,2,3)
+      //(1,2,3)
+      //etc
+      const auto nfs = field->size();
+      for (int i = 0; i < nfs; i++){
+        *fFileout << (*field)[i] << ' ';
+        if((i+1)%3 == 0){
+          *fFileout << '\n';
+        }
+      }
+    }
+    
+    
+  }
+}
+
+bool TPZVTKGenerator::IsValidEl(TPZCompEl *cel)
+{
+  if(!cel || ! cel->Reference()){return false;}
+  
+  const auto gel = cel->Reference();
+  const auto geldim = gel->Dimension();
+  const auto meshdim = gel->Mesh()->Dimension();
+  if(geldim != meshdim){return false;}
+  if(gel->HasSubElement()){return false;}
+  if(gel->Type() == EPiramide){
+    std::cout<<__PRETTY_FUNCTION__
+             <<"\n pyramid element not supported yet! Aborting..."
+             <<std::endl;
+    DebugStop();
+  }
+  switch (gel->Type()){
+    case EPoint:
+    case EOned:
+    case ETriangle:
+    case EQuadrilateral:
+    case ETetraedro:
+    case EPiramide:
+    case EPrisma:
+    case ECube:
+      return true;
+    case EPolygonal: /*8*/	
+    case EInterface: /*9*/	
+    case EInterfacePoint: /*10*/	
+    case EInterfaceLinear: /*11*/	
+    case EInterfaceSurface: /*12*/	
+    case ESubstructure: /*13*/	
+    case EGlobLoc: /*14*/	
+    case EDiscontinuous: /*15*/	
+    case EAgglomerate: /*16*/	
+    case ENoType: /*17*/	
+      return false;
+    }
+}
+
+void TPZVTKGenerator::Do(REAL time)
+{
+  TPZSimpleTimer timer("Do");
+
+  const bool isCplxMesh = fCMesh->GetSolType() == ESolType::EComplex;
+
+  std::ostringstream filenamefinal;
+  std::stringstream appended;
+  std::vector<int> datalength;
+  int offs = 0;
+
+  filenamefinal << fFilename;
+  filenamefinal << "_step" << std::setw(5) << std::setfill('0')
+                  << fOutputCount;
+
+  fLastOutputName = filenamefinal.str();
+
+  filenamefinal << ".vtk";
+  
+  if (fOutputCount > 0) {
+    // cout << IM(4) << " ( " << fOutputCount << " )";
+    const auto currt = fTimes.size();
+    fTimes.resize(currt + 1);
+    if (time == -1) {
+      AppendToVec(fTimes, fOutputCount);
+    } else {
+      AppendToVec(fTimes, time);
+    }
+  } else {
+    if (time != -1) {
+      fTimes[0] = time;
+    }
+  }
+  fOutputCount++;
+
+  fFileout = new std::ofstream(filenamefinal.str());
+
+  ResetArrays();
+
+  TPZManVector<std::array<REAL, 3>,200> ref_vertices_line(0),
+    ref_vertices_trig(0), ref_vertices_quad(0),
+    ref_vertices_tet(0),  ref_vertices_hex(0),
+    ref_vertices_prism(0);
+
+  TPZVec<std::array<int, TPZVTK::MAX_PTS + 2>> ref_lines,
+    ref_trigs, ref_quads, ref_tets, ref_hexes, ref_prisms;
+
+  TPZManVector<std::array<REAL, 3>,200> ref_vertices;
+  TPZVec<std::array<int, TPZVTK::MAX_PTS + 2>> ref_elems;
+
+
+  const auto meshdim = fCMesh->Dimension();
+  {
+    TPZSimpleTimer timer("FillRefEls");
+    if(meshdim == 3){
+      FillReferenceTet(ref_vertices_tet, ref_tets);
+      FillReferenceHex(ref_vertices_hex, ref_hexes);
+      FillReferencePrism(ref_vertices_prism, ref_prisms);
+    }else if(meshdim == 2){
+      FillReferenceTrig(ref_vertices_trig, ref_trigs);
+      FillReferenceQuad(ref_vertices_quad, ref_quads);
+    }else{
+      FillReferenceLine(ref_vertices_line, ref_lines);
+    }
+  }
+
+  // header:
+  *fFileout << "# vtk DataFile Version 3.0" << std::endl;
+  *fFileout << "vtk output" << std::endl;
+  *fFileout << "ASCII" << std::endl;
+  *fFileout << "DATASET UNSTRUCTURED_GRID" << std::endl;
+
+  
+  
+  for (auto cel : fCMesh->ElementVec()) {
+    if (! IsValidEl(cel)){continue;}
+    const auto eltype = cel->Reference()->Type();
+
+    switch (eltype) {
+    case EOned:
+      ref_vertices = ref_vertices_line;
+      ref_elems = ref_lines;
+      break;
+    case ETriangle:
+      ref_vertices = ref_vertices_trig;
+      ref_elems = ref_trigs;
+      break;
+    case EQuadrilateral:
+      ref_vertices = ref_vertices_quad;
+      ref_elems = ref_quads;
+      break;
+    case ETetraedro:
+      ref_vertices = ref_vertices_tet;
+      ref_elems = ref_tets;
+      break;
+    case ECube:
+      ref_vertices = ref_vertices_hex;
+      ref_elems = ref_hexes;
+      break;
+    case EPrisma:
+      ref_vertices = ref_vertices_prism;
+      ref_elems = ref_prisms;
+      break;
+    default:
+      PZError << "VTK output for element type" << MElementType_Name(eltype)
+              << "not supported";
+      DebugStop();
+    }
+
+    const int offset = fPoints.size();
+    const int eldim = cel->Dimension();
+    TPZManVector<REAL, 3> qsi(eldim, 0), pt(3, 0.);
+    std::array<REAL, 3> ptx;
+    for (const auto &ip : ref_vertices) {
+      for (auto x = 0; x < eldim; x++) {
+        qsi[x] = ip[x];
+      }
+      cel->Reference()->X(qsi, pt);
+      for (auto x = 0; x < 3; x++) {
+        ptx[x] = pt[x];
+      }
+      AppendToVec(fPoints, ptx);
+      // does it make a difference if printBound?
+    }
+
+    if (isCplxMesh) {
+      ComputeFieldAtEl<CSTATE>(cel, ref_vertices, fFields);
+    } else {
+      ComputeFieldAtEl<STATE>(cel, ref_vertices, fFields);
+    }
+
+    for (const auto &elem : ref_elems) {
+      std::array<int, TPZVTK::MAX_PTS + 2> new_elem = elem;
+      for (int i = 2; i <= new_elem[0]; ++i)
+        new_elem[i] += offset;
+      AppendToVec(fCells, new_elem);
+    }
+  }
+
+  PrintPointsLegacy();
+  PrintCellsLegacy();
+  PrintCellTypesLegacy(meshdim);
+  PrintFieldDataLegacy();
+
+  
+  std::cout << " Done." << std::endl;
+}
+
+
+template<class TVar>
+TPZPostProcEl<TVar>::TPZPostProcEl(TPZCompEl *cel) : fCel(cel){
+  auto test = dynamic_cast<TPZMultiphysicsElement*>(cel);
+  if(test){fIsMultiphysics = true;}
+}
+
+template<class TVar>
+void TPZPostProcEl<TVar>::InitData(){
+  if(fIsMultiphysics){
+    auto mfcel = dynamic_cast<TPZMultiphysicsElement*>(fCel);
+    const int64_t nref = mfcel->NMeshes();
+    fDatavec.resize(nref);
+    mfcel->InitMaterialData(fDatavec);
+  }else{
+    auto intel = dynamic_cast<TPZInterpolationSpace*>(fCel);
+    intel->InitMaterialData(fMatdata);
+  }
+}
+
+template<class TVar>
+void TPZPostProcEl<TVar>::ComputeRequiredData(TPZVec<REAL> &qsi){
+  if(fIsMultiphysics){
+    auto mfcel = dynamic_cast<TPZMultiphysicsElement*>(fCel);
+    const int64_t nref = mfcel->NMeshes();
+    for(int ir = 0; ir < nref; ir++){
+      fDatavec[ir].fNeedsSol= true;
+    }
+    TPZManVector<TPZTransform<> > trvec;
+    mfcel->AffineTransform(trvec);
+    mfcel->ComputeRequiredData(qsi, trvec, fDatavec);
+  }else{
+    auto intel = dynamic_cast<TPZInterpolationSpace*>(fCel);
+    fMatdata.fNeedsSol = true;
+		intel->ComputeRequiredData(fMatdata, qsi);
+  }
+}
+
+
+template<class TVar>
+void TPZPostProcEl<TVar>::Solution(const TPZVec<REAL> &qsi, const int id, TPZVec<TVar> &sol)
+{
+  TPZMaterial * material = fCel->Material();
+  if(fIsMultiphysics){
+    auto mfcel = dynamic_cast<TPZMultiphysicsElement*>(fCel);
+    auto *matCombined =
+       dynamic_cast<TPZMatCombinedSpacesT<TVar>*>(material);
+    matCombined->Solution(fDatavec,id,sol);
+  }else{
+    auto intel = dynamic_cast<TPZInterpolationSpace*>(fCel);
+    auto *matSingle =
+       dynamic_cast<TPZMatSingleSpaceT<TVar>*>(material);
+    matSingle->Solution(fMatdata,id,sol);
+  }
+}

--- a/Post/TPZVTKGenerator.h
+++ b/Post/TPZVTKGenerator.h
@@ -13,6 +13,7 @@
 #include "pzeltype.h"
 #include <iostream>
 #include <map>
+#include <set>
 
 class TPZCompMesh;
 
@@ -97,6 +98,8 @@ class TPZVTKGenerator{
 protected:
   //! Computational mesh
   TPZCompMesh* fCMesh = nullptr;
+  //! Set of materials in which post-processing will take place
+  std::set<int> fPostProcMats;
   //! File name (no extension)
   std::string fFilename = "";
   //! Number of subdivisions of each geometric element
@@ -140,6 +143,8 @@ protected:
   void PrintFieldDataLegacy();
   //! Check if element should be processed
   bool IsValidEl(TPZCompEl *el);
+  //! Initializes field data
+  void InitFields(const TPZVec<std::string> &fields);
   /**@brief Compute all post-processing points and vtk cells. 
      It also creates list of valid computational elements for post-processing.*/
   void ComputePointsAndCells();
@@ -163,6 +168,35 @@ public:
      @param[in] vtkres resolution of vtk post-processing (number of el subdivision)
   */
   TPZVTKGenerator(TPZAutoPointer<TPZCompMesh> cmesh,
+                  const TPZVec<std::string> &fields,
+                  std::string filename,
+                  int vtkres);
+
+  /**
+     @brief Creates instance for generating .vtk results for given materials in a given mesh
+     @param[in] cmesh Computational mesh
+     @param[in] mats identifiers of materials to be post-processed
+     @param[in] fields names of fields to be post-processed
+     @param[in] filename filename (without extension)
+     @param[in] vtkres resolution of vtk post-processing (number of el subdivision)
+     @note All materials should have the same dimension
+  */
+  TPZVTKGenerator(TPZCompMesh* cmesh,
+                  std::set<int> mats,
+                  const TPZVec<std::string> &fields,
+                  std::string filename,
+                  int vtkres);
+  /**
+     @brief Creates instance for generating .vtk results for given materials in a given mesh
+     @param[in] cmesh Computational mesh
+     @param[in] mats identifiers of materials to be post-processed
+     @param[in] fields names of fields to be post-processed
+     @param[in] filename filename without extension
+     @param[in] vtkres resolution of vtk post-processing (number of el subdivision)
+     @note All materials should have the same dimension
+  */
+  TPZVTKGenerator(TPZAutoPointer<TPZCompMesh> cmesh,
+                  std::set<int> mats,
                   const TPZVec<std::string> &fields,
                   std::string filename,
                   int vtkres);

--- a/Post/TPZVTKGenerator.h
+++ b/Post/TPZVTKGenerator.h
@@ -1,3 +1,10 @@
+/*********************************************************************/
+/* File:   TPZVTKGenerator.h                                         */
+/* Author: Francisco Orlandini                                       */
+/* Date:   5. July 2022                                              */
+/* Adapted from: NGSolve's vtkoutput.hpp                             */
+/*********************************************************************/
+
 #ifndef _TPZVTKGENERATOR_H_
 #define _TPZVTKGENERATOR_H_
 
@@ -9,18 +16,15 @@
 
 class TPZCompMesh;
 
-/*********************************************************************/
-/* File:   TPZVTKGenerator.h                                         */
-/* Author: Francisco Orlandini                                       */
-/* Date:   5. July 2022                                              */
-/* Adapted from: NGSolve's vtkoutput.hpp                             */
-/*********************************************************************/
 
-namespace TPZVTK{//useful constants for compile time
-  //hexahedron: nnodes
+
+namespace TPZVTK{
+  //! max number of nodes for a given cell (hexahedron)
   static constexpr int MAX_PTS{8};
-  //pyramid: nsub els
+  //! max number of sub elements after a geometric refinement (pyramid)
   static constexpr int MAX_SUBEL{10};
+
+  //! cell types for .VTK format
   static int CellType(const MElementType el){
     switch (el){
     case EPoint:
@@ -48,7 +52,10 @@ namespace TPZVTK{//useful constants for compile time
     }
   }
 };
-
+/**
+   @brief Stores pointwise information on post-processed variables.
+   This class is used internally by the TPZVTKGenerator
+*/
 class TPZVTKField : public TPZVec<STATE>
 {
 public:
@@ -82,54 +89,70 @@ private:
   std::string fName = "none";
 };
 
+
+/**
+   @brief Manages exporting of post-processed quantities to .VTK files.
+*/
 class TPZVTKGenerator{
 protected:
+  //! Computational mesh
   TPZCompMesh* fCMesh = nullptr;
-
+  //! File name (no extension)
   std::string fFilename = "";
+  //! Number of subdivisions of each geometric element
   int fSubdivision{0};
+  //! Post-processed quantities
   TPZVec<TPZAutoPointer<TPZVTKField>> fFields;
-
+  //! Geometric coordinates of points in which quantities will be processed
   TPZVec<TPZManVector<REAL,3>> fPoints;
+  /** @brief Domain triangulation after subdivisions.
+      Each cell is organised as type nnodes node0 node1 node2 ... nodeN*/
   TPZVec<std::array<int,TPZVTK::MAX_PTS+2>> fCells;//max 
-
+  //! Used for exporting .VTK series (time-steps, different modes, etc)
   int fOutputCount = 0;
+  //! Used for associating each .VTK file with a given time value
   TPZVec<REAL> fTimes = {0};
+  //! Current file in which .VTK data will be written
   TPZAutoPointer<std::ofstream> fFileout{nullptr};
+  //! Name (no extension) of last output file
   std::string fLastOutputName = "";
-
+  //! All nodes in the reference element in which quantities are evaluated
   std::map<MElementType,TPZVec<TPZManVector<REAL,3>>> fRefVertices;
+  //! All sub-elements resulting of dividing the original reference element
   std::map<MElementType,TPZVec<std::array<int,TPZVTK::MAX_PTS+2>>> fRefEls;
   //! (el,first pos) list of elements and the initial position of their solution in the field vec
   TPZVec<std::pair<TPZCompEl*,int>> fElementVec;
 
+
+  //! Computes points (at reference element) for evaluating fields
   template<class TOPOL>
   void FillReferenceEl(TPZVec<TPZManVector<REAL,3>> &ref_coords,
                        TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
-
+  //! Calls FillReferenceEl to fill fRefVertices and fRefEls for all relevant topologies
   void FillRefEls(const int meshdim);
   //! Print all points in VTK Legacy format
   void PrintPointsLegacy();
   //! Print all cells in VTK Legacy format
   void PrintCellsLegacy();
   //! Print all cell types in VTK Legacy format
-  void PrintCellTypesLegacy(int meshdim);
+  void PrintCellTypesLegacy();
   //! Print all fields in VTK Legacy format
   void PrintFieldDataLegacy();
   //! Check if element should be processed
   bool IsValidEl(TPZCompEl *el);
-  //! Compute all post-processing points and create list of valid elements
-  void ComputePoints();
+  /**@brief Compute all post-processing points and vtk cells. 
+     It also creates list of valid computational elements for post-processing.*/
+  void ComputePointsAndCells();
 public:
   /**
      @brief Creates instance for generating .vtk results for a given mesh
      @param[in] cmesh Computational mesh
      @param[in] fields names of fields to be post-processed
-     @param[in] filename filename without extension
+     @param[in] filename filename (without extension)
      @param[in] vtkres resolution of vtk post-processing (number of el subdivision)
   */
   TPZVTKGenerator(TPZCompMesh* cmesh,
-                  const TPZVec<std::string> fields,
+                  const TPZVec<std::string> &fields,
                   std::string filename,
                   int vtkres);
   /**
@@ -140,7 +163,7 @@ public:
      @param[in] vtkres resolution of vtk post-processing (number of el subdivision)
   */
   TPZVTKGenerator(TPZAutoPointer<TPZCompMesh> cmesh,
-                  const TPZVec<std::string> fields,
+                  const TPZVec<std::string> &fields,
                   std::string filename,
                   int vtkres);
   //!Generates .vtk file for a given current solution of the mesh

--- a/Post/TPZVTKGenerator.h
+++ b/Post/TPZVTKGenerator.h
@@ -128,7 +128,8 @@ protected:
   std::map<MElementType,TPZVec<std::array<int,TPZVTK::MAX_PTS+2>>> fRefEls;
   //! (el,first pos) list of elements and the initial position of their solution in the field vec
   TPZVec<std::pair<TPZCompEl*,int>> fElementVec;
-
+  //! number of threads to be used for computing the fields
+  int fNThreads{4};
 
   //! Computes points (at reference element) for evaluating fields
   template<class TOPOL>
@@ -151,6 +152,8 @@ protected:
   /**@brief Compute all post-processing points and vtk cells. 
      It also creates list of valid computational elements for post-processing.*/
   void ComputePointsAndCells();
+  //!Compute fields for a range of elements
+  void ComputeFields(int first, int last);
 public:
   /**
      @brief Creates instance for generating .vtk results for a given mesh
@@ -213,6 +216,14 @@ public:
   /** @brief Resets post-processing data structure. Call this function if
    the mesh has had changes between Do() calls (refinement, etc)*/
   void ResetArrays();
+
+  //! Set number of threads to compute fields (0 for serial)
+  void SetNThreads(int nt) {
+    //let us avoid negative number of threads for the sake of it. 0 for serial
+    if(nt > -1 ){fNThreads = nt;}
+  }
+  //! Get number of threads to compute fields (0 for serial)
+  int NThreads() const {return fNThreads;} 
 };
 
 #endif /* _TPZVTKGENERATOR_H_ */

--- a/Post/TPZVTKGenerator.h
+++ b/Post/TPZVTKGenerator.h
@@ -1,0 +1,130 @@
+#ifndef _TPZVTKGENERATOR_H_
+#define _TPZVTKGENERATOR_H_
+
+#include "pzmanvector.h"
+#include "tpzautopointer.h"
+#include "pzeltype.h"
+#include <iostream>
+
+class TPZCompMesh;
+
+/*********************************************************************/
+/* File:   TPZVTKGenerator.h                                         */
+/* Author: Francisco Orlandini                                       */
+/* Date:   5. July 2022                                              */
+/* Adapted from: NGSolve's vtkoutput.hpp                             */
+/*********************************************************************/
+
+namespace TPZVTK{//useful constants for compile time
+  //hexahedron: nnodes
+  static constexpr int MAX_PTS{8};
+  //pyramid: nsub els
+  static constexpr int MAX_SUBEL{10};
+  static int CellType(const MElementType el){
+    switch (el){
+    case EPoint:
+      return 1;
+    case EOned:
+      return 3;
+    case ETriangle:
+      return 5;
+    case EQuadrilateral:
+      return 9;
+    case ETetraedro:
+      return 10;
+    case EPiramide:
+      return 14;
+    case EPrisma:
+      return 13;
+    case ECube:
+      return 12;
+    default:
+      std::cout << "TPZVTKGenerator Element Type "
+                << MElementType_Name(el) << " not supported!"
+                << std::endl;
+      DebugStop();
+      unreachable();
+    }
+  }
+};
+
+class TPZVTKField : public TPZVec<STATE>
+{
+public:
+  enum class Type{scal,vec,tens};
+  TPZVTKField() { ; };
+  TPZVTKField(Type t, int id, std::string name);
+  void SetType(Type t) {fType = t;}
+  Type GetType() const {return fType;}
+  std::string TypeName() const{
+    switch (fType){
+    case Type::scal: return "SCALARS";
+    case Type::vec: return "VECTORS";
+    case Type::tens: return "TENSORS";
+    }
+  }
+  
+  int Dimension() const {
+    switch (fType){
+    case Type::scal: return 1;
+    case Type::vec: return 3;
+    case Type::tens: return 9;
+    }
+  }
+  void SetName(std::string name) { fName = name; }
+  std::string Name() const{ return fName; }
+  void SetId(int id) {fId = id;}
+  int Id() {return fId;}
+private:
+  Type fType = Type::scal;
+  int fId = -1;
+  std::string fName = "none";
+};
+
+class TPZVTKGenerator{
+protected:
+  TPZAutoPointer<TPZCompMesh> fCMesh = nullptr;
+
+  std::string fFilename = "";
+  int fSubdivision{0};
+  TPZVec<TPZAutoPointer<TPZVTKField>> fFields;
+  TPZVec<std::array<REAL,3>> fPoints;
+  int fNPtsPerPt = fPoints.size() * 5;
+  TPZVec<std::array<int,TPZVTK::MAX_PTS+2>> fCells;//max 
+
+  int fOutputCount = 0;
+  TPZVec<REAL> fTimes = {0};
+  TPZAutoPointer<std::ofstream> fFileout{nullptr};
+  std::string fLastOutputName = "";
+
+  //! Resets fFields, fPoints, fCells
+  void ResetArrays();
+
+  void FillReferenceLine(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
+  void FillReferenceTrig(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
+  void FillReferenceQuad(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
+  void FillReferenceTet(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
+  void FillReferenceHex(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
+  void FillReferencePrism(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
+  
+  //! Print all points in VTK Legacy format
+  void PrintPointsLegacy();
+  //! Print all cells in VTK Legacy format
+  void PrintCellsLegacy();
+  //! Print all cell types in VTK Legacy format
+  void PrintCellTypesLegacy(int meshdim);
+  //! Print all fields in VTK Legacy format
+  void PrintFieldDataLegacy();
+  //! Check if element should be processed
+  bool IsValidEl(TPZCompEl *el);
+public:
+  //! Creates instance for generating .vtk results for a given mesh
+  TPZVTKGenerator(TPZAutoPointer<TPZCompMesh> cmesh,
+                  const TPZVec<std::string> fields,
+                  std::string filename,
+                  int vtkres);
+  //!Generates .vtk file for a given current solution of the mesh
+  void Do(REAL time = -1);
+};
+
+#endif /* _TPZVTKGENERATOR_H_ */

--- a/Post/TPZVTKGenerator.h
+++ b/Post/TPZVTKGenerator.h
@@ -88,8 +88,8 @@ protected:
   std::string fFilename = "";
   int fSubdivision{0};
   TPZVec<TPZAutoPointer<TPZVTKField>> fFields;
-  TPZVec<std::array<REAL,3>> fPoints;
-  int fNPtsPerPt = fPoints.size() * 5;
+
+  TPZVec<TPZManVector<REAL,3>> fPoints;
   TPZVec<std::array<int,TPZVTK::MAX_PTS+2>> fCells;//max 
 
   int fOutputCount = 0;
@@ -100,13 +100,9 @@ protected:
   //! Resets fFields, fPoints, fCells
   void ResetArrays();
 
-  void FillReferenceLine(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
-  void FillReferenceTrig(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
-  void FillReferenceQuad(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
-  void FillReferenceTet(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
-  void FillReferenceHex(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
-  void FillReferencePrism(TPZVec<std::array<REAL,3>> &ref_coords, TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
-  
+  template<class TOPOL>
+  void FillReferenceEl(TPZVec<TPZManVector<REAL,3>> &ref_coords,
+                       TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
   //! Print all points in VTK Legacy format
   void PrintPointsLegacy();
   //! Print all cells in VTK Legacy format

--- a/Post/TPZVTKGenerator.h
+++ b/Post/TPZVTKGenerator.h
@@ -100,6 +100,8 @@ protected:
   TPZCompMesh* fCMesh = nullptr;
   //! Set of materials in which post-processing will take place
   std::set<int> fPostProcMats;
+  //! Post-processing dimension
+  int fPostProcDim{-1};
   //! File name (no extension)
   std::string fFilename = "";
   //! Number of subdivisions of each geometric element
@@ -132,7 +134,7 @@ protected:
   void FillReferenceEl(TPZVec<TPZManVector<REAL,3>> &ref_coords,
                        TPZVec<std::array<int,TPZVTK::MAX_PTS + 2>> &ref_elems);
   //! Calls FillReferenceEl to fill fRefVertices and fRefEls for all relevant topologies
-  void FillRefEls(const int meshdim);
+  void FillRefEls();
   //! Print all points in VTK Legacy format
   void PrintPointsLegacy();
   //! Print all cells in VTK Legacy format
@@ -155,22 +157,26 @@ public:
      @param[in] fields names of fields to be post-processed
      @param[in] filename filename (without extension)
      @param[in] vtkres resolution of vtk post-processing (number of el subdivision)
+     @param[in] dim Post-processing dimension (defaults to dimension of mesh)
   */
   TPZVTKGenerator(TPZCompMesh* cmesh,
                   const TPZVec<std::string> &fields,
                   std::string filename,
-                  int vtkres);
+                  int vtkres,
+                  int dim = -1);
   /**
      @brief Creates instance for generating .vtk results for a given mesh
      @param[in] cmesh Computational mesh
      @param[in] fields names of fields to be post-processed
      @param[in] filename filename without extension
      @param[in] vtkres resolution of vtk post-processing (number of el subdivision)
+     @param[in] dim Post-processing dimension (defaults to dimension of mesh)
   */
   TPZVTKGenerator(TPZAutoPointer<TPZCompMesh> cmesh,
                   const TPZVec<std::string> &fields,
                   std::string filename,
-                  int vtkres);
+                  int vtkres,
+                  int dim = -1);
 
   /**
      @brief Creates instance for generating .vtk results for given materials in a given mesh

--- a/Post/TPZVTKGenerator.h
+++ b/Post/TPZVTKGenerator.h
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <map>
 #include <set>
+#include <array>
 
 class TPZCompMesh;
 

--- a/Refine/TPZRefPattern.cpp
+++ b/Refine/TPZRefPattern.cpp
@@ -1187,6 +1187,7 @@ void TPZRefPattern::ReadAndCreateRefinementPattern(std::istream &pattern){
         if(el > 0)
         {
             subel->SetFather(father);
+            father->SetSubElement(el-1, subel);
             subel->SetFatherIndex(father->Index());
         }
     }

--- a/Refine/TPZRefPatternDataBase.cpp
+++ b/Refine/TPZRefPatternDataBase.cpp
@@ -578,15 +578,20 @@ void TPZRefPatternDataBase::InitializeUniformRefPattern(MElementType elType)
 }
 
 //.........................................................................................................................................
-void TPZRefPatternDataBase::InitializeAllUniformRefPatterns()
+void TPZRefPatternDataBase::InitializeAllUniformRefPatterns(int maxd)
 {
-	InitializeUniformRefPattern(EOned);
-	InitializeUniformRefPattern(ETriangle);
-	InitializeUniformRefPattern(EQuadrilateral);
-	InitializeUniformRefPattern(ETetraedro);
-	InitializeUniformRefPattern(EPiramide);
-	InitializeUniformRefPattern(EPrisma);
-	InitializeUniformRefPattern(ECube);
+	switch(maxd){
+	default:
+		InitializeUniformRefPattern(ETetraedro);
+		InitializeUniformRefPattern(EPiramide);
+		InitializeUniformRefPattern(EPrisma);
+		InitializeUniformRefPattern(ECube);
+	case 2:
+		InitializeUniformRefPattern(EQuadrilateral);
+		InitializeUniformRefPattern(ETriangle);
+	case 1:
+		InitializeUniformRefPattern(EOned);
+	}
 }
 
 //.........................................................................................................................................

--- a/Refine/TPZRefPatternDataBase.h
+++ b/Refine/TPZRefPatternDataBase.h
@@ -60,7 +60,7 @@ public:
     int ImportRefPatterns(std::string &Path, int maxdim = 3);
 
     /** @brief Initialize the uniform refinement pattern from hard coaded data for all linear geometric elements */
-	void InitializeAllUniformRefPatterns();
+	void InitializeAllUniformRefPatterns(int maxd = 3);
 	
 	/** @brief Insert the refinement pattern in the list of availabe refinement patterns assigns an Id to refPattern */
 	void InsertRefPattern(TPZAutoPointer<TPZRefPattern> & refpat);

--- a/UnitTest_PZ/TestRefinement/TestRefinement.cpp
+++ b/UnitTest_PZ/TestRefinement/TestRefinement.cpp
@@ -17,7 +17,6 @@
 #include "tpzprism.h"
 #include "tpzpyramid.h"
 
-#include "TPZVTKGeoMesh.h"
 #include <stdio.h>
 #include <iostream>
 #include<catch2/catch.hpp>
@@ -58,7 +57,7 @@ namespace refinementtests{
     template<class TTopology>
     void TestingUniformRefinements(bool RefFromDatabase){
 
-        auto* gmesh = new TPZGeoMesh;
+        TPZGeoMesh* gmesh = new TPZGeoMesh;
         // using TTopology pztopology::TTopology;
 
         // Create nodes
@@ -87,13 +86,11 @@ namespace refinementtests{
 
         // Check determinant of jacobian matrix
         TestJacobian(gmesh);
-
-        std::string plotname = "test_"+MElementType_Name(TTopology::Type())+".vtk";
-        std::ofstream plotfile(plotname);
-        TPZVTKGeoMesh::PrintGMeshVTK(gmesh, plotfile);
+        
         /** Suggestions for future tests to add:
          * - Initialize and test ALL refinement patterns from the database
         */
+
 
         delete gmesh;
     }

--- a/UnitTest_PZ/TestRefinement/TestRefinement.cpp
+++ b/UnitTest_PZ/TestRefinement/TestRefinement.cpp
@@ -17,6 +17,7 @@
 #include "tpzprism.h"
 #include "tpzpyramid.h"
 
+#include "TPZVTKGeoMesh.h"
 #include <stdio.h>
 #include <iostream>
 #include<catch2/catch.hpp>
@@ -57,7 +58,7 @@ namespace refinementtests{
     template<class TTopology>
     void TestingUniformRefinements(bool RefFromDatabase){
 
-        TPZGeoMesh* gmesh = new TPZGeoMesh;
+        auto* gmesh = new TPZGeoMesh;
         // using TTopology pztopology::TTopology;
 
         // Create nodes
@@ -86,11 +87,13 @@ namespace refinementtests{
 
         // Check determinant of jacobian matrix
         TestJacobian(gmesh);
-        
+
+        std::string plotname = "test_"+MElementType_Name(TTopology::Type())+".vtk";
+        std::ofstream plotfile(plotname);
+        TPZVTKGeoMesh::PrintGMeshVTK(gmesh, plotfile);
         /** Suggestions for future tests to add:
          * - Initialize and test ALL refinement patterns from the database
         */
-
 
         delete gmesh;
     }

--- a/Util/pzvec.h
+++ b/Util/pzvec.h
@@ -476,21 +476,32 @@ void TPZVec<T>::Resize(const int64_t newsize) {
 	if(newsize == fNElements) return;
 	if (newsize == 0) {
 		fNElements = 0;
-        fNAlloc = 0;
+    fNAlloc = 0;
 		delete[] fStore;
 		fStore = nullptr;
 		return;
 	}
-	T *newstore = new T[newsize];
-	int64_t large = (fNElements < newsize) ? fNElements : newsize;
-	int64_t i;
-	for(i=0L; i<large; i++) {
-		newstore[i] = fStore[i];
-	}
-	if(fStore) delete[] fStore;
-	fStore = newstore;
-	fNElements = newsize;
-    fNAlloc = newsize;
+
+  /*
+    if needed to allocate, unless previous size was zero,
+    we allocate twice as much as requested. 
+    this aims to prevent repeated calls to new/delete
+    in operations such as appending to vector
+   */
+  if(newsize > this->fNAlloc){
+    const auto sz = fNAlloc == 0 ? newsize : 2*newsize;
+    T *newstore = new T[sz];
+    int64_t large = (fNElements < sz) ? fNElements : newsize;
+    int64_t i;
+    for(i=0L; i<large; i++) {
+      newstore[i] = fStore[i];
+    }
+    if(fStore) delete[] fStore;
+    fStore = newstore;
+    fNAlloc = sz;
+  }
+
+  fNElements = newsize;
 }
 
 template<class T>

--- a/Util/pzvec_extras.h
+++ b/Util/pzvec_extras.h
@@ -15,6 +15,16 @@
  * @{
  */
 
+
+//! Append to TPZVec
+template<class T, class R>//utility function
+void AppendToVec(TPZVec<T> &vec, R t){
+  static_assert(std::is_convertible_v<R, T>);
+  const auto sz = vec.size();
+  vec.Resize(sz+1);
+  vec[sz] = (T)t;
+}
+
 /**
  * @since Jan 9, 2002
  * @author Cantao!

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -34,4 +34,4 @@ set(docs_sources
 add_subdirectory(material)
 add_subdirectory(structmatrix)
 add_subdirectory(solver)
-    
+add_subdirectory(post)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Welcome to NeoPZ's documentation!
    :caption: Contents:
              
    analysis/index.rst
+   post/index.rst
    material/index.rst
    structmatrix/index.rst
    solver/index.rst
@@ -30,7 +31,8 @@ Introduction
 
 This documentation is an ongoing work. The following sections have been written:
 
-- :doc:`analysis/index` How a FEM analysis is performed in NeoPZ
+- :doc:`analysis/index` How a FEM analysis is performed in NeoPZ (ongoing)
+- :doc:`post/index` How to generate .VTK files of your simulation results in NeoPZ
 - :doc:`material/index` How weak formulations are implemented
 - :doc:`structmatrix/index` How different matrix storage formats can be used
 - :doc:`solver/index` Available solvers in NeoPZ

--- a/docs/post/CMakeLists.txt
+++ b/docs/post/CMakeLists.txt
@@ -1,0 +1,5 @@
+list(APPEND docs_sources
+  "${CMAKE_CURRENT_SOURCE_DIR}/index.rst"
+)
+
+set(docs_sources ${docs_sources} PARENT_SCOPE)

--- a/docs/post/index.rst
+++ b/docs/post/index.rst
@@ -1,0 +1,86 @@
+Post-processing results
+==========================
+
+.. toctree::
+   :maxdepth: 2
+   
+.. contents:: Table of Contents
+   :local:
+
+
+TPZVTKGenerator (usage)
+---------------------------
+
+The :cpp:expr:`TPZVTKGenerator` is a utility class for post-processing quantities
+obtained by a FEM simulation in a straightforward way.
+It efficiently generates files in the `VTK Legacy format <http://www.princeton.edu/~efeibush/viscourse/vtk.pdf>`__ .
+
+In the following examples, it is assumed that a solution was computed for a given
+computatinal mesh ``cmesh`` and that the header
+``#include <TPZVTKGenerator.h>`` was included.
+
+For further information on how to setup the post-processing quantities, see documentation
+for the :cpp:expr:`TPZMaterial` class, specially :cpp:expr:`TPZMaterial::VariableIndex` and :cpp:expr:`TPZMaterial::NSolutionVariables`.
+
+
+Post-processing all materials of a given dimension
+++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. code-block:: cpp
+
+   const std::string plotfile = "myfile";//no .vtk at the end
+   constexpr int vtkRes{2};//vtk post-processing resolution
+
+   //list of variables to be post-processed. It can be scalar, vectors, tensors, etc.
+   TPZVec<std::string> fields = {
+   "scalar_var",
+   "vec_var",
+   "another_scalar_var",
+   "yet_another_scalar_var"};
+
+   const int postprocdim{2};
+   //if postprocdim is not set, it will be set as cmesh->Dimension()
+   auto vtk = TPZVTKGenerator(cmesh, fields, plotfile, vtkRes,postprocdim); 
+   
+
+   //generates the .vtk file
+   vtk.Do();
+   //compute another solution, etc, etc
+   vtk.Do();
+   //if the elements are refined after a call to TPZVTKGenerator::Do,
+   //one must then call
+
+   vtk.ResetArrays();
+   vtk.Do();
+
+Post-processing a given set of materials
+++++++++++++++++++++++++++++++++++++++++
+
+.. note::
+   All materials must have the same dimension
+        
+.. code-block:: cpp
+
+   const std::string plotfile = "myfile";//no .vtk at the end
+   constexpr int vtkRes{2};//vtk post-processing resolution
+
+   //list of variables to be post-processed. It can be scalar, vectors, tensors, etc.
+   TPZVec<std::string> fields = {
+   "scalar_var",
+   "vec_var",
+   "another_scalar_var",
+   "yet_another_scalar_var"};
+
+   std::set<int> postprocmats = {1,2,3};
+   
+   auto vtk = TPZVTKGenerator(cmesh,postprocmats,fields, plotfile, vtkRes); 
+   //proceed as in the above example
+
+
+Full documentation is available below
+
+TPZVTKGenerator (full docs)
++++++++++++++++++++++++++++
+
+.. doxygenclass:: TPZVTKGenerator
+   :members:


### PR DESCRIPTION
This PR introduces the `TPZVTKGenerator` class for simple post-processing of FEM results, allowing for parallel post processing.

Experiments have shown up to ten times faster execution using the serial version, as compared to `TPZAnalysis::PostProcess`. This is due to a reduced number of calls to `InitMaterialData` and `ComputeRequiredData` (which will have a greater impact as the number of post processed variables is increased), along with avoiding dynamic allocation whenever possible.

Its usage is demonstrated as follows

```c++
#include "TPZVTKGenerator.h"

//code etc etc

//variables to be post-processed (can be either scalars, vectors or tensors)
TPZVec<std::string> fields = {
"scalar_var",
"vec_var",
"another_scalar_var",
"yet_another_scalar_var"};

//OPTION 1
//geometric dimension to be post processed
const int postprocdim{2};
auto vtk = TPZVTKGenerator(cmesh, fields, plotfile, vtkRes,postprocdim); //if no postprocdim was given, maxdim will be chosen

//OPTION 2:
//material identifiers for which post-processing will be executed (must have same dimension)
std::set<int> mats = {1,2,3,4};
auto vtk = TPZVTKGenerator(cmesh, mats, fields, plotfile, vtkRes);


//optional, set 0 for serial code
vtk.SetNThreads(4);
vtk.Do();
//let us assume you load another solution into the mesh
vtk.Do();
```

The following changes were performed in NeoPZ:
- `TPZVec<T>` allocates more memory than requested (unless initial size was zero)
- Adds a parameter for the maximum refinement dimension in `TPZRefPatternDataBase::InitializeAllUniformRefPatterns` (default value maintains original behaviour)
- Father element has knowledge of subelements in the refinement pattern mesh
- Adds `AppendToVec` to `pzvec_extras.h`
- Adds overrides (`TPZElementGroup` and `TPZSubCompMesh`) for existent method `TPZCompEl::NumberOfCompElementsInsideThisCompEl` (this was not used, but I've kept the commit so as to be consistent)
- Adds `TPZCompEl::GetCompElList` for getting the list of computational elements to be post-processed (overriden only in `TPZElementGroup` and `TPZSubCompMesh`)
