### PR TITLE
Persistence fix

### DIFF
--- a/Mesh/pzelchdiv.cpp
+++ b/Mesh/pzelchdiv.cpp
@@ -157,7 +157,8 @@ TPZIntelGen<TSHAPE>()
 {
 	this->fPreferredOrder = -1;
 	int i;
-	for(i=0;i<TSHAPE::NSides;i++) {
+  constexpr int ncon = TSHAPE::NFacets+1;
+	for(i=0;i<ncon;i++) {
 		this-> fConnectIndexes[i] = -1;
 	}
 

--- a/Mesh/pzelchdivbound2.cpp
+++ b/Mesh/pzelchdivbound2.cpp
@@ -157,9 +157,8 @@ TPZIntelGen<TSHAPE>()
 {
 	this->fPreferredOrder = -1;
 	int i;
-	for(i=0;i<TSHAPE::NSides;i++) {
-		this-> fConnectIndexes[i] = -1;
-	}
+  //hdiv bound will always have only one connect
+  this-> fConnectIndexes[0] = -1;
 }
 
 // TESTADO

--- a/StrMatrix/TPZStructMatrixOMPorTBB.cpp
+++ b/StrMatrix/TPZStructMatrixOMPorTBB.cpp
@@ -532,7 +532,9 @@ void TPZStructMatrixOMPorTBB<TVar>::OrderElements(){
 
 template<class TVar>
 int TPZStructMatrixOMPorTBB<TVar>::ClassId() const{
-    return Hash("TPZStructMatrixOMPorTBB") ^ TPZStrMatParInterface::ClassId() << 1;
+    return Hash("TPZStructMatrixOMPorTBB") ^
+        ClassIdOrHash<TVar>() << 1 ^
+        TPZStrMatParInterface::ClassId();
 }
 
 template<class TVar>

--- a/UnitTest_PZ/CMakeLists.txt
+++ b/UnitTest_PZ/CMakeLists.txt
@@ -34,6 +34,7 @@ add_subdirectory(TestBlend)
 add_subdirectory(TestShape)
 add_subdirectory(TestMultithreading)
 add_subdirectory(TestHDivCollapsed)
+add_subdirectory(TestPersistence)
 
 if(USING_LAPACK)
   add_subdirectory(TestSBFem)

--- a/UnitTest_PZ/TestPersistence/CMakeLists.txt
+++ b/UnitTest_PZ/TestPersistence/CMakeLists.txt
@@ -1,0 +1,2 @@
+# @file neopz/UnitTest_PZ/TestPersistence/CMakeLists.txt  -- CMake file for unit test of blend elements
+add_unit_test(TestPersistence TestPersistence.cpp)

--- a/UnitTest_PZ/TestPersistence/TestPersistence.cpp
+++ b/UnitTest_PZ/TestPersistence/TestPersistence.cpp
@@ -1,0 +1,60 @@
+/**
+ * @file BlendUnitTest.cpp
+ * @brief Define a Unit Test for testing features related to writing to and reading
+ from files.
+ *
+ */
+
+#include<catch2/catch.hpp>
+
+#include "pzfmatrix.h"
+#include "tpzautopointer.h"
+
+TEST_CASE("MatrixWriteTest","[persistence_tests]") {
+  //create any dummy variable to be written on disk
+  using namespace std::complex_literals;
+  TPZFMatrix<CSTATE> mymat = {{
+      {1.0,1.0+1i,1.0+2i},
+      {2.0,2.0+1i,2.0+2i},
+      {3.0,3.0+1i,3.0+2i}}};
+
+  const std::string mat_file("testfile.pz");
+  /*
+    TPZPersistenceManager::PopulateClassIdMap is a fundamental function
+    for writing/reading from files in NeoPZ, as the identifiers of NeoPZ
+    classes are registered in a map, allowing for identifying instances
+    when reading from a file. Therefore, we just test opening and closing a file.
+  */
+  SECTION("PopulateMap"){
+    TPZPersistenceManager::OpenWrite(mat_file);
+    TPZPersistenceManager::CloseWrite();
+  }
+
+  SECTION("WriteToFile"){
+    TPZPersistenceManager::OpenWrite(mat_file);
+    TPZPersistenceManager::WriteToFile(&mymat);
+    TPZPersistenceManager::CloseWrite();
+  }
+
+  SECTION("ReadFromFile"){
+    TPZPersistenceManager::OpenRead(mat_file);
+    TPZAutoPointer<TPZFMatrix<CSTATE>> mymat_file =
+      dynamic_cast<TPZFMatrix<CSTATE>*>(TPZPersistenceManager::ReadFromFile());
+    TPZPersistenceManager::CloseRead();
+
+    SECTION("MatData"){
+      REQUIRE(mymat_file);
+      REQUIRE(mymat_file->Rows() == mymat.Rows());
+      REQUIRE(mymat_file->Cols() == mymat.Cols());
+    }
+    SECTION("MatVals"){
+      const int nrows = mymat.Rows();
+      const int ncols = mymat.Cols();
+      for(int i = 0; i < nrows; i++){
+        for(int j = 0; j < ncols; j++){
+          REQUIRE(mymat_file->GetVal(i,j) == mymat.GetVal(i,j));
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds an initial unit test for NeoPZ's persistence features.

By invoking `TPZPersistenceManager::OpenWrite`, the `TPZPersistenceManager::PopulateClassIdMap` routine will be called
and all classes for which `TPZRestoreClass<T>` templates are defined will have their default constructor checked at runtime.