### PR TITLE
External PARDISO configuration

### DIFF
--- a/Matrix/pzsysmp.cpp
+++ b/Matrix/pzsysmp.cpp
@@ -478,16 +478,18 @@ int TPZSYsmpMatrix<TVar>::Decompose_LDLt()
     if (this->IsDecomposed() != ENoDecompose) {
         DebugStop();
     }
-    typename TPZPardisoSolver<TVar>::MStructure str =
+    if(!fPardisoControl.HasCustomSettings()){
+      typename TPZPardisoSolver<TVar>::MStructure str =
         TPZPardisoSolver<TVar>::MStructure::ESymmetric;
-    typename TPZPardisoSolver<TVar>::MSystemType sysType =
-		TPZPardisoSolver<TVar>::MSystemType::ESymmetric;
-	typename TPZPardisoSolver<TVar>::MProperty prop =
-		this->IsDefPositive() ?
-		TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:
-		TPZPardisoSolver<TVar>::MProperty::EIndefinite;
-    fPardisoControl.SetStructure(str);
-	fPardisoControl.SetMatrixType(sysType,prop);
+      typename TPZPardisoSolver<TVar>::MSystemType sysType =
+        TPZPardisoSolver<TVar>::MSystemType::ESymmetric;
+      typename TPZPardisoSolver<TVar>::MProperty prop =
+        this->IsDefPositive() ?
+        TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:
+        TPZPardisoSolver<TVar>::MProperty::EIndefinite;
+      fPardisoControl.SetStructure(str);
+      fPardisoControl.SetMatrixType(sysType,prop);
+    }
     fPardisoControl.Decompose(this);
     this->SetIsDecomposed(ELDLt);
     return 1;
@@ -501,16 +503,18 @@ int TPZSYsmpMatrix<TVar>::Decompose_Cholesky()
         DebugStop();
     }
     this->fDefPositive = true;
-    typename TPZPardisoSolver<TVar>::MStructure str =
+    if(!fPardisoControl.HasCustomSettings()){
+      typename TPZPardisoSolver<TVar>::MStructure str =
         TPZPardisoSolver<TVar>::MStructure::ESymmetric;
-    typename TPZPardisoSolver<TVar>::MSystemType sysType =
-		TPZPardisoSolver<TVar>::MSystemType::ESymmetric;
-	typename TPZPardisoSolver<TVar>::MProperty prop =
-		this->IsDefPositive() ?
-		TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:
-		TPZPardisoSolver<TVar>::MProperty::EIndefinite;
-    fPardisoControl.SetStructure(str);
-	fPardisoControl.SetMatrixType(sysType,prop);
+      typename TPZPardisoSolver<TVar>::MSystemType sysType =
+        TPZPardisoSolver<TVar>::MSystemType::ESymmetric;
+      typename TPZPardisoSolver<TVar>::MProperty prop =
+        this->IsDefPositive() ?
+        TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:
+        TPZPardisoSolver<TVar>::MProperty::EIndefinite;
+      fPardisoControl.SetStructure(str);
+      fPardisoControl.SetMatrixType(sysType,prop);
+    }
     fPardisoControl.Decompose(this);
     this->SetIsDecomposed(ELDLt);
     return 1;

--- a/Matrix/pzysmp.cpp
+++ b/Matrix/pzysmp.cpp
@@ -1007,21 +1007,23 @@ int TPZFYsmpMatrix<TVar>::Decompose_LU()
     if (this->IsDecomposed() != ENoDecompose) {
         DebugStop();
     }
