### PR TITLE
New parallel interface; USING_OMP becomes a compilation flag; Contribute acceleration using BLAS; error fixes

### DIFF
--- a/Analysis/pzsmanal.cpp
+++ b/Analysis/pzsmanal.cpp
@@ -113,7 +113,14 @@ void TPZSubMeshAnalysis::AssembleInternal()
 //	time_t before = time (NULL);
 	fStructMatrix->Assemble(fReducableStiff,fRhs,fGuiInterface);
     
-    matred->SetF(fRhs);
+    if (fStructMatrix->HasRange()) {
+        TPZFMatrix<TVar> rhsloc(fStructMatrix->EquationFilter().NActiveEquations(),fRhs.Cols(),0.);
+        fStructMatrix->EquationFilter().Gather(fRhs, rhsloc);
+        matred->SetF(rhsloc);
+    }
+    else{
+        matred->SetF(fRhs);
+    }
 //	time_t after = time(NULL);
 //	double diff = difftime(after, before);
 //	std::cout << __PRETTY_FUNCTION__ << " tempo " << diff << std::endl;

--- a/Analysis/pzsmanal.cpp
+++ b/Analysis/pzsmanal.cpp
@@ -70,6 +70,9 @@ void TPZSubMeshAnalysis::AssembleInternal()
     {
         fReducableStiff = new TPZMatRed<TVar, TPZFMatrix<TVar> > ();
     }
