### PR TITLE
Special maps

### DIFF
--- a/SpecialMaps/TPZCylinderMap.cpp
+++ b/SpecialMaps/TPZCylinderMap.cpp
@@ -82,7 +82,7 @@ namespace pzgeom {
             for (int i=0; i<3; i++) {
                 localco[i] = 0.;
                 for (int j=0; j<3; j++) {
-                    localco[i] += fRotation(j,i)*(co[i]-fOrigin[i]);
+                    localco[i] += fRotation(j,i)*(co[j]-fOrigin[j]);
                 }
             }
             const REAL radius = sqrt(localco[0]*localco[0]+localco[1]*localco[1]);

--- a/SpecialMaps/TPZCylinderMap.cpp
+++ b/SpecialMaps/TPZCylinderMap.cpp
@@ -16,29 +16,29 @@ namespace pzgeom {
     constexpr REAL tol = std::numeric_limits<REAL>::epsilon()*1000;
     /// axis direction with the vertical axis
     template<class TGeo>
-    void TPZCylinderMap<TGeo>::SetCylinderAxis(const TPZVec<REAL> &axis)
+    void TPZCylinderMap<TGeo>::SetCylinderAxis(const TPZVec<REAL> &orig_axis)
     {
-        //master cylinder has axis in this direction
-        TPZManVector<REAL,3> orig_axis = {0,0,1};
+        /**master cylinder has axis in the z-direction.
+         therefore, a rotation matrix to convert from reference axis
+        to cylinder's axis will have the cylinder's axis as the 3 column
+        (for [0,0,1] is transformed to the cylinder's axis).
+        we now need to find two orthonormal vectors to compose our matrix*/
+        TPZManVector<REAL,3> reference_axis = {0,0,1};
 
         //let us normalize axis
         REAL normaxis = 0;
-        for(const auto &ax : axis){normaxis += ax*ax;}
+        for(const auto &ax : orig_axis){normaxis += ax*ax;}
         normaxis = sqrt(normaxis);
-        /*
-          We know three things about this rotation matrix:
-          Let us assume that x is the original axis and y is the new axis.
-          1. Rx = y
-          2. R^t y = x
-          3. R(x \times y) = x \times y
-         */
-        const auto &x = orig_axis;
+        const TPZManVector<REAL,3> axis = {orig_axis[0]/normaxis,
+                                           orig_axis[1]/normaxis,
+                                           orig_axis[2]/normaxis};
+        const auto &x = reference_axis;
         const auto &y = axis;
-        TPZManVector<REAL,3> z(3,0.);
-        //Let us compute the cross product between x and y
-        Cross(x,y,z);
+        TPZManVector<REAL,3> orth1(3,0.);
+        Cross(x,y,orth1);
 
-        if(fabs(z[0]) < tol && fabs(z[1]) < tol && fabs(z[2]) < tol){
+        //if they are aligned, then it is just a matter of sign
+        if(fabs(orth1[0]) < tol && fabs(orth1[1]) < tol && fabs(orth1[2]) < tol){
             //x and y are aligned
             //let us compute the inner product
             REAL inner{0};
@@ -48,33 +48,21 @@ namespace pzgeom {
                 fRotation(i,i) = sign;
             }
         }else{
-            //we first normalise the z vector
+            /**if they are not aligned, orth1 is already an orth vector,
+             we need to normalise it*/
             {
-                REAL normz{0};
-                for(auto &zx : z) {normz += zx*zx;}
-                normz = sqrt(normz);
-                for(auto &zx : z) {zx /= normz;}
-            }
-            //now we build a 9x9 matrix to find the rotation matrix
-            TPZFNMatrix<81,REAL> M(9,9,0.), b(9,1,0.);
-            for(int c = 0; c < 3; c++){
-                for(int i = 0; i < 3; i++){
-                    for(int j =0 ; j < 3; j++){
-                        M(3*c+i,3*c+j) = x[j];
-                        M(3*c+i,3*j) = y[j];
-                        M(3*c+2+i,3*c+j) = z[j];
-                    }
-                }
-                b(3*c+0,0) = y[c];
-                b(3*c+1,0) = x[c];
-                b(3*c+2,0) = z[c];
+                REAL normorth1{0};
+                for(auto &xx : orth1) {normorth1 += xx*xx;}
+                normorth1 = sqrt(normorth1);
+                for(auto &xx : orth1) {xx /= normorth1;}
             }
 
-            M.Solve_Cholesky(&b);
-            for(int i = 0; i < 9; i++){
-                const auto r = i/3;
-                const auto c = i%3;
-                fRotation(r,c) = b(i,0);
+            TPZManVector<REAL,3> orth2(3,0.);
+            Cross(y,orth1,orth2);
+            for(int i = 0; i < 3; i++){
+                fRotation(i,0) = orth1[i];
+                fRotation(i,1) = orth2[i];
+                fRotation(i,2) = y[i];
             }
         }
     }

--- a/SpecialMaps/tpzchangeel.cpp
+++ b/SpecialMaps/tpzchangeel.cpp
@@ -573,19 +573,23 @@ bool TPZChangeEl::CreateMiddleNodeAtEdge(TPZGeoMesh *Mesh, int64_t ElemIndex, in
         }
         neighEdge = neighEdge.Neighbour();
     }
+
+    const auto nodeidx = Mesh->NodeVec().AllocateNewElement();
+    Mesh->NodeVec()[nodeidx].Initialize(middleCoord,*Mesh);
+    middleNodeId = nodeidx;
     
-    //if not returned true...
-    TPZGeoNode midNode;
-    midNode.SetCoord(middleCoord);
+    // //if not returned true...
+    // TPZGeoNode midNode;
+    // midNode.SetCoord(middleCoord);
     
-    /** Setting Midnodes Id's */
-    int64_t NewNodeId = Mesh->NNodes();
-    Mesh->SetNodeIdUsed(NewNodeId);
-    midNode.SetNodeId(NewNodeId);
+    // /** Setting Midnodes Id's */
+    // int64_t NewNodeId = Mesh->NNodes();
+    // Mesh->SetNodeIdUsed(NewNodeId);
+    // midNode.SetNodeId(NewNodeId);
     
-    /** Allocating Memory for MidNodes and Pushing Them */
-    middleNodeId = Mesh->NodeVec().AllocateNewElement();
-    Mesh->NodeVec()[middleNodeId] = midNode;
+    // /** Allocating Memory for MidNodes and Pushing Them */
+    // middleNodeId = Mesh->NodeVec().AllocateNewElement();
+    // Mesh->NodeVec()[middleNodeId] = midNode;
 
     return true;
 }

--- a/SpecialMaps/tpzchangeel.h
+++ b/SpecialMaps/tpzchangeel.h
@@ -32,6 +32,14 @@ public:
     /** @brief Turns a regular element into a geoblend */
     static TPZGeoEl * ChangeToGeoBlend(TPZGeoMesh *Mesh, int64_t ElemIndex);
 
+    /** @brief Turns a regular linear element into a TPZArc3D*/
+    static TPZGeoEl * ChangeToArc3D(TPZGeoMesh *mesh, const int64_t ElemIndex,
+                                    const TPZVec<REAL> &xcenter, const REAL radius);
+    /** @brief Turns a regular 2D element into a TPZCylinderMap*/
+    static TPZGeoEl * ChangeToCylinder(TPZGeoMesh *mesh, const int64_t ElemIndex,
+                                       const TPZVec<REAL> &xcenter,
+                                       const TPZVec<REAL> &axis, const REAL radius);
+
     /** @brief Slide middle nodes of an quadratic geoelement to the quarterpoint with respect to a given side */
     static TPZGeoEl * ChangeToQuarterPoint(TPZGeoMesh *Mesh, int64_t ElemIndex, int targetSide);
 

--- a/SpecialMaps/tpzchangeel.h
+++ b/SpecialMaps/tpzchangeel.h
@@ -51,6 +51,20 @@ public:
 	 */
     static int64_t NearestNode(TPZGeoMesh * gmesh, TPZVec<REAL> &x, double tol);
     static bool CreateMiddleNodeAtEdge(TPZGeoMesh *Mesh, int64_t ElemIndex, int edge, int64_t &middleNodeId);
+
+    /**
+       @brief Stores the first neighbour for each side of a given element
+       @note If, for a given side, the neighbour is itself, an empty TPZGeoElSide is placed in its position
+       @param gel [in] given geometric element
+       @param neighs [out] vector of neighbours
+     */
+    static void StoreNeighbours(TPZGeoEl* gel, TPZVec<TPZGeoElSide> &neighs);
+    /**
+       @brief Restores neighbourhood information, checking for empty TPZGeoElSides in the vector
+       @param gel [in/out] given geometric element
+       @param neighs [in] vector of neighbours
+     */
+    static void RestoreNeighbours(TPZGeoEl* gel, TPZVec<TPZGeoElSide> &neighs);
 };
 
 #endif


### PR DESCRIPTION
This PR aims to fix issues with existing special maps, enhance functionalities and add unit tests.

The changes were focused in `TPZCylinder3D` class, which maps 2D elements to a cylinder shell, and routines in `TPZChangeEl`, which can be quite useful for replacing linear elements in a given geometric mesh while retaining all connectivity information.

- Fixes issue with local transformation of `TPZCylinder3D` and adds unit tests
- Refactor of existing routines in `TPZChangeEl`
- Refactor of neighbourhood store/restore in `TPZChangeEl`
- Adds `TPZChangeEl::ChangeToArc3D` and `TPZChangeEl::ChangeToCylinder`
- Adds unit tests for `TPZChangeEl` routines