-	typename TPZPardisoSolver<TVar>::MStructure str =
+		if(!fPardisoControl.HasCustomSettings()){
+			typename TPZPardisoSolver<TVar>::MStructure str =
         this->IsSymmetric() ?
-		TPZPardisoSolver<TVar>::MStructure::ESymmetric:
-		TPZPardisoSolver<TVar>::MStructure::ENonSymmetric;
-	typename TPZPardisoSolver<TVar>::MSystemType sysType =
-		this->IsSymmetric() ?
-		TPZPardisoSolver<TVar>::MSystemType::ESymmetric:
-		TPZPardisoSolver<TVar>::MSystemType::ENonSymmetric;
-	typename TPZPardisoSolver<TVar>::MProperty prop =
-		this->IsDefPositive() ?
-		TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:
-		TPZPardisoSolver<TVar>::MProperty::EIndefinite;
-	fPardisoControl.SetStructure(str);
-	fPardisoControl.SetMatrixType(sysType,prop);
-    fPardisoControl.Decompose(this);
+				TPZPardisoSolver<TVar>::MStructure::ESymmetric:
+				TPZPardisoSolver<TVar>::MStructure::ENonSymmetric;
+			typename TPZPardisoSolver<TVar>::MSystemType sysType =
+				this->IsSymmetric() ?
+				TPZPardisoSolver<TVar>::MSystemType::ESymmetric:
+				TPZPardisoSolver<TVar>::MSystemType::ENonSymmetric;
+			typename TPZPardisoSolver<TVar>::MProperty prop =
+				this->IsDefPositive() ?
+				TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:
+				TPZPardisoSolver<TVar>::MProperty::EIndefinite;
+			fPardisoControl.SetStructure(str);
+			fPardisoControl.SetMatrixType(sysType,prop);
+		}
+		fPardisoControl.Decompose(this);
     this->SetIsDecomposed(ELU);
     return 1;
 #endif

--- a/Solvers/TPZEigenSolver.cpp
+++ b/Solvers/TPZEigenSolver.cpp
@@ -2,6 +2,8 @@
 #include "TPZKrylovEigenSolver.h"
 #include "TPZSpectralTransform.h"
 #include "Hash/TPZHash.h"
+#include "pzysmp.h"
+#include "pzsysmp.h"
 #include <numeric>
 
 template <class TVar>
@@ -21,6 +23,21 @@ void TPZEigenSolver<TVar>::ResetMatrix()
   fMatrixA = newA;
   fMatrixB = newB;
 }
+
+template<class TVar>
+TPZPardisoSolver<TVar> *
+TPZEigenSolver<TVar>::GetPardisoControl(TPZAutoPointer<TPZMatrix<TVar>> mat){
+  auto sym = TPZAutoPointerDynamicCast<TPZSYsmpMatrix<TVar>>(mat);
+  if(sym){
+    return  &(sym->GetPardisoControl());
+  }
+  auto nsym = TPZAutoPointerDynamicCast<TPZFYsmpMatrix<TVar>>(mat);
+  if(nsym){
+    return  &(nsym->GetPardisoControl());
+  }
+  return nullptr;
+}
+
 
 template<class TVar>
 void TPZEigenSolver<TVar>::SortEigenvalues(TPZVec<CTVar> &w, TPZVec<int> &indices)

--- a/Solvers/TPZEigenSolver.h
+++ b/Solvers/TPZEigenSolver.h
@@ -21,6 +21,10 @@ enum class TPZEigenSort{
   TargetMagnitude/*!< Magnitude closest to target*/
 };
 