+    if(!fStructMatrix->HasRange()){
+        fReducableStiff->Redim(numeq,numinternal);
+    }
 	TPZMatRed<TVar, TPZFMatrix<TVar> > *matred = dynamic_cast<TPZMatRed<TVar, TPZFMatrix<TVar> > *> (fReducableStiff.operator->());
     if(!mySolver.Matrix())
     {
@@ -96,7 +99,7 @@ void TPZSubMeshAnalysis::AssembleInternal()
             fStructMatrix->EquationFilter().SetNumEq(numeq); // it does not hurt to set it again in case it was forgotten after condensing...
         }
         else{
-            fReducableStiff->Redim(numeq,numinternal);
+            // fReducableStiff->Redim(numeq,numinternal);
             fStructMatrix->SetEquationRange(0, numinternal);
             mySolver.SetMatrix(fStructMatrix->Create());
             fStructMatrix->EquationFilter().Reset();

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,13 @@ if(USING_TBB)
 	enable_tbb(pz)
 endif()
 
+#enabling OMP library
+option(USING_OMP "Whether the TBB library will be linked in" OFF)
+if(USING_OMP)
+    include(cmake/EnableOMP.cmake)
+    enable_omp(pz)
+endif()
+
 #enabling LIKWID library
 option(USING_LIKWID "Whether the likwid library will be linked in" OFF)
 if(USING_LIKWID)

--- a/Material/DarcyFlow/TPZHybridDarcyFlow.cpp
+++ b/Material/DarcyFlow/TPZHybridDarcyFlow.cpp
@@ -135,7 +135,7 @@ void TPZHybridDarcyFlow::Contribute(const TPZVec<TPZMaterialDataT<STATE>> &datav
         LDA = dphi.Rows();
         LDB = dphi.Rows();
         LDC = ek.Rows();
-        if(LDC != phr+2)
+        if(LDC != phr+2 && datavec.size() ==4)
             DebugStop();
         A = &dphi(0,0);
         B = &dphi(0,0);

--- a/Material/DarcyFlow/TPZHybridDarcyFlow.cpp
+++ b/Material/DarcyFlow/TPZHybridDarcyFlow.cpp
@@ -4,6 +4,9 @@
 
 #include "TPZHybridDarcyFlow.h"
 #include "pzaxestools.h"
+#ifdef USING_MKL
+#include "mkl.h"
+#endif
 
 TPZHybridDarcyFlow::TPZHybridDarcyFlow() : TPZRegisterClassId(&TPZHybridDarcyFlow::ClassId),
                                TPZMatCombinedSpacesT<STATE>(), TPZDarcyFlow() {}
@@ -88,40 +91,251 @@ void TPZHybridDarcyFlow::Contribute(const TPZVec<TPZMaterialDataT<STATE>> &datav
                         REAL weight,TPZFMatrix<STATE> &ek,
                         TPZFMatrix<STATE> &ef)
 {
-    const TPZFMatrix<REAL> &phi = datavec[0].fPhi;
-    const TPZFMatrix<REAL> &dphi = datavec[0].dphix;
-    const TPZVec<REAL> &x = datavec[0].x;
-    const TPZFMatrix<REAL> &axes = datavec[0].axes;
-    const TPZFMatrix<REAL> &jacinv = datavec[0].jacinv;
-    auto phr = dphi.Cols();
+    /**
+    datavec[1] L2 mesh (phi's)
+    datavec[0] Hdiv mesh,
+    datavec[2] Interface Mesh
+    datavec[3] Interface Mesh
 
-    const STATE perm = GetPermeability(datavec[0].x);
+    Implement the matrix
+    |Sk Ck^T |  = |f1|
+    |Ck  0   |    |f2|
+    Sk = int_K K graduk.gradv dx = int_K K gradphi_i.gradphi_j dx
+    CK = int_partialK lambda_k*uk dx = int_K phi_i dx
+    f1 = int_K f*v dx = int_K f*phi_j dx
+    ck = int_partialK phi_i*mu_j dx
+    f2 = int_partialK g*mu_j dx
+    **/
 
-    STATE source_term = 0;
-    if (this->HasForcingFunction()) {
-        TPZManVector<STATE, 1> res(1);
+    TPZFMatrix<REAL>  &phi = datavec[1].phi;
+    TPZFMatrix<REAL> &dphi = datavec[1].dphix;
+    TPZVec<REAL>  &x = datavec[1].x;
+
+    int phr = phi.Rows();
+
+    STATE fXfLoc = 0;
+
+    if(fForcingFunction) {            // phi(in, 0) = phi_in
+        TPZManVector<STATE,1> res(1);
         fForcingFunction(x, res);
-        source_term = -res[0];
+        fXfLoc = res[0];
     }
 
-    // Darcy's equation
-    for (int in = 0; in < phr; in++) {
-        ef(in, 0) -= weight * source_term * (phi(in, 0));
-        for (int jn = 0; jn < phr; jn++) {
-            for (int kd = 0; kd < fDim; kd++) {
-                ek(in, jn) += weight * (dphi(kd, in) * perm * dphi(kd, jn));
+    STATE KPerm = GetPermeability(datavec[0].x);
+
+#if defined(USING_MKL)
+    {
+        double *A, *B, *C;
+        int m, n, k;
+        double alpha, beta;
+        m = phr, k = fDim, n = phr;
+        alpha = weight*KPerm;
+        beta = 1.0;
+        int LDA,LDB,LDC;
+        LDA = dphi.Rows();
+        LDB = dphi.Rows();
+        LDC = ek.Rows();
+        if(LDC != phr+2)
+            DebugStop();
+        A = &dphi(0,0);
+        B = &dphi(0,0);
+        C = &ek(0,0);
+        cblas_dgemm(CblasColMajor, CblasTrans, CblasNoTrans,
+                       phr, phr, LDA,alpha , A, LDA, B, LDB, beta, C, LDC);
+    }
+    {
+        //saxpy implementation
+        int N = phr;
+        double alpha = weight*fXfLoc;
+        double *X = &phi(0,0);
+        int incX = 1;
+        double *Y = &ef(0,0);
+        int incY = 1;
+        cblas_daxpy(N,alpha,X,incX, Y,incY);
+    }
+    if(datavec.size() >=4){
+        int N = phr;
+        double alpha = weight;
+        double *X = &phi(0,0);
+        int incX = 1;
+        double *Y = &ek(0,phr);
+        int incY = 1;
+        cblas_daxpy(N,alpha,X,incX, Y,incY);
+        Y = &ek(phr,0);
+        incY = ek.Rows();
+        cblas_daxpy(N,alpha,X,incX, Y,incY);
+    }
+#else
+    //Equacao de Poisson
+    for( int in = 0; in < phr; in++ ) {
+        int kd;
+        ef(in, 0) +=  (STATE)weight * fXfLoc * (STATE)phi(in,0);
+
+        //matrix Sk
+        for( int jn = 0; jn < phr; jn++ ) {
+            for(kd=0; kd<fDim; kd++) {
+                ek(in,jn) += (STATE)weight*(KPerm*(STATE)(dphi(kd,in)*dphi(kd,jn)));
             }
         }
     }
-    auto nspaces = datavec.size();
-    for(int ispace = 1; ispace < nspaces; ispace+= 2)
-    {
-        for (int in = 0; in <phr; in++) {
-            ek(in,phr+(ispace-1)*2) += weight*phi(in,0);
-            ek(phr+(ispace-1)*2,in) += weight*phi(in,0);
-        }
-        ek(phr+(ispace-1)*2,phr+(ispace-1)*2+1) -= weight;
-        ek(phr+(ispace-1)*2+1,phr+(ispace-1)*2) -= weight;
+    if(datavec.size() >=4){
+        for (int in =0; in < phr; in++) {
+            ek(phr,in) += weight*phi(in,0);//lambda*phi
+            ek(in,phr) += weight*phi(in,0);
     }
+#endif
+    //equacoes de restricao de pressao media
+    if(datavec.size() >=4) {
+        ek(phr, phr + 1) -= weight;
+        ek(phr + 1, phr) -= weight;
+    }
+}
+
+void TPZHybridDarcyFlow::ContributeBC(const TPZVec<TPZMaterialDataT<STATE>> &datavec, REAL weight, TPZFMatrix<STATE> &ek,TPZFMatrix<STATE> &ef,TPZBndCondT<STATE> &bc)
+{
+    TPZFMatrix<REAL>  &phi_u = datavec[1].phi;
+    TPZFMatrix<REAL>  &phi_flux = datavec[0].phi;
+    //    TPZFMatrix<REAL> &axes = data.axes;
+    int phr_primal = phi_u.Rows();
+    int phr_hybrid = phi_flux.Rows();
+    bool primal = true;   /// weather pressure or flux is hybridized
+    TPZManVector<REAL,3> x(3);
+    if(phr_hybrid)
+    {
+        primal = false;
+        x = datavec[0].x;
+    }
+    else
+    {
+        x = datavec[1].x;
+    }
+    short in,jn;
+    STATE v2[1];
+    v2[0] = bc.Val2()[0];
+
+    if(bc.HasForcingFunctionBC()) {            // phi(in, 0) = phi_in                          // JORGE 2013 01 26
+        TPZManVector<STATE> res(1);
+        TPZFNMatrix<3,STATE> dres(3,1);
+        bc.ForcingFunctionBC()(x, res, dres);
+        v2[0] = res[0];
+    }
+
+    if(primal)
+    {
+        switch (bc.Type()) {
+            case 0 :            // Dirichlet condition
+                for(in = 0 ; in < phr_primal; in++) {
+                    ef(in,0) += (STATE)(fBigNumber* phi_u(in,0) * weight) * v2[0];
+                    for (jn = 0 ; jn < phr_primal; jn++) {
+                        ek(in,jn) += fBigNumber * phi_u(in,0) * phi_u(jn,0) * weight;
+                    }
+                }
+                break;
+            case 1 :            // Neumann condition
+                for(in = 0 ; in < phr_primal; in++) {
+                    ef(in,0) += v2[0] * (STATE)(phi_u(in,0) * weight);
+                }
+                break;
+            case 2 :        // mixed condition
+                for(in = 0 ; in < phr_primal; in++) {
+                    ef(in, 0) += v2[0] * (STATE)(phi_u(in, 0) * weight);
+                    for (jn = 0 ; jn < phi_u.Rows(); jn++) {
+                        ek(in,jn) += bc.Val1()(0,0) * (STATE)(phi_u(in,0) * phi_u(jn,0) * weight);     // peso de contorno => integral de contorno
+                    }
+                }
+                break;
+            default:
+                DebugStop();
+        }
+    } else
+    {
+        switch (bc.Type()) {
+            case 0 :            // Dirichlet condition
+                for(in = 0 ; in < phr_hybrid; in++) {
+                    ef(in,0) += v2[0] * (STATE)(phi_flux(in,0) * weight);
+                }
+                break;
+            case 1 :            // Neumann condition
+                for(in = 0 ; in < phr_hybrid; in++) {
+                    ef(in,0) += (STATE)(fBigNumber* phi_flux(in,0) * weight) * v2[0];
+                    for (jn = 0 ; jn < phr_hybrid; jn++) {
+                        ek(in,jn) += fBigNumber * phi_flux(in,0) * phi_flux(jn,0) * weight;
+                    }
+                }
+                break;
+            case 2 :        // mixed condition
+                DebugStop();
+                for(in = 0 ; in < phr_hybrid; in++) {
+                    ef(in, 0) += v2[0] * (STATE)(phi_flux(in, 0) * weight);
+                    for (jn = 0 ; jn < phi_flux.Rows(); jn++) {
+                        ek(in,jn) += 1./bc.Val1()(0,0) * (STATE)(phi_flux(in,0) * phi_flux(jn,0) * weight);     // peso de contorno => integral de contorno
+                    }
+                }
+                break;
+        }
+    }
+}
+
+void TPZHybridDarcyFlow::Errors(const TPZVec<TPZMaterialDataT<STATE>> &data, TPZVec<REAL> &errors)
+{
+    if(!fExactSol) return;
+
+    errors.Resize(NEvalErrors());
+    errors.Fill(0.0);
+
+    TPZManVector<STATE> u_exact(1);
+    TPZFNMatrix<9,STATE> du_exact;
+
+
+    if(this->fExactSol){
+
+        this->fExactSol(data[1].x,u_exact,du_exact);
+    }
+
+    REAL pressure = data[1].sol[0][0];
+
+    // errors[0] norm L2 || u ||_l2
+
+    errors[0] = (pressure-u_exact[0])*(pressure-u_exact[0]);//exact error pressure
+
+    // errors[1] Semi norm H1 || grad u ||_l2
+
+    TPZManVector<STATE,3> sol(1),dsol(3,0.);
+
+    TPZFMatrix<REAL> &dsolaxes = data[1].dsol[0];
+    TPZFNMatrix<9,REAL> flux(3,0);
+    TPZAxesTools<REAL>::Axes2XYZ(dsolaxes, flux, data[1].axes);
+
+    for(int id=0; id<fDim; id++) {
+        REAL diff = fabs(flux(id,0) - du_exact(id,0));
+        errors[1]  += diff*diff;
+    }
+
+    // error[2] H1 norm
+
+    errors[2] = errors[0] +errors[1];
+
+    // error[3] Energy norm || u ||_e = a(u,u)= int_K K gradu.gradu dx
+
+    STATE KPerm = GetPermeability(data[0].x);
+
+
+    TPZFNMatrix<9,REAL> gradpressure(fDim,1),Kgradu(fDim,1);
+    for (int i=0; i<fDim; i++) {
+        gradpressure(i,0) = du_exact(i,0);
+        Kgradu(i,0) = gradpressure(0)*KPerm;
+    }
+
+    REAL energy = 0.;
+    for (int i=0; i<fDim; i++) {
+        for (int j=0; j<fDim; j++) {
+            double cperm =0.;
+            if(i==j)
+                cperm = KPerm;
+            energy += cperm*fabs(flux(j,0) - du_exact(j,0))*fabs(flux(i,0) - du_exact(i,0));
+        }
+    }
+
+    errors[3] = energy;
 }
 /**@}*/

--- a/Material/DarcyFlow/TPZHybridDarcyFlow.cpp
+++ b/Material/DarcyFlow/TPZHybridDarcyFlow.cpp
@@ -182,6 +182,7 @@ void TPZHybridDarcyFlow::Contribute(const TPZVec<TPZMaterialDataT<STATE>> &datav
         for (int in =0; in < phr; in++) {
             ek(phr,in) += weight*phi(in,0);//lambda*phi
             ek(in,phr) += weight*phi(in,0);
+        }
     }
 #endif
     //equacoes de restricao de pressao media

--- a/Material/DarcyFlow/TPZHybridDarcyFlow.h
+++ b/Material/DarcyFlow/TPZHybridDarcyFlow.h
@@ -56,6 +56,8 @@ public:
 	 */
     [[nodiscard]] std::string Name() const override { return "TPZHybridDarcyFlow"; }
 
+    virtual int NEvalErrors()  const override {return 4;}
+
     /** @name Contribute */
     /** @{ */
     /**
@@ -86,7 +88,7 @@ public:
     virtual void ContributeBC(const TPZVec<TPZMaterialDataT<STATE>> &datavec,
                               REAL weight, TPZFMatrix<STATE> &ek,
                               TPZFMatrix<STATE> &ef,
-                              TPZBndCondT<STATE> &bc) override {}
+                              TPZBndCondT<STATE> &bc) override;
 
     /**@}*/
     /** @brief Returns the solution associated with a given index
@@ -117,7 +119,7 @@ public:
       \param[out] errors The calculated errors.
      */
     virtual void Errors(const TPZVec<TPZMaterialDataT<STATE>> &data,
-                        TPZVec<REAL> &errors) override {}
+                        TPZVec<REAL> &errors) override;
 
     /**
      * @brief Returns an unique class identifier

--- a/Material/DarcyFlow/TPZMixedDarcyFlow.cpp
+++ b/Material/DarcyFlow/TPZMixedDarcyFlow.cpp
@@ -550,16 +550,16 @@ void TPZMixedDarcyFlow::Errors(const TPZVec<TPZMaterialDataT<STATE>> &data, TPZV
     TPZManVector<STATE, 3> gradpressurefem(3, 0.);
     this->Solution(data, VariableIndex("GradPressure"), gradpressurefem);
 
-    TPZManVector<STATE, 3> fluxexactneg(3, 0);
+    TPZManVector<STATE, 3> fluxexact(3, 0);
     TPZManVector<STATE, 3> gradpressure(3, 0);
     for (int i = 0; i < 3; i++) {
         gradpressure[i] = du_exact[i];
-        fluxexactneg[i] = -perm * gradpressure[i];
+        fluxexact[i] = -perm * gradpressure[i];
     }
 
     REAL L2flux = 0., L2grad = 0.;
     for (int i = 0; i < 3; i++) {
-        L2flux += (fluxfem[i] + fluxexactneg[i]) * inv_perm * (fluxfem[i] + fluxexactneg[i]);
+        L2flux += (fluxfem[i] - fluxexact[i]) * inv_perm * (fluxfem[i] - fluxexact[i]);
         L2grad += (du_exact[i] - gradpressurefem[i]) * (du_exact[i] - gradpressurefem[i]);
     }
     errors[0] = (pressurefem[0] - u_exact[0]) * (pressurefem[0] - u_exact[0]);//L2 error for pressure

--- a/Material/TPZBndCond.h
+++ b/Material/TPZBndCond.h
@@ -40,7 +40,8 @@ public :
     [[nodiscard]] int ClassId() const override;
     //! Whether the boundary condition has a forcing function
     [[nodiscard]] virtual bool HasForcingFunctionBC() const = 0;
-    void Print(std::ostream &out = std::cout) const;
+  
+    virtual void Print(std::ostream &out = std::cout) const;
     
     void Read(TPZStream& buf, void* context) override;
 

--- a/Material/TPZBndCondBase.h
+++ b/Material/TPZBndCondBase.h
@@ -29,12 +29,14 @@ class TPZBndCondBase :
                    const TPZFMatrix<TVar> &val1,
                    const TPZVec<TVar> &val2);
     
+    //! Prints data associated with the material.
+    void Print(std::ostream &out = std::cout) const override;
+
+
     [[nodiscard]] int ClassId() const override;
     void Read(TPZStream &buf, void*context) override;
     void Write(TPZStream &buf, int withclassid) const override;
 
-
-    void Print(std::ostream &out) const override;
     
     void SetMaterial(TPZMaterial *) final;
     
@@ -88,20 +90,6 @@ void TPZBndCondBase<TVar, Interfaces...>::SetMaterial(TPZMaterial *mat){
 }
 
 
-template<class TVar, class...Interfaces>
-void TPZBndCondBase<TVar, Interfaces...>::Print(
-  std::ostream &out) const
-{
-    TPZMaterialT<TVar>::Print(out);
-    TPZBndCondT<TVar>::Print(out);
-    if(this->fMaterial){
-        out<<"Associated with mat id: "<<this->fMaterial->Id()<<std::endl;
-    }
-    /* The following will perform calls to all the Read methods of the interfaces. 
-       This is a c++17 addition called fold expressions.*/
-//    (Interfaces::Print(out),...);
-}
-
 
 template<class TVar, class...Interfaces>
 int TPZBndCondBase<TVar, Interfaces...>::ClassId() const{
@@ -117,6 +105,16 @@ int TPZBndCondBase<TVar, Interfaces...>::ClassId() const{
 //        }
 //    }
     return id;
+}
+
+//! Prints data associated with the material.
+template<class TVar, class...Interfaces>
+void TPZBndCondBase<TVar, Interfaces...>::Print(std::ostream &out) const {
+    TPZMaterialT<TVar>::Print(out);
+    TPZBndCondT<TVar>::Print(out);
+    /* The following will perform calls to all the Read methods of the interfaces.
+       This is a c++17 addition called fold expressions.*/
+//    (Interfaces::Print(out),...);
 }
 
 

--- a/Material/TPZBndCondBase.h
+++ b/Material/TPZBndCondBase.h
@@ -33,6 +33,9 @@ class TPZBndCondBase :
     void Read(TPZStream &buf, void*context) override;
     void Write(TPZStream &buf, int withclassid) const override;
 
+
+    void Print(std::ostream &out) const override;
+    
     void SetMaterial(TPZMaterial *) final;
     
     [[nodiscard]] int Dimension() const final
@@ -82,6 +85,21 @@ void TPZBndCondBase<TVar, Interfaces...>::SetMaterial(TPZMaterial *mat){
     // it is called a fold expression (from c++17 on)
     // https://en.cppreference.com/w/cpp/language/fold
     (Interfaces::SetMaterialImpl(mat),...);
+}
+
+
+template<class TVar, class...Interfaces>
+void TPZBndCondBase<TVar, Interfaces...>::Print(
+  std::ostream &out) const
+{
+    TPZMaterialT<TVar>::Print(out);
+    TPZBndCondT<TVar>::Print(out);
+    if(this->fMaterial){
+        out<<"Associated with mat id: "<<this->fMaterial->Id()<<std::endl;
+    }
+    /* The following will perform calls to all the Read methods of the interfaces. 
+       This is a c++17 addition called fold expressions.*/
+//    (Interfaces::Print(out),...);
 }
 
 

--- a/Material/TPZBndCondT.cpp
+++ b/Material/TPZBndCondT.cpp
@@ -14,16 +14,18 @@ TPZBndCondT<TVar>::TPZBndCondT(int type,
 {
 
 }
+
+//! Prints data associated with the material.
 template<class TVar>
-void TPZBndCondT<TVar>::Print(std::ostream &out) const
-{
+void TPZBndCondT<TVar>::Print(std::ostream &out) const {
     TPZBndCond::Print(out);
-    fBCVal1.Print("val 1", out);
-    out<<"val 2:";
-    for(auto v : fBCVal2){out<<' '<<v;}
-    out<<'\n';
-    out<<"Has forcing function: "<<HasForcingFunctionBC()<<std::endl;
+    out << "Has forcing function " << HasForcingFunctionBC() << std::endl;
+    out << "Forcing function p order " << fForcingFunctionBCPOrder << std::endl;
+    fBCVal1.Print("Val1", out);
+    out << "Val2 " << fBCVal2 << std::endl;
 }
+
+
 
 template<class TVar>
 int TPZBndCondT<TVar>::ClassId() const{

--- a/Material/TPZBndCondT.cpp
+++ b/Material/TPZBndCondT.cpp
@@ -14,6 +14,16 @@ TPZBndCondT<TVar>::TPZBndCondT(int type,
 {
 
 }
+template<class TVar>
+void TPZBndCondT<TVar>::Print(std::ostream &out) const
+{
+    TPZBndCond::Print(out);
+    fBCVal1.Print("val 1", out);
+    out<<"val 2:";
+    for(auto v : fBCVal2){out<<' '<<v;}
+    out<<'\n';
+    out<<"Has forcing function: "<<HasForcingFunctionBC()<<std::endl;
+}
 
 template<class TVar>
 int TPZBndCondT<TVar>::ClassId() const{

--- a/Material/TPZBndCondT.h
+++ b/Material/TPZBndCondT.h
@@ -58,6 +58,9 @@ public:
     }
     //@}
 
+    //! Prints data associated with the material.
+    void Print(std::ostream &out = std::cout) const override;
+
     /** @name ReadWrite */
 	/** @{ */
     int ClassId() const override;

--- a/Material/TPZLagrangeMultiplierCS.h
+++ b/Material/TPZLagrangeMultiplierCS.h
@@ -68,7 +68,6 @@ class TPZLagrangeMultiplierCS :
                              TPZFMatrix<TVar> &ek, TPZFMatrix<TVar> &ef) override;
 
     
-    
     void FillDataRequirementsInterface(TPZMaterialDataT<TVar> &data,
                                        std::map<int, TPZMaterialDataT<TVar>> &datavec_left,
                                        std::map<int, TPZMaterialDataT<TVar>> &datavec_right) override;
@@ -132,7 +131,4 @@ protected:
     TVar fMultiplier{1.};
 };
 
-
-extern template class TPZLagrangeMultiplierCS<STATE>;
-extern template class TPZLagrangeMultiplierCS<CSTATE>;
 #endif /* defined(__PZ__TPZLagrangeMultiplier__) */

--- a/Matrix/pzfmatrix.cpp
+++ b/Matrix/pzfmatrix.cpp
@@ -315,6 +315,22 @@ void TPZFMatrix<float>::AddFel(TPZFMatrix<float> &rhs,TPZVec<int64_t> &source, T
     }
 }
 
+template<class TVar>
+void TPZFMatrix<TVar>::AddFelNonAtomic(TPZFMatrix<TVar> &rhs,TPZVec<int64_t> &source, TPZVec<int64_t> &destination) {
+    if(rhs.Cols() != this->Cols() && source.NElements()) {
+        PZError << "TPZFMatrix::AddFel number of columns does not correspond\n";
+        DebugStop();
+        return;
+    }
+    int64_t ncol = this->Cols();
+    int64_t nrow = source.NElements();
+    int64_t i,j;
+    for(j=0; j<ncol; j++) {
+        for(i=0; i<nrow; i++) {
+            operator()(destination[i],j) += rhs(source[i],j);
+        }
+    }
+}
 
 
 /*******************************/

--- a/Matrix/pzfmatrix.cpp
+++ b/Matrix/pzfmatrix.cpp
@@ -93,13 +93,31 @@ TPZMatrix<TVar>( A.fRow, A.fCol ), fElem(0), fGiven(0), fSize(0) {
 
 template<class TVar>
 TPZFMatrix<TVar>::TPZFMatrix(TPZFMatrix<TVar> &&A)
-    : TPZMatrix<TVar>(A), fElem(A.fElem),
-      fGiven(A.fGiven),fSize(A.fSize),
-      fPivot(A.fPivot), fWork(A.fWork)
-{
-    A.fElem=nullptr;
-    A.fGiven=nullptr;
-    A.fSize=0;
+: TPZMatrix<TVar>(A){
+    
+    if(A.fGiven == A.fElem){
+        int64_t size = this->fRow * this->fCol;
+        if(!size) return;
+        fElem = new TVar[ size ] ;
+    #ifdef PZDEBUG2
+        if ( size && fElem == NULL ) Error( "Constructor <memory allocation error>." );
+    #endif
+        // Copia a matriz
+        TVar * src = A.fElem;
+        TVar * p = fElem;
+        memcpy((void *)(p),(void *)(src),(size_t)size*sizeof(TVar));
+    }
+    else{
+        fElem = A.fElem;
+        fGiven = A.fGiven;
+        fSize = A.fSize;
+        fPivot = A.fPivot;
+        fWork = A.fWork;
+        A.fElem=nullptr;
+        A.fGiven=nullptr;
+        A.fSize=0;
+    }
+    
 }
 
 /********************************/

--- a/Matrix/pzfmatrix.h
+++ b/Matrix/pzfmatrix.h
@@ -196,6 +196,9 @@ public:
      * @param destination Destine index on current matrix
      */
     void AddFel(TPZFMatrix<TVar> &rhs,TPZVec<int64_t> &source, TPZVec<int64_t> &destination);
+
+    ///Idem AddFel, but uses Non Atomic sum
+    void AddFelNonAtomic(TPZFMatrix<TVar> &rhs,TPZVec<int64_t> &source, TPZVec<int64_t> &destination);
     
     
     /**

--- a/Matrix/pzmatred.cpp
+++ b/Matrix/pzmatred.cpp
@@ -167,6 +167,9 @@ TPZMatRed<TVar, TSideMatrix>::SetK00(TPZAutoPointer<TPZMatrix<TVar> > K00)
 template<class TVar, class TSideMatrix>
 void TPZMatRed<TVar,TSideMatrix>::SetF(const TPZFMatrix<TVar> & F)
 {
+    if(F.Rows() != fDim0+fDim1){
+        DebugStop();
+    }
 	
 	int64_t FCols=F.Cols(),c,r,r1;
 	

--- a/Matrix/pzmatred.h
+++ b/Matrix/pzmatred.h
@@ -89,6 +89,12 @@ public:
 		fIsReduced = 1;
 	}
 	
+    void ResetReduced()
+    {
+        TPZMatrix<TVar>::Resize(fDim0+fDim1, fDim0+fDim1);
+        fIsReduced = 0;
+    }
+    
     void ReallocSolver() {
         fSolver->ReallocMatrix();
     }

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -378,6 +378,13 @@ public:
 	 */
 	virtual  void AddKel(TPZFMatrix<TVar>&elmat, TPZVec<int64_t> &sourceindex,  TPZVec<int64_t> &destinationindex);
 
+    /**
+     * @brief Similar to Addkel, but uses atomic add instead of regular sum
+     */
+    virtual  void AddKelAtomic(TPZFMatrix<TVar>&elmat, TPZVec<int64_t> &sourceindex,  TPZVec<int64_t> &destinationindex){
+        DebugStop();
+    };
+
 	/**
 	 * @name Inquire
 	 * @brief Returns information of the current object

--- a/Matrix/pzsbndmat.cpp
+++ b/Matrix/pzsbndmat.cpp
@@ -682,7 +682,10 @@ TPZSBMatrix<TVar>::Decompose_LDLt()
             }
         }
         
-        if ( IsZero(GetVal(j,j)) )this->Error(__PRETTY_FUNCTION__, "Decompose_LDLt <Zero on diagonal>" );
+        if ( IsZero(GetVal(j,j)) )
+        {
+            this->Error(__PRETTY_FUNCTION__, "Decompose_LDLt <Zero on diagonal>" );
+        }
         end  = MIN( int64_t(j + fBand )+1, this->Dim() );
         //cout<<"end="<<end<<"\n";
         for( l=j+1; l<end;l++)

--- a/Matrix/pzsysmp.h
+++ b/Matrix/pzsysmp.h
@@ -110,6 +110,8 @@ public :
     virtual void AddKel(TPZFMatrix<TVar> & elmat, TPZVec<int64_t> & destinationindex) override;
 	
 	virtual void AddKel(TPZFMatrix<TVar> & elmat, TPZVec<int64_t> & sourceindex, TPZVec<int64_t> & destinationindex) override;
+
+    void AddKelAtomic(TPZFMatrix<TVar>&elmat, TPZVec<int64_t> &sourceindex,  TPZVec<int64_t> &destinationindex) override;
     /// Access function for the coefficients
     TPZVec<TVar> &A()
     {

--- a/Mesh/TPZCompElH1.cpp
+++ b/Mesh/TPZCompElH1.cpp
@@ -107,7 +107,7 @@ void TPZCompElH1<TSHAPE>::InitMaterialData(TPZMaterialData &data){
     TPZManVector<int,TSHAPE::NSides> orders(TSHAPE::NSides-TSHAPE::NCornerNodes);
     TPZManVector<int,TSHAPE::NFacets> sideorient(TSHAPE::NFacets,0);
     TPZGeoEl *gel = this->Reference();
-    for(int i=0; i<TSHAPE::NCornerNodes; i++) ids[i] = gel->NodeIndex(i);
+    for(int i=0; i<TSHAPE::NCornerNodes; i++) ids[i] = gel->Node(i).Id();
     for(int i=TSHAPE::NCornerNodes; i<TSHAPE::NSides; i++) orders[i-TSHAPE::NCornerNodes] = this->Connect(i).Order();
     TPZShapeData &shapedata = data;
     TPZShapeH1<TSHAPE>::Initialize(ids, orders, shapedata);

--- a/Mesh/TPZCompElHDivCollapsed.cpp
+++ b/Mesh/TPZCompElHDivCollapsed.cpp
@@ -286,7 +286,7 @@ void TPZCompElHDivCollapsed<TSHAPE>::InitMaterialDataT(TPZMaterialDataT<TVar> &d
     // Node ids of geoel
     TPZGeoEl *gel = this->Reference();
     TPZManVector<int64_t,TSHAPE::NCornerNodes> ids(TSHAPE::NCornerNodes);
-    for(int i=0; i<TSHAPE::NCornerNodes; i++) ids[i] = gel->NodeIndex(i);
+    for(int i=0; i<TSHAPE::NCornerNodes; i++) ids[i] = gel->Node(i).Id();
     
     // Init shape data
     TPZShapeHDivCollapsed<TSHAPE>::Initialize(ids, connectorders, sideorient, shapedata);

--- a/Mesh/TPZCompElKernelHDiv.cpp
+++ b/Mesh/TPZCompElKernelHDiv.cpp
@@ -60,7 +60,7 @@ void TPZCompElKernelHDiv<TSHAPE>::InitMaterialData(TPZMaterialData &data)
     TPZManVector<int,TSHAPE::NSides> orders(TSHAPE::NSides-TSHAPE::NCornerNodes);
     TPZManVector<int,TSHAPE::NFacets> sideorient(TSHAPE::NFacets,0);
     TPZGeoEl *gel = this->Reference();
-    for(int i=0; i<TSHAPE::NCornerNodes; i++) ids[i] = gel->NodeIndex(i);
+    for(int i=0; i<TSHAPE::NCornerNodes; i++) ids[i] = gel->Node(i).Id();
     for(int i=TSHAPE::NCornerNodes; i<TSHAPE::NSides; i++) orders[i-TSHAPE::NCornerNodes] = this->Connect(i).Order()+1;
     if (TSHAPE::Type() == ETriangle){
         orders[TSHAPE::NSides-TSHAPE::NCornerNodes-1]++;

--- a/Mesh/TPZMultiphysicsInterfaceEl.cpp
+++ b/Mesh/TPZMultiphysicsInterfaceEl.cpp
@@ -512,6 +512,16 @@ void TPZMultiphysicsInterfaceElement::CalcStiffT(TPZElementMatrixT<TVar> &ef)
     
 }//CalcStiff
 
+template
+void TPZMultiphysicsInterfaceElement::CalcStiffT<STATE>(TPZElementMatrixT<STATE> &ek,
+                                                 TPZElementMatrixT<STATE> &ef);
+
+template
+void TPZMultiphysicsInterfaceElement::CalcStiffT<STATE>(TPZElementMatrixT<STATE> &ef);
+
+
+
+
 const TPZIntPoints & TPZMultiphysicsInterfaceElement::GetIntegrationRule() const
 {
     if (!fIntegrationRule) {
@@ -830,6 +840,12 @@ void TPZMultiphysicsInterfaceElement::ComputeRequiredDataT(TPZMaterialDataT<TVar
 
 }
 
+template
+void TPZMultiphysicsInterfaceElement::ComputeRequiredDataT<STATE>(TPZMaterialDataT<STATE> &data, TPZVec<STATE> &point);
+
+template
+void TPZMultiphysicsInterfaceElement::ComputeRequiredDataT<CSTATE>(TPZMaterialDataT<CSTATE> &data, TPZVec<REAL> &point);
+
 void TPZMultiphysicsInterfaceElement::CreateGraphicalElement(TPZGraphMesh &grmesh, int dimension)
 {
 	TPZGeoEl *ref = Reference();
@@ -943,6 +959,12 @@ void TPZMultiphysicsInterfaceElement::SolutionT(TPZVec<REAL> &qsi, int var,TPZVe
 		
 	matInterface->SolutionInterface(data,datavecleft,datavecright,var, sol,LeftSide.Element(),RightSide.Element());
 }
+
+template
+void TPZMultiphysicsInterfaceElement::SolutionT<STATE>(TPZVec<REAL> &qsi, int var,TPZVec<STATE> &sol);
+template
+void TPZMultiphysicsInterfaceElement::SolutionT<CSTATE>(TPZVec<REAL> &qsi, int var,TPZVec<CSTATE> &sol);
+
 
 void TPZMultiphysicsInterfaceElement::ComputeSideTransform(TPZCompElSide &Neighbor, TPZTransform<> &transf){
 	TPZGeoEl * neighel = Neighbor.Element()->Reference();

--- a/Mesh/TPZMultiphysicsInterfaceEl.h
+++ b/Mesh/TPZMultiphysicsInterfaceEl.h
@@ -170,15 +170,14 @@ public:
      * Compute the stiffness matrix and load vector of the interface element
      */
     void CalcStiff(TPZElementMatrixT<STATE> &ek,
-                   TPZElementMatrixT<STATE> &ef) override
-    {
+                   TPZElementMatrixT<STATE> &ef) override {
         CalcStiffT(ek,ef);
     }
     
     /**
      * Compute the load vector of the interface element
      */
-    void CalcStiff(TPZElementMatrixT<STATE> &ef){
+    void CalcStiff(TPZElementMatrixT<STATE> &ef) {
         CalcStiffT(ef);
     }
 

--- a/Mesh/TPZSBFemMultiphysicsElGroup.cpp
+++ b/Mesh/TPZSBFemMultiphysicsElGroup.cpp
@@ -514,12 +514,6 @@ void TPZSBFemMultiphysicsElGroup::InitializeElementMatrix(TPZElementMatrixT<STAT
 		(ef.fConnect)[i] = ConnectIndex(i);
 		(ek.fConnect)[i] = ConnectIndex(i);
 	}
-    std::map<int64_t,TPZOneShapeRestraint>::const_iterator it;
-    for (it = fRestraints.begin(); it != fRestraints.end(); it++) 
-    {
-        ef.fOneRestraints.push_back(it->second);
-        ek.fOneRestraints.push_back(it->second);
-    }
 }//void
 
 void TPZSBFemMultiphysicsElGroup::LoadSolution()

--- a/Mesh/pzcmesh.cpp
+++ b/Mesh/pzcmesh.cpp
@@ -2771,7 +2771,8 @@ void TPZCompMesh::SaddlePermute2()
 void TPZCompMesh::GetEquationSetByMat(std::set<int64_t>& matidset, std::set<int64_t>& eqset) {
     
     if (!matidset.size()) {
-        DebugStop();
+        std::cout << "\nNo materials provided to TPZCompMesh::GetEquationSetByMat(). Returning..." << std::endl;
+        return;
     }
     
     for (TPZCompEl* cel : this->ElementVec()) {
@@ -2787,20 +2788,27 @@ void TPZCompMesh::GetEquationSetByMat(std::set<int64_t>& matidset, std::set<int6
         for(int ic = 0 ; ic < ncon ; ic++){
             TPZConnect& con = cel->Connect(ic);
 //            if(con.HasDependency() || con.IsCondensed()) continue; //CHECAR COM PHIL
-            const int64_t seqnum = con.SequenceNumber();
-            if(seqnum < 0) DebugStop();
-            const int64_t firsteq = this->Block().Position(seqnum);
-            const int64_t blocksize = this->Block().Size(seqnum);
-            for (int i = 0; i < blocksize; i++) {
-                eqset.insert(firsteq+i);
-            }
+            AddConnectEquationsToSet(con, eqset);
         }
     }
     
+#ifdef PZDEBUG
     if(!eqset.size()){
-        std::cout << "\n\n\t===> Warning! TPZCompMesh::GetEquationSetByMat() did not find any equations for the material set provided" << std::endl;
+        std::cout << "\n\n\t===> Warning! TPZCompMesh::GetEquationSetByMat() did not find any equations for the material set provided | ";
         std::cout << "matidset = ";
         for(auto const& id : matidset) std::cout << id << " ";
+        std::cout << std::endl;
+    }
+#endif
+}
+
+void TPZCompMesh::AddConnectEquationsToSet(TPZConnect& con, std::set<int64_t>& eqset){
+    const int64_t seqnum = con.SequenceNumber();
+    if(seqnum < 0) DebugStop();
+    const int64_t firsteq = this->Block().Position(seqnum);
+    const int64_t blocksize = this->Block().Size(seqnum);
+    for (int i = 0; i < blocksize; i++) {
+        eqset.insert(firsteq+i);
     }
 }
 

--- a/Mesh/pzcmesh.cpp
+++ b/Mesh/pzcmesh.cpp
@@ -2791,7 +2791,6 @@ void TPZCompMesh::GetEquationSetByMat(std::set<int64_t>& matidset, std::set<int6
             if(seqnum < 0) DebugStop();
             const int64_t firsteq = this->Block().Position(seqnum);
             const int64_t blocksize = this->Block().Size(seqnum);
-            const int64_t lasteq = firsteq + blocksize;
             for (int i = 0; i < blocksize; i++) {
                 eqset.insert(firsteq+i);
             }

--- a/Mesh/pzcmesh.cpp
+++ b/Mesh/pzcmesh.cpp
@@ -2785,7 +2785,7 @@ void TPZCompMesh::GetEquationSetByMat(std::set<int64_t>& matidset, std::set<int6
         
         const int ncon = cel->NConnects();
         for(int ic = 0 ; ic < ncon ; ic++){
-            TPZConnect& con = cel->Connect(0);
+            TPZConnect& con = cel->Connect(ic);
 //            if(con.HasDependency() || con.IsCondensed()) continue; //CHECAR COM PHIL
             const int64_t seqnum = con.SequenceNumber();
             if(seqnum < 0) DebugStop();

--- a/Mesh/pzcmesh.h
+++ b/Mesh/pzcmesh.h
@@ -591,6 +591,12 @@ public:
 	/** @brief Will build the list of element boundary conditions build the list of connect boundary conditions. */
 	/** Put material pointers into the elements. Check on the number of dof of the connects */
 	int Consolidate();
+    
+    
+    /// Returns all the equatios associated to the materials in matidset
+    /// @param mat set with matids to search for their equations
+    /// @param eqset set of equations associated with the materials in matidset (set holdss unique values)
+    void GetEquationSetByMat(std::set<int64_t>& matidset, std::set<int64_t>& eqset);
 	
 	/**
 	 * ??

--- a/Mesh/pzcmesh.h
+++ b/Mesh/pzcmesh.h
@@ -597,6 +597,12 @@ public:
     /// @param mat set with matids to search for their equations
     /// @param eqset set of equations associated with the materials in matidset (set holdss unique values)
     void GetEquationSetByMat(std::set<int64_t>& matidset, std::set<int64_t>& eqset);
+    
+    
+    /// Adds the equations related to connect con to the set eqset
+    /// @param con connect with equations to be added
+    /// @param eqset set with equations
+    void AddConnectEquationsToSet(TPZConnect& con, std::set<int64_t>& eqset);
 	
 	/**
 	 * ??

--- a/Mesh/pzcondensedcompel.cpp
+++ b/Mesh/pzcondensedcompel.cpp
@@ -461,7 +461,8 @@ void TPZCondensedCompEl::CalcStiffInternal(TPZElementMatrixT<TVar> &ekglob,TPZEl
     {
         REAL normk01 = Norm(fCondensed.K01());
         REAL normf0 = Norm(fCondensed.F0());
-        if(std::isnan(normk01) || std::isnan(normf0))
+        REAL normK11 = Norm(K11);
+        if(std::isnan(normk01) || std::isnan(normf0) || std::isnan(normK11))
         {
             Print();
             DebugStop();

--- a/Mesh/pzconnect.cpp
+++ b/Mesh/pzconnect.cpp
@@ -78,13 +78,13 @@ void TPZConnect::Print(const TPZCompMesh &mesh, std::ostream & out) {
       const TPZFMatrix<STATE> &meshSol = mesh.Solution();
       for(auto ieq=0; ieq< mesh.Block().Size(fSequenceNumber); ieq++)
         {
-          out << meshSol.at(mesh.Block().at(fSequenceNumber,0,ieq,0)) << ' ';
+            out << meshSol.at({mesh.Block().Index(fSequenceNumber,ieq),0}) << ' ';
         }
     }else{
       const TPZFMatrix<CSTATE> &meshSol = mesh.Solution();
       for(auto ieq=0; ieq< mesh.Block().Size(fSequenceNumber); ieq++)
         {
-          out << meshSol.at(mesh.Block().at(fSequenceNumber,0,ieq,0)) << ' ';
+            out << meshSol.at({mesh.Block().Index(fSequenceNumber,ieq),0}) << ' ';
         }
     }
 	}

--- a/Mesh/pzelementgroup.cpp
+++ b/Mesh/pzelementgroup.cpp
@@ -66,11 +66,6 @@ void TPZElementGroup::AddElement(TPZCompEl *cel)
     }
     int64_t elindex = cel->Index();
     Mesh()->ElementVec()[elindex] = 0;
-    std::list<TPZOneShapeRestraint> ellist = cel->GetShapeRestraints();
-    for (std::list<TPZOneShapeRestraint>::iterator it=ellist.begin(); it != ellist.end(); it++) {
-        int64_t cindex = it->fFaces[0].first;
-        fRestraints[cindex] = *it;
-    }
 #ifdef PZ_LOG2
     if (logger.isDebugEnabled())
     {
@@ -139,10 +134,11 @@ void TPZElementGroup::ReorderConnects()
     for(int ic=0; ic<nc; ic++) fConnectIndexes[ic] = orderedindexes[ic].second;
 }
 
-void TPZElementGroup::ReorderConnects(TPZManVector<int64_t> &connects)
+void TPZElementGroup::ReorderConnects(TPZVec<int64_t> &connects)
 {
     int64_t nc = connects.size();
 
+    if(nc > fConnectIndexes.size()) fConnectIndexes.Resize(nc, -1);
     // TPZManVector<std::pair<int,int64_t>, 100 > orderedindexes(connects.size());
     for (int ic=0; ic<nc; ic++)
     {
@@ -181,11 +177,6 @@ void TPZElementGroup::InitializeElementMatrix(TPZElementMatrix &ek, TPZElementMa
     ek.Matrix().Redim(rows, rows);
     ek.fType = TPZElementMatrix::EK;
     InitializeElementMatrix(ef);
-    std::map<int64_t,TPZOneShapeRestraint>::const_iterator it;
-    for (it = fRestraints.begin(); it != fRestraints.end(); it++) {
-        ek.fOneRestraints.push_back(it->second);
-        ef.fOneRestraints.push_back(it->second);
-    }
 }//void
 
 void TPZElementGroup::InitializeElementMatrix(TPZElementMatrix &ef) const {
@@ -206,10 +197,6 @@ void TPZElementGroup::InitializeElementMatrix(TPZElementMatrix &ef) const {
 	for(int i=0; i<ncon; i++){
 		(ef.fConnect)[i] = ConnectIndex(i);
 	}
-    std::map<int64_t,TPZOneShapeRestraint>::const_iterator it;
-    for (it = fRestraints.begin(); it != fRestraints.end(); it++) {
-        ef.fOneRestraints.push_back(it->second);
-    }
 }//void
 
 

--- a/Mesh/pzelementgroup.h
+++ b/Mesh/pzelementgroup.h
@@ -23,7 +23,6 @@ class TPZElementGroup : public TPZCompEl
 protected:
     TPZStack<TPZCompEl *,10> fElGroup;
     TPZManVector<int64_t,27> fConnectIndexes;
-    std::map<int64_t,TPZOneShapeRestraint> fRestraints;
 
 public:
     
@@ -88,7 +87,7 @@ public:
     /// Reorder the connects in increasing number of elements connected
     void ReorderConnects();
 
-    void ReorderConnects(TPZManVector<int64_t> &connects);
+    void ReorderConnects(TPZVec<int64_t> &connects);
     
     const TPZVec<TPZCompEl *> &GetElGroup(){
         return fElGroup;

--- a/Post/TPZVTKGenerator.cpp
+++ b/Post/TPZVTKGenerator.cpp
@@ -616,28 +616,16 @@ void TPZVTKGenerator::Do(REAL time)
   std::vector<int> datalength;
   int offs = 0;
   // create name of the current .vtk file
-  filenamefinal << fFilename;
-  filenamefinal << "_step" << std::setw(5) << std::setfill('0')
-                  << fOutputCount;
+  filenamefinal << fFilename << '.';
+  if(fStep > -1){
+    filenamefinal << fStep;
+  }else{
+    filenamefinal << fOutputCount;
+  }
 
   fLastOutputName = filenamefinal.str();
 
   filenamefinal << ".vtk";
-  
-  if (fOutputCount > 0) {
-    // cout << IM(4) << " ( " << fOutputCount << " )";
-    const auto currt = fTimes.size();
-    fTimes.resize(currt + 1);
-    if (time == -1) {
-      AppendToVec(fTimes, fOutputCount);
-    } else {
-      AppendToVec(fTimes, time);
-    }
-  } else {
-    if (time != -1) {
-      fTimes[0] = time;
-    }
-  }
 
   fFileout = new std::ofstream(filenamefinal.str());
 

--- a/Post/TPZVTKGenerator.cpp
+++ b/Post/TPZVTKGenerator.cpp
@@ -264,7 +264,7 @@ void TPZVTKGenerator::FillRefEls()
 
      The points are computed only for elements of correct dimension.
    */
-  TPZSimpleTimer timer("FillRefEls",true);
+  TPZSimpleTimer timer("FillRefEls");
   
   TPZManVector<TPZManVector<MElementType,3>,4> eltypes{
     {},
@@ -474,7 +474,7 @@ void TPZVTKGenerator::FillReferenceEl(TPZVec<TPZManVector<REAL,3>> &ref_coords,
 void TPZVTKGenerator::PrintPointsLegacy()
 {
   /*print all post-processing nodes in legacy .VTK format*/
-  TPZSimpleTimer timer("PrintPts",true);
+  TPZSimpleTimer timer("PrintPts");
   
   (*fFileout) << "POINTS " << fPoints.size() << " float" << std::endl;
   for(const auto &p : fPoints){
@@ -489,7 +489,7 @@ void TPZVTKGenerator::PrintPointsLegacy()
 void TPZVTKGenerator::PrintCellsLegacy()
 {
   /*print all resulting post-processing cells in legacy .VTK format*/
-  TPZSimpleTimer timer("PrintCells",true);
+  TPZSimpleTimer timer("PrintCells");
   
   // count number of data for cells, one + number of vertices
   int ndata = 0;
@@ -511,7 +511,7 @@ void TPZVTKGenerator::PrintCellsLegacy()
 void TPZVTKGenerator::PrintCellTypesLegacy()
 {
   /*print all cell type info in legacy .VTK format*/
-  TPZSimpleTimer timer("PrintCellTypes",true);
+  TPZSimpleTimer timer("PrintCellTypes");
   
   *fFileout << "CELL_TYPES " << fCells.size() << std::endl;
 
@@ -526,7 +526,7 @@ void TPZVTKGenerator::PrintCellTypesLegacy()
 void TPZVTKGenerator::PrintFieldDataLegacy()
 {
   /*print all post-processed quantities in legacy .VTK format*/
-  TPZSimpleTimer timer("PrintField",true);
+  TPZSimpleTimer timer("PrintField");
   
   for (auto field : fFields){
     *fFileout << field->TypeName() <<' ' << field->Name()
@@ -609,7 +609,7 @@ void TPZVTKGenerator::Do(REAL time)
     NOTE: if the mesh has changed (i.e., geometric refinement), 
     ResetArrays() must be called.
 */
-  TPZSimpleTimer timer("Do",true);
+  TPZSimpleTimer timer("Do");
 
   std::ostringstream filenamefinal;
   std::stringstream appended;

--- a/Post/TPZVTKGenerator.h
+++ b/Post/TPZVTKGenerator.h
@@ -116,8 +116,8 @@ protected:
   TPZVec<std::array<int,TPZVTK::MAX_PTS+2>> fCells;//max 
   //! Used for exporting .VTK series (time-steps, different modes, etc)
   int fOutputCount = 0;
-  //! Used for associating each .VTK file with a given time value
-  TPZVec<REAL> fTimes = {0};
+  //! Used for manually setting the step value (fOutputCount is ignored if fStep>0)
+  int fStep = -1;
   //! Current file in which .VTK data will be written
   TPZAutoPointer<std::ofstream> fFileout{nullptr};
   //! Name (no extension) of last output file
@@ -223,7 +223,11 @@ public:
     if(nt > -1 ){fNThreads = nt;}
   }
   //! Get number of threads to compute fields (0 for serial)
-  int NThreads() const {return fNThreads;} 
+  int NThreads() const {return fNThreads;}
+  //! Sets manually the step of next post-processing round (must be >0)
+  void SetStep(int st){fStep = st;}
+  //! Gets the current step of next post-rpocessing round (if <0, fOutputCount is used)
+  int Step() const {return fStep;}
 };
 
 #endif /* _TPZVTKGENERATOR_H_ */

--- a/Post/TPZVTKGeoMesh.cpp
+++ b/Post/TPZVTKGeoMesh.cpp
@@ -1098,7 +1098,7 @@ void TPZVTKGeoMesh::PrintGMeshVTK(TPZGeoMesh * gmesh, std::set<int64_t> & elInde
     file.clear();
     int64_t nelements = gmesh->NElements();
 
-    std::stringstream node, connectivity, type, material;
+    std::stringstream node, connectivity, type, elementindex, material, geldim;
 
     //Header
     file << "# vtk DataFile Version 3.0" << std::endl;
@@ -1144,7 +1144,11 @@ void TPZVTKGeoMesh::PrintGMeshVTK(TPZGeoMesh * gmesh, std::set<int64_t> & elInde
         int elType = TPZVTKGeoMesh::GetVTK_ElType(gmesh->ElementVec()[el]);
         type << elType << std::endl;
 
-        material << el << std::endl;
+        elementindex << el << std::endl;
+        
+        material << gel->MaterialId() << std::endl;
+        
+        geldim << gel->Dimension() << std::endl;
 
         nVALIDelements++;
     }
@@ -1161,11 +1165,19 @@ void TPZVTKGeoMesh::PrintGMeshVTK(TPZGeoMesh * gmesh, std::set<int64_t> & elInde
     file << type.str() << std::endl;
 
     file << "CELL_DATA" << " " << nVALIDelements << std::endl;
-    file << "FIELD FieldData 1" << std::endl;
+    file << "FIELD FieldData 3" << std::endl;
 
     file << "elIndex 1 " << nVALIDelements << " int" << std::endl;
 
+    file << elementindex.str();
+
+    file << "material 1 " << nVALIDelements << " int" << std::endl;
+
     file << material.str();
+
+    file << "dimension 1 " << nVALIDelements << " int" << std::endl;
+
+    file << geldim.str();
 
     file.close();
 }

--- a/Pre/TPZAnalyticSolution.cpp
+++ b/Pre/TPZAnalyticSolution.cpp
@@ -1331,6 +1331,23 @@ void TLaplaceExample1::uxy(const TPZVec<TVar> &x, TPZVec<TVar> &disp) const
             disp[0] = B*temp;
         }
             break;
+
+        case ESteepWave:
+        {
+            TPZManVector<TVar,3> x0;
+            x0.resize(fDimension);
+            TVar r2Circle = TVar(0);
+            TVar r0 = TVar(0.7);
+            TVar alpha = TVar(100);
+
+            for (int i=0; i<fDimension; i++) {
+                x0[i] = TVar(-0.05);
+                r2Circle += (xloc[i]-x0[i])*(xloc[i]-x0[i]);
+            }
+            TVar rCircle = sqrt(r2Circle);
+            disp[0] = atan(alpha*(rCircle-r0));
+        }
+            break;
             
             //----
         case ESinMark://(r^(2/3)-r^2)sin(20/3) para homogeneo dirichlet e r^(2/3)sin(20/3) para f=0
@@ -1653,6 +1670,24 @@ void TLaplaceExample1::uxy(const TPZVec<FADFADSTATE > &x, TPZVec<FADFADSTATE > &
             disp[0] = B*temp;
         }
             break;
+
+        case ESteepWave:
+        {
+            TPZManVector<TVar,3> x0;
+            x0.resize(fDimension);
+            TVar r2Circle = TVar(0);
+            TVar r0 = TVar(0.7);
+            TVar alpha = TVar(100);
+
+            for (int i=0; i<fDimension; i++) {
+                x0[i] = TVar(-0.05);
+                r2Circle += (xloc[i]-x0[i])*(xloc[i]-x0[i]);
+            }
+            TVar rCircle = FADsqrt(r2Circle);
+            disp[0] = FADatan(alpha*(rCircle-r0));
+        }
+            break;
+
         case ESinSinDirNonHom: //sin(2pi x)sin(2pi y)+1/(x+y+1)
         {
             

--- a/Pre/TPZAnalyticSolution.h
+++ b/Pre/TPZAnalyticSolution.h
@@ -332,7 +332,7 @@ struct TElasticity3DAnalytic : public TPZAnalyticSolution
 struct TLaplaceExample1 : public TPZAnalyticSolution
 {
     
-    enum EExactSol {ENone, EConst, EX, ESinSin, ECosCos,  EArcTan, EArcTanSingular,ESinDist, E10SinSin,E2SinSin, ESinSinDirNonHom,ESinMark,ESteklovNonConst,EGalvisNonConst,EBoundaryLayer,EBubble, EBubble2D,ESinCosCircle, EHarmonic, EHarmonic2,
+    enum EExactSol {ENone, EConst, EX, ESinSin, ECosCos,  EArcTan, EArcTanSingular, ESteepWave, ESinDist, E10SinSin,E2SinSin, ESinSinDirNonHom,ESinMark,ESteklovNonConst,EGalvisNonConst,EBoundaryLayer,EBubble, EBubble2D,ESinCosCircle, EHarmonic, EHarmonic2,
     ESquareRootUpper, ESquareRootLower, ESquareRoot, ELaplace2D, EHarmonic3, EHarmonicPoly};
     
     int fDimension = 2;

--- a/Pre/TPZMHMeshControl.h
+++ b/Pre/TPZMHMeshControl.h
@@ -308,7 +308,7 @@ public:
         return result;
     }
 
-    TPZManVector<int64_t> GetGeoToMHMDomain() {
+    TPZVec<int64_t> &GetGeoToMHMDomain() {
         return fGeoToMHMDomain;
     }
 

--- a/Pre/TPZMHMixedMeshChannelControl.cpp
+++ b/Pre/TPZMHMixedMeshChannelControl.cpp
@@ -86,7 +86,7 @@ void TPZMHMixedMeshChannelControl::BuildComputationalMesh(bool usersubstructure,
                 if(!intel) DebugStop();
                 int64_t cindex = intel->SideConnectIndex(0, gelside.Side());
                 int locindex = intel->SideConnectLocId(0, gelside.Side());
-                if(cindex == cto_index) {
+                if(cindex == cto_index || matid == fSkeletonMatId) {
                     intel->SetConnectIndex(locindex, cfrom_index);
                 } else if(cindex != cfrom_index) {
                     DebugStop();

--- a/Solvers/EigenSolvers/TPZLapackEigenSolver.cpp
+++ b/Solvers/EigenSolvers/TPZLapackEigenSolver.cpp
@@ -462,7 +462,7 @@ int TPZLapackEigenSolver<TVar>::SolveGeneralisedEigenProblem(
 
     for(int i = 0 ; i < dim ; i ++){
       if( IsZero(beta[i])){
-        DebugStop(); //fran: i really dont know what to do with this result
+//        DebugStop(); //fran: i really dont know what to do with this result
       }
       else{
         eigenValues[i] = (realeigen[i] + (CTVar)1i*imageigen[i]) / beta[i];

--- a/Solvers/TPZPardisoSolver.cpp
+++ b/Solvers/TPZPardisoSolver.cpp
@@ -14,7 +14,6 @@
 
 
 #ifdef USING_MKL
-
 #include "mkl_pardiso.h"
 #else
 #define NOMKL                                                   \

--- a/StrMatrix/CMakeLists.txt
+++ b/StrMatrix/CMakeLists.txt
@@ -13,6 +13,7 @@ set(public_headers
     pzstrmatrixor.h
     pzstrmatrixot.h
     pzstrmatrixflowtbb.h
+    TPZStructMatrixOMPorTBB.h
     #matrix storage format
     #full
     pzfstrmatrix.h
@@ -44,6 +45,7 @@ set(headers
     pzstrmatrixor.h
     pzstrmatrixot.h
     pzstrmatrixflowtbb.h
+    TPZStructMatrixOMPorTBB.cpp
     #matrix storage format
     #full
     pzfstrmatrix.h

--- a/StrMatrix/TPZEquationFilter.h
+++ b/StrMatrix/TPZEquationFilter.h
@@ -71,6 +71,22 @@ public:
       this->SetActiveEquations( activeEquations );
     }
 
+    void ExcludeEquations(std::set<int64_t> &filteredeq)
+    {
+        // Activating filter
+        fIsActive = true;
+        
+        // Create set with all the equations of the problemn
+        std::set<int64_t> alleqset;
+        int i = 0;
+        std::generate_n(std::inserter(alleqset, alleqset.begin()), fNumEq, [&i](){ return i++; }); // alleqset = 1,2,3,4,...,fNumEq-1
+        
+        // Removed the filtered equations from alleqset and put on set activeset
+        std::set<int64_t> activeset;
+        std::set_difference(alleqset.begin(), alleqset.end(), filteredeq.begin(), filteredeq.end(), std::inserter(activeset,activeset.begin()));
+        BuildActEqsAndDestIndDataStructure(activeset);
+    }
+    
     ///Define as equacoes ativas
     void SetActiveEquations(TPZVec<int64_t> &active)
     {
@@ -83,14 +99,18 @@ public:
         if (neq) {
             activeset.insert(&active[0], &active[neq-1]+1);
         }
-#ifdef PZDEBUG       
+        BuildActEqsAndDestIndDataStructure(activeset);
+    }
+    
+    void BuildActEqsAndDestIndDataStructure(std::set<int64_t>& activeset) {
+#ifdef PZDEBUG
         if (activeset.size() > fNumEq){
-            std::cout << "active set with size = " << activeset.size() << 
+            std::cout << "active set with size = " << activeset.size() <<
                          " should be greater than the number of equations " << fNumEq << std::endl;
             DebugStop();
         }
         if (*activeset.rbegin() > fNumEq){
-            std::cout << "active set rbegin = " << *activeset.rbegin() << 
+            std::cout << "active set rbegin = " << *activeset.rbegin() <<
                          " cannot be greater than the number of equations " << fNumEq << std::endl;
             DebugStop();
         }

--- a/StrMatrix/TPZSSpStructMatrix.cpp
+++ b/StrMatrix/TPZSSpStructMatrix.cpp
@@ -213,11 +213,14 @@ void TPZSSpStructMatrix<TVar,TPar>::Write(TPZStream& buf, int withclassid) const
 
 #include "pzstrmatrixot.h"
 #include "pzstrmatrixflowtbb.h"
+#include "TPZStructMatrixOMPorTBB.h"
 
 template class TPZSSpStructMatrix<STATE,TPZStructMatrixOR<STATE>>;
 template class TPZSSpStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZSSpStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
+template class TPZSSpStructMatrix<STATE,TPZStructMatrixOMPorTBB<STATE>>;
 
 template class TPZSSpStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
 template class TPZSSpStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
 template class TPZSSpStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;
+template class TPZSSpStructMatrix<CSTATE,TPZStructMatrixOMPorTBB<CSTATE>>;

--- a/StrMatrix/TPZStructMatrixOMPorTBB.cpp
+++ b/StrMatrix/TPZStructMatrixOMPorTBB.cpp
@@ -1,0 +1,570 @@
+//
+// Created by victor on 29/08/2022.
+//
+
+#include "TPZStructMatrixOMPorTBB.h"
+/**
+ * @file
+ * @brief Contains the implementation of the TPZStructMatrixOMPorTBB methods.
+ */
+
+#include "pzvec.h"
+#include "pzfmatrix.h"
+#include "pzmanvector.h"
+#include "pzadmchunk.h"
+#include "pzcmesh.h"
+#include "pzgmesh.h"
+#include "pzelmat.h"
+#include "pzcompel.h"
+#include "pzintel.h"
+#include "pzsubcmesh.h"
+#include "TPZLinearAnalysis.h"
+#include "pzsfulmat.h"
+#include "TPZParallelUtils.h"
+#include "pzgnode.h"
+#include "TPZTimer.h"
+#include "TPZElementMatrixT.h"
+#include "pzsysmp.h"
+#include "TPZThreadPool.h"
+
+#ifdef USING_MKL
+#include "mkl.h"
+#endif
+
+#ifdef USING_TBB
+#include <tbb/parallel_for.h>
+
+#include <tbb/info.h>
+#include <tbb/task_arena.h>
+#include <tbb/global_control.h>
+#endif
+
+#ifdef USING_OMP
+#include "omp.h"
+#endif
+#include "pzcheckconsistency.h"
+#include "TPZMaterial.h"
+#include "TPZStrMatParInterface.h"
+
+using namespace std;
+
+#include "pzlog.h"
+
+#include "run_stats_table.h"
+#include <thread>
+
+#ifdef PZ_LOG
+static TPZLogger logger("pz.strmatrix.TPZStructMatrixOMPorTBB");
+static TPZLogger loggerel("pz.strmatrix.element");
+static TPZLogger loggerel2("pz.strmatrix.elementinterface");
+static TPZLogger loggerelmat("pz.strmatrix.elementmat");
+static TPZLogger loggerCheck("pz.strmatrix.checkconsistency");
+#endif
+
+#ifdef CHECKCONSISTENCY
+static TPZCheckConsistency stiffconsist("ElementStiff");
+#endif
+
+RunStatsTable stat_ass_graph_LCC("-ass_graph_ot", "Run statistics table for the graph creation and coloring TPZStructMatrixOMPorTBB.");
+
+template<class TVar>
+TPZStructMatrixOMPorTBB<TVar>::TPZStructMatrixOMPorTBB(): TPZStrMatParInterface()
+{
+this->SetNumThreads(TPZThreadPool::globalInstance().threadCount());
+}
+
+template<class TVar>
+TPZStructMatrixOMPorTBB<TVar>::TPZStructMatrixOMPorTBB(const TPZStructMatrixOMPorTBB &copy) : TPZStrMatParInterface(copy) {
+    fElSequenceColor = copy.fElSequenceColor;
+    fElBlocked = copy.fElBlocked;
+    fElementsComputed = copy.fElementsComputed;
+    fElementCompleted = copy.fElementCompleted;
+    fSomeoneIsSleeping = copy.fSomeoneIsSleeping;
+    fShouldColor = copy.fShouldColor;
+    fUsingTBB = copy.fUsingTBB;
+}
+
+
+static RunStatsTable ass_stiff("-ass_stiff", "Assemble Stiffness");
+static RunStatsTable ass_rhs("-ass_rhs", "Assemble Stiffness");
+
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::Assemble(TPZBaseMatrix & mat, TPZBaseMatrix & rhs, TPZAutoPointer<TPZGuiInterface> guiInterface) {
+#ifdef USING_MKL
+    mkl_domain_set_num_threads(1, MKL_DOMAIN_BLAS);
+    //mkl_set_num_threads_local(1);
+#endif
+    ass_stiff.start();
+
+    const auto &equationFilter =
+            (dynamic_cast<TPZStructMatrix *>(this))->EquationFilter();
+    ass_stiff.start();
+
+    if (equationFilter.IsActive()) {
+        int64_t neqcondense = equationFilter.NActiveEquations();
+#ifdef PZDEBUG
+        if (mat.Rows() != neqcondense) {
+            DebugStop();
+        }
+#endif
+        TPZFMatrix<STATE> rhsloc(neqcondense, rhs.Cols(), 0.);
+        if (this->fNumThreads) {
+            this->MultiThread_Assemble(mat, rhsloc, guiInterface);
+        } else {
+            this->Serial_Assemble(mat, rhsloc, guiInterface);
+        }
+
+        equationFilter.Scatter(rhsloc, rhs);
+    } else {
+        if (this->fNumThreads) {
+            this->MultiThread_Assemble(mat, rhs, guiInterface);
+        } else {
+            this->Serial_Assemble(mat, rhs, guiInterface);
+        }
+    }
+    ass_stiff.stop();
+#ifdef USING_MKL
+    mkl_set_num_threads_local(0);
+#endif
+}
+
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::Assemble(TPZBaseMatrix & rhs, TPZAutoPointer<TPZGuiInterface> guiInterface){
+    ass_rhs.start();
+    const auto &equationFilter =
+            (dynamic_cast<TPZStructMatrix *>(this))->EquationFilter();
+    if(equationFilter.IsActive())
+    {
+        int64_t neqcondense = equationFilter.NActiveEquations();
+        int64_t neqexpand = equationFilter.NEqExpand();
+
+        TPZFMatrix<TVar> &source = dynamic_cast<TPZFMatrix<TVar>&>(rhs);
+        if(rhs.Rows() != neqexpand || Norm(source) != 0.)
+        {
+            DebugStop();
+        }
+        TPZFMatrix<STATE> rhsloc(neqcondense,1,0.);
+        if(this->fNumThreads)
+        {
+#ifdef HUGEDEBUG
+            TPZFMatrix<STATE> rhsserial(rhsloc);
+            this->Serial_Assemble(rhsserial, guiInterface);
+#endif
+            this->MultiThread_Assemble(rhsloc,guiInterface);
+#ifdef HUGEDEBUG
+            rhsserial -= rhsloc;
+            REAL norm = Norm(rhsserial);
+            std::cout << "difference between serial and parallel " << norm << std::endl;
+#endif
+        }
+        else
+        {
+            this->Serial_Assemble(rhsloc,guiInterface);
+        }
+        equationFilter.Scatter(rhsloc,rhs);
+    }
+    else
+    {
+        if(this->fNumThreads){
+#ifdef HUGEDEBUG
+            TPZFMatrix<STATE> rhsserial(rhs);
+            this->Serial_Assemble(rhsserial, guiInterface);
+#endif
+            this->MultiThread_Assemble(rhs,guiInterface);
+#ifdef HUGEDEBUG
+            REAL normrhs = Norm(rhs);
+            REAL normrhsserial = Norm(rhsserial);
+            std::cout << "normrhs = " << normrhs << " normrhsserial " << normrhsserial << std::endl;
+            rhsserial -= rhs;
+            REAL norm = Norm(rhsserial);
+            std::cout << "difference between serial and parallel " << norm << std::endl;
+#endif
+        }
+        else{
+            this->Serial_Assemble(rhs,guiInterface);
+        }
+    }
+    ass_rhs.stop();
+}
+
+
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::Serial_Assemble(TPZBaseMatrix & mat, TPZBaseMatrix & rhs, TPZAutoPointer<TPZGuiInterface> guiInterface){
+    //mkl_set_num_threads_local(1);
+    //mkl_domain_set_num_threads(1, MKL_DOMAIN_BLAS);
+
+    auto *myself = dynamic_cast<TPZStructMatrix*>(this);
+    auto *cmesh = myself->Mesh();
+
+    TPZMatrix<TVar> &stiffness = dynamic_cast<TPZMatrix<TVar>&>(mat);
+    TPZFMatrix<TVar> &source = dynamic_cast<TPZFMatrix<TVar>&>(rhs);
+
+    const auto &equationFilter =
+            (dynamic_cast<TPZStructMatrix *>(this))->EquationFilter();
+
+    int64_t nelem = cmesh->NElements();
+    std::cout << "LCC_Serial_Assemble\n";
+    for (int64_t iel = 0; iel < nelem; iel++)
+    {
+        TPZCompEl *el = cmesh->Element(iel);
+        if (!el) continue;
+
+
+        TPZElementMatrixT<TVar> ek(cmesh, TPZElementMatrix::EK), ef(cmesh, TPZElementMatrix::EF);
+
+        el->CalcStiff(ek, ef);
+
+        if(!el->HasDependency()) {
+            ek.ComputeDestinationIndices();
+            equationFilter.Filter(ek.fSourceIndex, ek.fDestinationIndex);
+            //            TPZSFMatrix<STATE> test(stiffness);
+            //            TPZFMatrix<STATE> test2(stiffness.Rows(),stiffness.Cols(),0.);
+            //            stiffness.Print("before assembly",std::cout,EMathematicaInput);
+            stiffness.AddKel(ek.fMat,ek.fSourceIndex,ek.fDestinationIndex);
+            source.AddFel(ef.fMat,ek.fSourceIndex,ek.fDestinationIndex);
+            //            stiffness.Print("stiffness after assembly STK = ",std::cout,EMathematicaInput);
+            //            rhs.Print("rhs after assembly Rhs = ",std::cout,EMathematicaInput);
+            //            test2.AddKel(ek.fMat,ek.fSourceIndex,ek.fDestinationIndex);
+            //            test -= stiffness;
+            //            test.Print("matriz de rigidez diference",std::cout);
+            //            test2.Print("matriz de rigidez interface",std::cout);
+
+
+        } else {
+            // the element has dependent nodes
+            ek.ApplyConstraints();
+            ef.ApplyConstraints();
+            ek.ComputeDestinationIndices();
+            equationFilter.Filter(ek.fSourceIndex, ek.fDestinationIndex);
+
+            stiffness.AddKel(ek.fConstrMat,ek.fSourceIndex,ek.fDestinationIndex);
+            source.AddFel(ef.fConstrMat,ek.fSourceIndex,ek.fDestinationIndex);
+
+        }
+    }
+#ifdef PZDEBUG
+    VerifyStiffnessSum(mat);
+#endif
+#ifdef USING_MKL
+    mkl_set_num_threads_local(0);
+#endif
+}
+
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::VerifyStiffnessSum(TPZBaseMatrix & mat){
+
+    TPZMatrix<TVar> &stiffness = dynamic_cast<TPZMatrix<TVar>&>(mat);
+
+    REAL totalSum = 0;
+    for(int irow =0; irow < mat.Rows();irow++){
+        for (int icol = 0; icol < mat.Cols(); icol++)
+            totalSum += abs(stiffness.GetVal( irow, icol));
+    }
+    std::cout << "totalSum stisffnes =" << totalSum <<std::endl;
+}
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::Serial_Assemble(TPZBaseMatrix & rhs, TPZAutoPointer<TPZGuiInterface> guiInterface){
+
+
+}
+
+template<class TVar>
+int TPZStructMatrixOMPorTBB<TVar>::GetNumberColors(){
+    auto *myself = dynamic_cast<TPZStructMatrix*>(this);
+    auto *cmesh = myself->Mesh();
+    int64_t nelem = cmesh->NElements();
+    if (fElVecColor.size() != nelem) DebugStop();
+    int ncolor = -1;
+    for (int iel=0; iel<nelem; iel++){
+        if (ncolor < fElVecColor[iel])
+            ncolor = fElVecColor[iel];
+    }
+    ncolor++;
+    return ncolor;
+}
+
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::MultiThread_Assemble(TPZBaseMatrix & mat, TPZBaseMatrix & rhs, TPZAutoPointer<TPZGuiInterface> guiInterface){
+    //mkl_domain_set_num_threads(1, MKL_DOMAIN_BLAS);
+    //mkl_set_num_threads_local(1);
+    if (fShouldColor){
+        if (fUsingTBB){
+            AssemblingUsingTBBandColoring(mat,rhs);
+
+        }else{
+            AssemblingUsingOMPandColoring(mat,rhs);
+        }
+
+    }else{
+        if (fUsingTBB){
+            AssemblingUsingTBBbutNotColoring(mat,rhs);
+
+        }else{
+            AssemblingUsingOMPbutNotColoring(mat,rhs);
+        }
+    }
+
+#ifdef PZDEBUG
+    VerifyStiffnessSum(mat);
+#endif
+}
+
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::AssemblingUsingTBBandColoring(TPZBaseMatrix & mat, TPZBaseMatrix & rhs ){
+#ifndef USING_TBB
+    DebugStop();
+#endif
+#ifdef USING_TBB
+    auto *myself = dynamic_cast<TPZStructMatrix*>(this);
+    auto *cmesh = myself->Mesh();
+
+    int64_t nelem = cmesh->NElements();
+    const int nthread = this->fNumThreads;
+
+    TPZStructMatrixOMPorTBB::OrderElements();
+    int ncolor = GetNumberColors();
+
+    for (int icol=0; icol<ncolor; icol++){
+
+        //tbb::task_scheduler_init init(nthread); //dont work in computer of LABMEC
+        tbb::global_control global_limit(tbb::global_control::max_allowed_parallelism, nthread);
+        tbb::parallel_for( tbb::blocked_range<int64_t>(0,nelem),
+                          [&](tbb::blocked_range<int64_t> r){
+        for (int64_t iel = r.begin(); iel < r.end(); iel++)
+            {
+                if (icol != fElVecColor[iel]) continue;
+                TPZCompEl *el = cmesh->Element(iel);
+                if (!el) continue;
+
+                ComputingCalcstiffAndAssembling(mat,rhs,el);
+
+            }
+        });
+    }
+#endif
+}
+
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::AssemblingUsingOMPandColoring(TPZBaseMatrix & mat,TPZBaseMatrix & rhs ){
+#ifdef USING_OMP
+
+    auto *myself = dynamic_cast<TPZStructMatrix*>(this);
+    auto *cmesh = myself->Mesh();
+
+    int64_t nelem = cmesh->NElements();
+    const int nthread = this->fNumThreads;
+
+    TPZStructMatrixOMPorTBB::OrderElements();
+    int ncolor = GetNumberColors();
+
+    for (int icol=0; icol<ncolor; icol++){
+
+        omp_set_num_threads(nthread);
+        #pragma omp parallel for schedule(dynamic,1)
+        for (int64_t iel = 0; iel < nelem; iel++){
+        if (icol != fElVecColor[iel]) continue;
+        TPZCompEl *el = cmesh->Element(iel);
+        if (!el) continue;
+
+            ComputingCalcstiffAndAssembling(mat,rhs,el);
+
+        }
+    }
+#else
+    DebugStop();
+#endif
+}
+
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::AssemblingUsingTBBbutNotColoring(TPZBaseMatrix & mat, TPZBaseMatrix & rhs ){
+#ifdef USING_TBB
+    auto *myself = dynamic_cast<TPZStructMatrix*>(this);
+    auto *cmesh = myself->Mesh();
+    int64_t nelem = cmesh->NElements();
+    const int nthread = this->fNumThreads;
+
+
+        //tbb::task_scheduler_init init(nthread); //dont work in computer of LABMEC
+        tbb::global_control global_limit(tbb::global_control::max_allowed_parallelism, nthread);
+        tbb::parallel_for( tbb::blocked_range<int64_t>(0,nelem),
+                          [&](tbb::blocked_range<int64_t> r){
+        for (int64_t iel = r.begin(); iel < r.end(); iel++)
+        {
+            TPZCompEl *el = cmesh->Element(iel);
+            if (!el) continue;
+
+            ComputingCalcstiffAndAssembling(mat,rhs,el);
+
+        }
+        });
+#else
+    DebugStop();
+#endif
+
+}
+
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::AssemblingUsingOMPbutNotColoring(TPZBaseMatrix & mat, TPZBaseMatrix & rhs ){
+#ifdef USING_OMP
+
+    auto *myself = dynamic_cast<TPZStructMatrix*>(this);
+    auto *cmesh = myself->Mesh();
+
+    int64_t nelem = cmesh->NElements();
+    const int nthread = this->fNumThreads;
+
+    omp_set_num_threads(nthread);
+    omp_set_nested(true);
+    #pragma omp parallel for schedule(dynamic,1)
+    for (int64_t iel = 0; iel < nelem; iel++){
+        {
+            TPZCompEl *el = cmesh->Element(iel);
+            if (!el) continue;
+
+            ComputingCalcstiffAndAssembling(mat,rhs,el);
+        }
+    }
+#else
+    DebugStop();
+#endif
+}
+
+
+
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::MultiThread_Assemble(TPZBaseMatrix & rhs, TPZAutoPointer<TPZGuiInterface> guiInterface)
+{
+    std::cout <<"\n\n\nPlease implement TPZStructMatrixOMPorTBB::MultiThread_Assemble(TPZBaseMatrix & rhs, TPZAutoPointer<TPZGuiInterface> guiInterface)\n\n\n";
+    DebugStop();
+}
+
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::ComputingCalcstiffAndAssembling(TPZBaseMatrix & mat,TPZBaseMatrix & rhs,TPZCompEl *el){
+
+    auto *myself = dynamic_cast<TPZStructMatrix*>(this);
+    auto *cmesh = myself->Mesh();
+
+    TPZMatrix<TVar> &stiffness = dynamic_cast<TPZMatrix<TVar>&>(mat);
+    TPZFMatrix<TVar> &source = dynamic_cast<TPZFMatrix<TVar>&>(rhs);
+
+    TPZElementMatrixT<TVar> ek(cmesh, TPZElementMatrix::EK), ef(cmesh, TPZElementMatrix::EF);
+    el->CalcStiff(ek, ef);
+
+    const auto &equationFilter =
+            (dynamic_cast<TPZStructMatrix *>(this))->EquationFilter();
+
+    if(!el->HasDependency()) {
+        ek.ComputeDestinationIndices();
+        equationFilter.Filter(ek.fSourceIndex, ek.fDestinationIndex);
+
+        if (fShouldColor){
+            stiffness.AddKel(ek.fMat,ek.fSourceIndex,ek.fDestinationIndex);
+            source.AddFelNonAtomic(ef.fMat,ek.fSourceIndex,ek.fDestinationIndex);
+        }else{
+            stiffness.AddKelAtomic(ek.fMat,ek.fSourceIndex,ek.fDestinationIndex);
+            source.AddFel(ef.fMat,ek.fSourceIndex,ek.fDestinationIndex);
+        }
+
+    } else {
+        // the element has dependent nodes
+        ek.ApplyConstraints();
+        ef.ApplyConstraints();
+        ek.ComputeDestinationIndices();
+        equationFilter.Filter(ek.fSourceIndex, ek.fDestinationIndex);
+        if (fShouldColor){
+            stiffness.AddKel(ek.fConstrMat, ek.fSourceIndex, ek.fDestinationIndex);
+            source.AddFelNonAtomic(ef.fConstrMat,ek.fSourceIndex,ek.fDestinationIndex);
+        }else{
+            stiffness.AddKelAtomic(ek.fConstrMat, ek.fSourceIndex, ek.fDestinationIndex);
+            source.AddFel(ef.fConstrMat,ek.fSourceIndex,ek.fDestinationIndex);
+        }
+
+    }
+}
+
+
+
+static void AssembleColor(int64_t el, TPZStack<int64_t> &connectlist, TPZVec<int64_t> &elContribute) {
+    for (auto connect : connectlist) {
+        elContribute[connect] = el;
+    }
+}
+
+//Coloring computational elements 2022
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::OrderElements(){
+    auto *myself = dynamic_cast<TPZStructMatrix*>(this);
+    auto *cmesh = myself->Mesh();
+    int64_t nconnects = cmesh->NConnects();
+    int64_t nelement = cmesh->ElementVec().NElements();
+    fElVecColor.Resize(nelement);
+    fElVecColor.Fill(-1);
+    TPZVec<int> used(nconnects,0);
+    bool haswork = true;
+    int color = 0;
+
+    while (haswork){
+        haswork = false;
+        for (int64_t iel = 0; iel < nelement; iel++){
+            TPZCompEl *compel = cmesh->Element(iel);
+            if (!compel) continue;
+            if (fElVecColor[iel] != -1) continue;
+
+            TPZStack<int64_t> connectlist;
+            compel->BuildConnectList(connectlist);
+
+            bool canColor = true;
+            for (auto ic : connectlist){
+                if (used[ic]){
+                    canColor = false;
+                    haswork = true;
+                }
+            }
+            if (canColor){
+                for (auto ic : connectlist) used[ic] = 1;
+                fElVecColor[iel] = color;
+            }
+        }
+        if (haswork) {
+            color++;
+            used.Fill(0);
+        }
+    }
+}
+
+
+template<class TVar>
+int TPZStructMatrixOMPorTBB<TVar>::ClassId() const{
+    return Hash("TPZStructMatrixOMPorTBB") ^ TPZStrMatParInterface::ClassId() << 1;
+}
+
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::Read(TPZStream& buf, void* context) {
+    TPZStrMatParInterface::Read(buf, context);
+
+    buf.Read(fElBlocked);
+    buf.Read(fElSequenceColor);
+    buf.Read(&fElementCompleted);
+    buf.Read(&fSomeoneIsSleeping);
+    int64_t fCurrentIndexLong;
+    buf.Read(&fCurrentIndexLong);
+    fCurrentIndex = fCurrentIndexLong;
+}
+
+template<class TVar>
+void TPZStructMatrixOMPorTBB<TVar>::Write(TPZStream& buf, int withclassid) const {
+    TPZStrMatParInterface::Write(buf, withclassid);
+
+    buf.Write(fElBlocked);
+    buf.Write(fElSequenceColor);
+    buf.Write(&fElementCompleted);
+    buf.Write(&fSomeoneIsSleeping);
+    int64_t fCurrentIndexLong;
+    fCurrentIndexLong = fCurrentIndex;
+    buf.Write(&fCurrentIndexLong);
+}
+
+template class TPZStructMatrixOMPorTBB<STATE>;
+template class TPZRestoreClass<TPZStructMatrixOMPorTBB<STATE>>;
+template class TPZStructMatrixOMPorTBB<CSTATE>;
+template class TPZRestoreClass<TPZStructMatrixOMPorTBB<CSTATE>>;

--- a/StrMatrix/TPZStructMatrixOMPorTBB.cpp
+++ b/StrMatrix/TPZStructMatrixOMPorTBB.cpp
@@ -414,7 +414,6 @@ void TPZStructMatrixOMPorTBB<TVar>::AssemblingUsingOMPbutNotColoring(TPZBaseMatr
     const int nthread = this->fNumThreads;
 
     omp_set_num_threads(nthread);
-    omp_set_nested(true);
     #pragma omp parallel for schedule(dynamic,1)
     for (int64_t iel = 0; iel < nelem; iel++){
         {

--- a/StrMatrix/TPZStructMatrixOMPorTBB.h
+++ b/StrMatrix/TPZStructMatrixOMPorTBB.h
@@ -27,7 +27,6 @@ synchronized.
 #include "pzmatrix.h"
 #include "pzfmatrix.h"
 
-//class TPZStructMatrixOMPorTBB;
 #include "TPZStrMatParInterface.h"
 
 /**

--- a/StrMatrix/TPZStructMatrixOMPorTBB.h
+++ b/StrMatrix/TPZStructMatrixOMPorTBB.h
@@ -1,0 +1,136 @@
+//
+// Created by victor on 29/08/2022.
+//
+
+/**
+ * @file
+ * @brief Contains the TPZStructMatrixOMPorTBB class which is a TPZStructMatrixBase using graph coloring to define the order
+to process the elements and each color is processed and
+synchronized.
+ */
+
+#ifndef PZ_TPZSTRUCTMATRIXOMPORTBB_H
+#define PZ_TPZSTRUCTMATRIXOMPORTBB_H
+
+#include <set>
+#include <map>
+#include <semaphore.h>
+#include <mutex>
+#include <condition_variable>
+#include "pzvec.h"
+#include "tpzautopointer.h"
+#include "pzcmesh.h"
+#include "pzelmat.h"
+#include "TPZSemaphore.h"
+#include "TPZEquationFilter.h"
+#include "TPZGuiInterface.h"
+#include "pzmatrix.h"
+#include "pzfmatrix.h"
+
+//class TPZStructMatrixOMPorTBB;
+#include "TPZStrMatParInterface.h"
+
+/**
+ * @brief Refines geometrical mesh (all the elements) num times
+ * @ingroup geometry
+ */
+//void UniformRefine(int num, TPZGeoMesh &m);
+
+/**
+ * @brief It is responsible for a interface among Matrix and Finite Element classes. \ref structural "Structural Matrix"
+ * @ingroup structural
+ */
+template<class TVar>
+class TPZStructMatrixOMPorTBB : public virtual TPZStrMatParInterface{
+
+public:
+
+    TPZStructMatrixOMPorTBB();
+
+    TPZStructMatrixOMPorTBB(const TPZStructMatrixOMPorTBB &copy);
+
+    //! Move constructor
+    TPZStructMatrixOMPorTBB(TPZStructMatrixOMPorTBB &&copy) = default;
+
+    virtual ~TPZStructMatrixOMPorTBB() = default;
+
+    //! Copy assignment operator
+    TPZStructMatrixOMPorTBB& operator=(const TPZStructMatrixOMPorTBB &) = default;
+    //! Move assignment operator
+    TPZStructMatrixOMPorTBB& operator=(TPZStructMatrixOMPorTBB &&) = default;
+
+    /** @brief Assemble the global system of equations into the matrix which has already been created */
+    void Assemble(TPZBaseMatrix & mat, TPZBaseMatrix & rhs, TPZAutoPointer<TPZGuiInterface> guiInterface) override;
+    void Assemble(TPZBaseMatrix & rhs, TPZAutoPointer<TPZGuiInterface> guiInterface) override;
+
+public:
+    int ClassId() const override;
+    void Read(TPZStream &buf, void *context) override;
+    void Write(TPZStream &buf, int withclassid) const override;
+
+protected:
+
+    /** @brief Assemble the global system of equations into the matrix which has already been created */
+    virtual void Serial_Assemble(TPZBaseMatrix & mat, TPZBaseMatrix & rhs, TPZAutoPointer<TPZGuiInterface> guiInterface);
+
+    /** @brief Assemble the global right hand side */
+    virtual void Serial_Assemble(TPZBaseMatrix & rhs, TPZAutoPointer<TPZGuiInterface> guiInterface);
+
+    /** @brief Assemble the global right hand side */
+    virtual void MultiThread_Assemble(TPZBaseMatrix & rhs, TPZAutoPointer<TPZGuiInterface> guiInterface);
+
+    /** @brief Assemble the global system of equations into the matrix which has already been created */
+    virtual void MultiThread_Assemble(TPZBaseMatrix & mat, TPZBaseMatrix & rhs, TPZAutoPointer<TPZGuiInterface> guiInterface);
+
+    void VerifyStiffnessSum(TPZBaseMatrix & mat);
+
+    void AssemblingUsingTBBandColoring(TPZBaseMatrix & mat, TPZBaseMatrix & rhs );
+
+
+
+    void AssemblingUsingOMPandColoring(TPZBaseMatrix & mat, TPZBaseMatrix & rhs );
+
+
+    void AssemblingUsingTBBbutNotColoring(TPZBaseMatrix & mat, TPZBaseMatrix & rhs );
+
+
+    void AssemblingUsingOMPbutNotColoring(TPZBaseMatrix & mat, TPZBaseMatrix & rhs );
+
+    void ComputingCalcstiffAndAssembling(TPZBaseMatrix & mat,TPZBaseMatrix & rhs,TPZCompEl *el);
+
+public:
+    void OrderElements();
+    int  GetNumberColors();
+
+    void SetTBBorOMP (bool type){
+        fUsingTBB = type;
+    }
+
+    void SetShouldColor (bool type){
+        fShouldColor = type;
+    }
+
+protected:
+    TPZVec<int> fElVecColor;
+    bool fShouldColor = false;
+    bool fUsingTBB = false;
+
+    /** @brief Vectors for mesh coloring */
+    TPZVec<int64_t> fElBlocked, fElSequenceColor;
+
+    /// vector of the size of the elements containing 0 or 1 if the element has been computed (in the order of computation sequence)
+    TPZVec<int64_t> fElementsComputed;
+
+    /// All elements below or equal this index have been computed
+    int64_t fElementCompleted;
+
+    /// variable indicating if a thread is sleeping
+    int fSomeoneIsSleeping;
+
+    std::atomic<int64_t> fCurrentIndex;
+};
+
+extern template class TPZStructMatrixOMPorTBB<STATE>;
+extern template class TPZStructMatrixOMPorTBB<CSTATE>;
+
+#endif //PZ_TPZSTRUCTMATRIXOMPORTBB_H

--- a/UnitTest_PZ/TestMaterial/TestDarcyFlow.cpp
+++ b/UnitTest_PZ/TestMaterial/TestDarcyFlow.cpp
@@ -50,17 +50,17 @@ static void computeStiffnessH1(TPZFMatrix<STATE> &ek)
 static void computeStiffnessHybrid(TPZFMatrix<STATE> &ek)
 {
     ek.Zero();
-    TPZVec<TPZMaterialDataT<STATE>> DataVec(3);
+    TPZVec<TPZMaterialDataT<STATE>> DataVec(4);
     TPZManVector<int64_t> ids = {0,1,2,3};
     TPZManVector<int> connectorders = {1,1,1,1,1};
     
-    TPZShapeH1<pzshape::TPZShapeQuad>::Initialize(ids,connectorders,DataVec[0]);
-    int64_t nshape = DataVec[0].fPhi.Rows();
+    TPZShapeH1<pzshape::TPZShapeQuad>::Initialize(ids,connectorders,DataVec[1]);
+    int64_t nshape = DataVec[1].fPhi.Rows();
     int order = 0;
     int dimension = 2;
     pzshape::TPZShapeDisc::MShapeType shtype = pzshape::TPZShapeDisc::ETensorial;
-    pzshape::TPZShapeDisc::Initialize(order,dimension,shtype,DataVec[1]);
     pzshape::TPZShapeDisc::Initialize(order,dimension,shtype,DataVec[2]);
+    pzshape::TPZShapeDisc::Initialize(order,dimension,shtype,DataVec[3]);
     TPZHybridDarcyFlow material(1, 2);
     pzshape::TPZShapeQuad::IntruleType integrule(2);
     ek.Redim(nshape+2,nshape+2);
@@ -71,11 +71,12 @@ static void computeStiffnessHybrid(TPZFMatrix<STATE> &ek)
     {
         REAL weight;
         integrule.Point(p, pt, weight);
-        TPZShapeH1<pzshape::TPZShapeQuad>::Shape(pt, DataVec[0]);
+        TPZShapeH1<pzshape::TPZShapeQuad>::Shape(pt, DataVec[1]);
         int degree = 0;
-        pzshape::TPZShapeDisc::Shape(dimension,degree,pt,DataVec[1].fPhi,DataVec[1].fDPhi,shtype);
         pzshape::TPZShapeDisc::Shape(dimension,degree,pt,DataVec[2].fPhi,DataVec[2].fDPhi,shtype);
-        DataVec[0].dphix = DataVec[0].fDPhi;
+        pzshape::TPZShapeDisc::Shape(dimension,degree,pt,DataVec[3].fPhi,DataVec[3].fDPhi,shtype);
+        DataVec[1].dphix = DataVec[1].fDPhi;
+        DataVec[1].phi = DataVec[1].fPhi;
         material.Contribute(DataVec, weight, ek, ef);
     }
 }

--- a/UnitTest_PZ/TestSBFem/TPZDarcySBFemHdiv.h
+++ b/UnitTest_PZ/TestSBFem/TPZDarcySBFemHdiv.h
@@ -70,7 +70,7 @@ public:
     void ContributeBC(const TPZVec<TPZMaterialDataT<STATE>> &datavec, REAL weight, TPZFMatrix<STATE> &ek,
                       TPZFMatrix<STATE> &ef, TPZBndCondT<STATE> &bc) override;
 
-    void Errors(const TPZVec<TPZMaterialDataT<STATE>> &data, TPZVec<REAL> &errors);
+    void Errors(const TPZVec<TPZMaterialDataT<STATE>> &data, TPZVec<REAL> &errors) override;
 
 };
 

--- a/Util/log4cxx.cfg
+++ b/Util/log4cxx.cfg
@@ -117,7 +117,7 @@ log4j.appender.strmatrix.layout=org.apache.log4j.PatternLayout
 log4j.appender.strmatrix.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n
 
 
-log4j.logger.pz.strmatrix.element=info,element
+log4j.logger.pz.strmatrix.element=debug,element
 log4j.appender.element=org.apache.log4j.FileAppender
 log4j.appender.element.File=LOG/Element.txt
 log4j.appender.element.Append=false

--- a/cmake/EnableOMP.cmake
+++ b/cmake/EnableOMP.cmake
@@ -1,7 +1,5 @@
 function(enable_omp target)
     find_package(OpenMP REQUIRED)
-    include_directories(/usr/local/include)
-    link_directories(/usr/local/lib)
     if (NOT OpenMP_FOUND)
         message(FATAL_ERROR "Could not find OpenMP. If OpenMP is not needed, "
                 "configure the project with -DUSING_OMP=OFF")

--- a/cmake/EnableOMP.cmake
+++ b/cmake/EnableOMP.cmake
@@ -1,0 +1,12 @@
+function(enable_omp target)
+    find_package(OpenMP REQUIRED)
+    include_directories(/usr/local/include)
+    link_directories(/usr/local/lib)
+    if (NOT OpenMP_FOUND)
+        message(FATAL_ERROR "Could not find OpenMP. If OpenMP is not needed, "
+                "configure the project with -DUSING_OMP=OFF")
+    endif()
+    target_link_libraries(${target} PRIVATE OpenMP::OpenMP_CXX)
+    target_include_directories(${target} PRIVATE ${OpenMP_INCLUDE_DIRS})
+    target_compile_definitions(${target} PRIVATE USING_OMP)
+endfunction()


### PR DESCRIPTION
A new parallel interface called _TPZStructMatrixOMPorTBB_  becomes available to the library. As the name suggests, it is now possible to simply use _omp_ or _tbb_ to accelerate the assemblage process. It is also possible to choose between using AtomicAdd or Coloring the elements to make the process thread-safe. In order to so, it was required to introduce the following functions:

- TPZFMatrix<TVar>::AddFelNonAtomic;
- TPZMatrix<TVar>::AddKelAtomic;

The default AddFel<TVar> uses AtomicAdd for specializations _double_ and _float_, now the introduction AddFelNonAtomic allows a faster assemblage process for coloring schemes. On the other hand, AddKelAtomic uses PutVal function, which uses non atomic add, making the creation of the function required. Since OMP is not always available, the new flag USING_OMP becomes necessary.

Both the contributes of TPZHybridDarcyFlow and TPZLagrangeMultiplierCS.h now have support to BLAS acceleration.  