+
+template <class T>
+class TPZPardisoSolver;
+
 /**
 * @ingroup solver
 * @brief  Defines an interface for  eigenvalue problems solvers.
@@ -138,7 +142,18 @@ public:
   int ClassId() const override;
   //! Resets Matrices
   void ResetMatrix() override;
+  //!Gets PARDISO control of Matrix A
+  //!Returns nullptr if not applicable (non-sparse matrix or matrix not set)
+  virtual TPZPardisoSolver<TVar> *GetPardisoControlA(){
+    return GetPardisoControl(fMatrixA);
+  }
+  //!Gets PARDISO control of Matrix A
+  //!Returns nullptr if not applicable (non-sparse matrix or matrix not set)
+  virtual TPZPardisoSolver<TVar> *GetPardisoControlB(){
+    return GetPardisoControl(fMatrixB);
+  }
 protected:
+  TPZPardisoSolver<TVar> *GetPardisoControl(TPZAutoPointer<TPZMatrix<TVar>> mat);
   /**
      @brief Sort the calculated eigenvalues and return a vector with
      size given by the NEigenvalues() method

--- a/Solvers/TPZEigenSolver.h
+++ b/Solvers/TPZEigenSolver.h
@@ -142,6 +142,8 @@ public:
   int ClassId() const override;
   //! Resets Matrices
   void ResetMatrix() override;
+  /** @name Pardiso*/
+  /** @{*/
   //!Gets PARDISO control of Matrix A
   //!Returns nullptr if not applicable (non-sparse matrix or matrix not set)
   virtual TPZPardisoSolver<TVar> *GetPardisoControlA(){
@@ -152,6 +154,7 @@ public:
   virtual TPZPardisoSolver<TVar> *GetPardisoControlB(){
     return GetPardisoControl(fMatrixB);
   }
+  /** @}*/
 protected:
   TPZPardisoSolver<TVar> *GetPardisoControl(TPZAutoPointer<TPZMatrix<TVar>> mat);
   /**

--- a/Solvers/TPZMatrixSolver.cpp
+++ b/Solvers/TPZMatrixSolver.cpp
@@ -111,6 +111,21 @@ int TPZMatrixSolver<TVar>::ClassId() const{
     return Hash("TPZMatrixSolver") ^ ClassIdOrHash<TVar>() ^ TPZSolver::ClassId() << 2;
 }
 
+#include "pzysmp.h"
+#include "pzsysmp.h"
+
+template<class TVar>
+TPZPardisoSolver<TVar> *TPZMatrixSolver<TVar>::GetPardisoControl(){
+  auto sym = TPZAutoPointerDynamicCast<TPZSYsmpMatrix<TVar>>(fContainer);
+  if(sym){
+    return  &(sym->GetPardisoControl());
+  }
+  auto nsym = TPZAutoPointerDynamicCast<TPZFYsmpMatrix<TVar>>(fContainer);
+  if(nsym){
+    return  &(nsym->GetPardisoControl());
+  }
+  return nullptr;
+}
 
 template class TPZMatrixSolver<float>;
 template class TPZMatrixSolver<std::complex<float> >;

--- a/Solvers/TPZMatrixSolver.h
+++ b/Solvers/TPZMatrixSolver.h
@@ -10,7 +10,8 @@
 #include "TPZSolver.h"
 #include "tpzautopointer.h"
 
-
+template<class T>
+class TPZPardisoSolver;
 
 /**
  * @ingroup solver
@@ -120,6 +121,9 @@ public:
     void Write(TPZStream &buf, int withclassid) const override;
     void Read(TPZStream &buf, void *context) override;
 
+    //!Returns nullptr if not applicable (non-sparse matrix or matrix not set)
+    virtual TPZPardisoSolver<TVar> *GetPardisoControl();
+  
 protected:
     /** @brief Reference matrix used to update the current matrix */
     TPZAutoPointer<TPZMatrix<TVar>> fReferenceMatrix;

--- a/Solvers/TPZPardisoSolver.h
+++ b/Solvers/TPZPardisoSolver.h
@@ -81,9 +81,20 @@ public:
     void SetStructure(MStructure str){
         fStructure = str;
     }
-    //! Gets reference to pardiso fParam array
-    inline TPZVec<long long> & GetParam()
+    /** @brief Gets copy of Pardiso param array
+        @note It is strongly suggested to call SetStructure and SetMatrixType before
+        customising the param array.*/
+    [[nodiscard]] inline TPZVec<long long> GetParam() const
     {return fParam;}
+
+    /** @brief Sets custom values to Pardiso param array.*/
+    void SetParam(const TPZVec<long long> & p);
+
+    /** @brief Resets custom values of Pardiso param array
+     @note This function should only be called if SetParam has been previously called.*/
+    void ResetParam();
+    //! Whether the param array has been set manually.
+    [[nodiscard]] bool HasCustomSettings() const {return fCustomSettings;}
 protected:
     /// Compute the `mtype` parameter of the pardiso_64 call
     long long MatrixType();
@@ -133,6 +144,8 @@ protected:
     bool fDecomposed{false};
     /// whether pardisoinit has been called
     bool fPardisoInitialized{false};
+    /// whether a custom param array has been set
+    bool fCustomSettings{false};
 };
 
 #endif /* TPZPARDISOSOLVER_H */

--- a/docs/solver/eigensolvers.rst
+++ b/docs/solver/eigensolvers.rst
@@ -22,7 +22,7 @@ Further documentation on TPZEigenSolver
 
 .. doxygenclass:: TPZEigenSolver
    :members:
-   :membergroups: Eigen
+   :membergroups: Eigen Pardiso
 
 .. _section-lapackeigensolver:
                   

--- a/docs/solver/eigensolvers.rst
+++ b/docs/solver/eigensolvers.rst
@@ -78,6 +78,11 @@ It is interesting to note that in this iteration, only the product :math:`A v_k`
    
 After the Arnoldi iteration is performed, an EVP for :math:`H` is then solved using LAPACK. Given that the dimensions of the Krylov subspace is :math:`m\ll n_{eq}`, where :math:`n_{eq}` is the original number of equations, using a dense matrix for :math:`H` does not represent a big impact.
 
+
+.. note::
+   The performance of the Krylov eigensolver will depend on the PARDISO settings.
+   See :ref:`section-pardiso-advanced` for how to set it up if needed.
+
 Further documentation on TPZKrylovEigenSolver
 =============================================
 

--- a/docs/solver/matrixsolvers.rst
+++ b/docs/solver/matrixsolvers.rst
@@ -37,8 +37,30 @@ The :cpp:expr:`TPZPardisoSolver` class acts as an wrapper for controlling the In
    The PARDISO solver is a solver for both symmetric and non-symmetric sparse matrices,
    so it should be used with either :cpp:expr:`TPZSSpStructMatrix` or :cpp:expr:`TPZSpStructMatrix`.
 
-.. note::
-   There is still plenty of tuning options to be implemented in this class. Please contact us or submit a Pull Request if you think this class could be improved.
+.. _section-pardiso-advanced:
+   
+Advanced settings
++++++++++++++++++
+
+PARDISO calls are set up primarily through the :code:`iparm` array (more info `here <https://www.intel.com/content/www/us/en/develop/documentation/onemkl-developer-reference-c/top/sparse-solver-routines/onemkl-pardiso-parallel-direct-sparse-solver-iface/pardiso-iparm-parameter.html>`_).
+We now provide means to access this array and configure PARDISO to match your needs.
+
+Ater the assembly of the FEM matrices, one can call
+:cpp:expr:`TPZMatrixSolver::GetPardisoControl` (or :cpp:expr:`TPZEigenSolver::GetPardisoControlA`, when solving EVPs with the :ref:`section-kryloveigensolver`)
+to have access to the corresponding instance of the :cpp:expr:`TPZPardisoSolver` class.
+
+Then, the methods :cpp:expr:`TPZPardisoSolver::GetParam`  and :cpp:expr:`TPZPardisoSolver::SetParam` can be used to customise the :code:`iparm` array.
+
+Upon usage, the parameters that were found to be of most importance are, as follows:
+
+- :code:`iparm[7]`: Maximum number of iterative refinement steps that the solver performs when perturbed pivots are obtained during the numerical factorization.
+- :code:`iparm[8]`: Tolerance level for the relative residual in the iterative refinement process. (:math:`10^{-param[8]}`)
+- :code:`iparm[9]`: Perturb the pivot elements with :math:`10^{-param[9]}`.
+- :code:`iparm[10]`: Use nonsymmetric permutation and scaling MPS
+- :code:`iparam[12]`: Maximum weighted matching algorithm is switched-off (default for symmetric).
+
+Further documentation on TPZPardisoSolver
++++++++++++++++++++++++++++++++++++++++++
 
 .. doxygenclass:: TPZPardisoSolver
    :members:


### PR DESCRIPTION
This PR aims to allow for changes on PARDISO's `param` array. In this way, it is possible to customise it with no need to change the code in `TPZPardisoSolver.cpp`.

A few checks are made in order to see whether custom settings have be applied, both in the `PardisoSolver<T>` template class and in the relevant sparse matrices.

Also, `TPZMatrixSolver<T>` and `TPZEigenSolver<T>` now provide methods for easier access to their `PardisoSolver<T>` instance, should it exist.