### PR TITLE
Symmetry changes in matrices

### DIFF
--- a/Material/Elasticity/TPZElasticity3D.cpp
+++ b/Material/Elasticity/TPZElasticity3D.cpp
@@ -406,7 +406,7 @@ void TPZElasticity3D::Contribute(const TPZMaterialDataT<STATE> &data,
     DebugStop();
 #endif
 #ifdef PZDEBUG
-	if ( !ek.VerifySymmetry( 1.e-8 ) ) PZError << __PRETTY_FUNCTION__ << "\nERROR - NON SYMMETRIC MATRIX" << std::endl;
+    if ( ek.VerifySymmetry( 1.e-8 )==SymProp::NonSym ) PZError << __PRETTY_FUNCTION__ << "\nERROR - NON SYMMETRIC MATRIX" << std::endl;
 #endif
 }//method
 

--- a/Matrix/TPZSYSMPMatrix.cpp
+++ b/Matrix/TPZSYSMPMatrix.cpp
@@ -215,7 +215,7 @@ void TPZSYsmpMatrix<TVar>::MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TV
     const int64_t nrows = this->Rows();
 
     const bool must_conj =
-      is_complex<TVar>::value && this->IsSymmetric() == SymProp::Herm;
+      is_complex<TVar>::value && this->GetSymmetry() == SymProp::Herm;
 
 
     if(must_conj){

--- a/Matrix/TPZSYSMPMatrix.cpp
+++ b/Matrix/TPZSYSMPMatrix.cpp
@@ -17,8 +17,8 @@
 
 template<class TVar>
 TPZSYsmpMatrix<TVar>::TPZSYsmpMatrix() : TPZRegisterClassId(&TPZSYsmpMatrix::ClassId),
-TPZMatrix<TVar>() {
-
+                                         TPZMatrix<TVar>() {
+  this->fSymProp = SymProp::Herm;
 #ifdef CONSTRUCTOR
     cerr << "TPZSYsmpMatrix(int rows,int cols)\n";
 #endif
@@ -26,9 +26,9 @@ TPZMatrix<TVar>() {
 
 
 template<class TVar>
-TPZSYsmpMatrix<TVar>::TPZSYsmpMatrix(const int64_t rows,const int64_t cols ) : TPZRegisterClassId(&TPZSYsmpMatrix::ClassId),
-TPZMatrix<TVar>(rows,cols) {
-
+TPZSYsmpMatrix<TVar>::TPZSYsmpMatrix(const int64_t rows,const int64_t cols) :
+    TPZRegisterClassId(&TPZSYsmpMatrix::ClassId), TPZMatrix<TVar>(rows,cols) {
+  this->fSymProp = SymProp::Herm;
 #ifdef CONSTRUCTOR
 	cerr << "TPZSYsmpMatrix(int rows,int cols)\n";
 #endif
@@ -63,7 +63,7 @@ const TVar TPZSYsmpMatrix<TVar>::GetVal(const int64_t row,const int64_t col ) co
         for(int64_t ic=fIA[col] ; ic < fIA[col+1]; ic++ ) {
             if ( fJA[ic] == row ) {
                 if constexpr (is_complex<TVar>::value){
-                    return std::conj(fA[ic]);
+                    return this->fSymProp == SymProp::Herm ? std::conj(fA[ic]) : fA[ic];
                 }else{
                     return fA[ic];
                 }
@@ -91,7 +91,7 @@ int TPZSYsmpMatrix<TVar>::PutVal(const int64_t r,const int64_t c,const TVar & va
         row = col;
         col = temp;
         if constexpr (is_complex<TVar>::value){
-          valcp = std::conj(val);
+            valcp = this->fSymProp == SymProp::Herm? std::conj(val) : val;
         }
     }
     for(int64_t ic=fIA[row] ; ic < fIA[row+1]; ic++ ) {
@@ -214,37 +214,43 @@ void TPZSYsmpMatrix<TVar>::MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TV
     const int64_t ncols = x.Cols();
     const int64_t nrows = this->Rows();
 
-    
-    if constexpr (is_complex<TVar>::value){
+    const bool must_conj =
+      is_complex<TVar>::value && this->IsSymmetric() == SymProp::Herm;
+
+
+    if(must_conj){
+      if constexpr (is_complex<TVar>::value){
         auto GetMyVal = [](const int64_t ir, const int64_t ic,
                            const bool opt, const TVar val){
-            if((ir <= ic && !opt)||(ir >= ic && opt)) return val;
-            else return std::conj(val);
+          if((ir <= ic && !opt)||(ir > ic && opt)) return val;
+          else return std::conj(val);
         };
         for (int64_t col=0; col<ncols; col++){
-            for(int64_t row=0; row<nrows; row++) {
-                for(int64_t iv=fIA[row]; iv<fIA[row+1]; iv++) {
-                    const int64_t ic = fJA[iv];
-                    const TVar val = GetMyVal(row,ic,opt,fA[iv]);
-                    z(row,col) += alpha * val * x.GetVal(ic,col);
-                    if(row != ic){
-                        z(ic,col) += alpha* std::conj(val) * x.GetVal(row,col);
-                    }
-                }
+          for(int64_t row=0; row<nrows; row++) {
+            for(int64_t iv=fIA[row]; iv<fIA[row+1]; iv++) {
+              const int64_t ic = fJA[iv];
+              const TVar val = GetMyVal(row,ic,opt,fA[iv]);
+              z(row,col) += alpha * val * x.GetVal(ic,col);
+              if(row != ic){
+                z(ic,col) += alpha* std::conj(val) * x.GetVal(row,col);
+              }
             }
+          }
         }
-    }else{
-        for (int64_t col=0; col<ncols; col++){
-            for(int64_t row=0; row<nrows; row++) {
-                for(int64_t iv=fIA[row]; iv<fIA[row+1]; iv++) {
-                    const int64_t ic = fJA[iv];
-                    z(row,col) += alpha*fA[iv] * x.GetVal(ic,col);
-                    if(row != ic){
-                        z(ic,col) += alpha*fA[iv] * x.GetVal(row,col);
-                    }
-                }
+      }//no need for else
+    }
+    else{
+      for (int64_t col=0; col<ncols; col++){
+        for(int64_t row=0; row<nrows; row++) {
+          for(int64_t iv=fIA[row]; iv<fIA[row+1]; iv++) {
+            const int64_t ic = fJA[iv];
+            z(row,col) += alpha * fA[iv] * x.GetVal(ic,col);
+            if(row != ic){
+              z(ic,col) += alpha * fA[iv] * x.GetVal(row,col);
             }
+          }
         }
+      }
     }
 }
 
@@ -296,16 +302,26 @@ void TPZSYsmpMatrix<TVar>::ComputeDiagonal() {
 	}
 }
 
+template<class TVar>
+void TPZSYsmpMatrix<TVar>::SetSymmetry (SymProp sp){
+    if(sp == SymProp::NonSym){
+        PZError<<__PRETTY_FUNCTION__
+               <<"\nTrying to set matrix with symmetric storage as non symmetric\n"
+               <<"Aborting..."<<std::endl;
+        DebugStop();
+    }
+}
+
 /** @brief Fill matrix storage with randomic values */
 /** This method use GetVal and PutVal which are implemented by each type matrices */
 template<class TVar>
-void TPZSYsmpMatrix<TVar>::AutoFill(int64_t nrow, int64_t ncol, int symmetric)
+void TPZSYsmpMatrix<TVar>::AutoFill(int64_t nrow, int64_t ncol, SymProp sym)
 {
-    if (!symmetric || nrow != ncol) {
+    if (sym == SymProp::NonSym || nrow != ncol) {
         DebugStop();
     }
     TPZFMatrix<TVar> orig;
-    orig.AutoFill(nrow,ncol,symmetric);
+    orig.AutoFill(nrow,ncol,sym);
     
     TPZVec<int64_t> IA(nrow+1);
     TPZStack<int64_t> JA;
@@ -318,9 +334,7 @@ void TPZSYsmpMatrix<TVar>::AutoFill(int64_t nrow, int64_t ncol, int symmetric)
             REAL test = rand()*1./RAND_MAX;
             if (test > 0.5) {
                 eqs[row].insert(col);
-                if (symmetric) {
-                    eqs[col].insert(row);
-                }
+                eqs[col].insert(row);
             }
         }
     }

--- a/Matrix/TPZSYSMPMatrix.h
+++ b/Matrix/TPZSYSMPMatrix.h
@@ -54,8 +54,8 @@ public :
       }                                                       
   }
   
-  /** @brief Checks if the current matrix is symmetric */
-  virtual int IsSymmetric() const  override { return 1; }
+  /** @brief Sets symmetry property of current matrix (only hermitian/symmetric allowed)*/
+  void SetSymmetry (SymProp sp) override;
   /** @brief Checks if current matrix is square */
   inline int IsSquare() const { return 1;}
     
@@ -78,7 +78,7 @@ public :
 
     /** @brief Fill matrix storage with randomic values */
     /** This method use GetVal and PutVal which are implemented by each type matrices */
-    void AutoFill(int64_t nrow, int64_t ncol, int symmetric) override;
+    void AutoFill(int64_t nrow, int64_t ncol, SymProp symmetric) override;
 	  
 	  /** @brief Get the matrix entry at (row,col) without bound checking */
 	  virtual const TVar GetVal(const int64_t row, const int64_t col ) const override;

--- a/Matrix/TPZSYSMPPardiso.cpp
+++ b/Matrix/TPZSYSMPPardiso.cpp
@@ -92,7 +92,7 @@ void TPZSYsmpMatrixPardiso<TVar>::MultAdd(const TPZFMatrix<TVar> &x,const TPZFMa
 			sparse_index_base_t idx = SPARSE_INDEX_BASE_ZERO;
 			sparse_matrix_t A;
 			matrix_descr descr;
-			descr.type = this->IsSymmetric() == SymProp::Herm ? SPARSE_MATRIX_TYPE_HERMITIAN : SPARSE_MATRIX_TYPE_SYMMETRIC;
+			descr.type = this->GetSymmetry() == SymProp::Herm ? SPARSE_MATRIX_TYPE_HERMITIAN : SPARSE_MATRIX_TYPE_SYMMETRIC;
 			descr.mode = SPARSE_FILL_MODE_UPPER;
 			descr.diag = SPARSE_DIAG_NON_UNIT;
 
@@ -195,7 +195,7 @@ int TPZSYsmpMatrixPardiso<TVar>::Decompose(const DecomposeType dt)
   }
 
   if(!fPardisoControl.HasCustomSettings()){
-    const auto sysType = this->IsSymmetric();
+    const auto sysType = this->GetSymmetry();
     typename TPZPardisoSolver<TVar>::MProperty prop =
       this->IsDefPositive() ?
       TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:

--- a/Matrix/TPZSYSMPPardiso.cpp
+++ b/Matrix/TPZSYSMPPardiso.cpp
@@ -92,7 +92,7 @@ void TPZSYsmpMatrixPardiso<TVar>::MultAdd(const TPZFMatrix<TVar> &x,const TPZFMa
 			sparse_index_base_t idx = SPARSE_INDEX_BASE_ZERO;
 			sparse_matrix_t A;
 			matrix_descr descr;
-			descr.type = SPARSE_MATRIX_TYPE_HERMITIAN;
+			descr.type = this->IsSymmetric() == SymProp::Herm ? SPARSE_MATRIX_TYPE_HERMITIAN : SPARSE_MATRIX_TYPE_SYMMETRIC;
 			descr.mode = SPARSE_FILL_MODE_UPPER;
 			descr.diag = SPARSE_DIAG_NON_UNIT;
 
@@ -195,15 +195,11 @@ int TPZSYsmpMatrixPardiso<TVar>::Decompose(const DecomposeType dt)
   }
 
   if(!fPardisoControl.HasCustomSettings()){
-    typename TPZPardisoSolver<TVar>::MStructure str =
-      TPZPardisoSolver<TVar>::MStructure::ESymmetric;
-    typename TPZPardisoSolver<TVar>::MSystemType sysType =
-      TPZPardisoSolver<TVar>::MSystemType::ESymmetric;
+    const auto sysType = this->IsSymmetric();
     typename TPZPardisoSolver<TVar>::MProperty prop =
       this->IsDefPositive() ?
       TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:
       TPZPardisoSolver<TVar>::MProperty::EIndefinite;
-    fPardisoControl.SetStructure(str);
     fPardisoControl.SetMatrixType(sysType,prop);
   }
   fPardisoControl.Decompose(this);

--- a/Matrix/TPZYSMPMatrix.cpp
+++ b/Matrix/TPZYSMPMatrix.cpp
@@ -955,13 +955,11 @@ void TPZFYsmpMatrix<TVar>::RowLUUpdate(int64_t sourcerow, int64_t destrow)
 /** @brief Fill matrix storage with randomic values */
 /** This method use GetVal and PutVal which are implemented by each type matrices */
 template<class TVar>
-void TPZFYsmpMatrix<TVar>::AutoFill(int64_t nrow, int64_t ncol, int symmetric)
+void TPZFYsmpMatrix<TVar>::AutoFill(int64_t nrow, int64_t ncol, SymProp sym)
 {
-    if (symmetric && nrow != ncol) {
-        DebugStop();
-    }
+	  const bool square = nrow == ncol;
     TPZFMatrix<TVar> orig;
-    orig.AutoFill(nrow,ncol,symmetric);
+    orig.AutoFill(nrow,ncol,sym);
     
     TPZVec<int64_t> IA(nrow+1);
     TPZStack<int64_t> JA;
@@ -974,9 +972,8 @@ void TPZFYsmpMatrix<TVar>::AutoFill(int64_t nrow, int64_t ncol, int symmetric)
             REAL test = rand()*1./RAND_MAX;
             if (test > 0.5) {
                 eqs[row].insert(col);
-                if (symmetric) {
-                    eqs[col].insert(row);
-                }
+							  //if the matrix is square, we want it to have a symmetric structure
+								if(square){eqs[col].insert(row);}
             }
         }
     }

--- a/Matrix/TPZYSMPMatrix.h
+++ b/Matrix/TPZYSMPMatrix.h
@@ -79,7 +79,7 @@ public:
 
   /** @brief Fill matrix storage with randomic values */
   /** This method use GetVal and PutVal which are implemented by each type matrices */
-  void AutoFill(int64_t nrow, int64_t ncol, int symmetric) override;
+  void AutoFill(int64_t nrow, int64_t ncol, SymProp symmetric) override;
     
 	/** @brief Get the matrix entry at (row,col) without bound checking */
 	virtual const TVar GetVal(const int64_t row,const int64_t col ) const override;

--- a/Matrix/TPZYSMPPardiso.cpp
+++ b/Matrix/TPZYSMPPardiso.cpp
@@ -99,7 +99,7 @@ TPZFYsmpMatrixPardiso<TVar>::MultAdd(const TPZFMatrix<TVar> &x,
 			sparse_index_base_t idx = SPARSE_INDEX_BASE_ZERO;
 			sparse_matrix_t A;
 			matrix_descr descr;
-      switch(this->IsSymmetric()){
+      switch(this->GetSymmetry()){
       case SymProp::NonSym:
         descr.type = SPARSE_MATRIX_TYPE_GENERAL;
         break;
@@ -215,7 +215,7 @@ int TPZFYsmpMatrixPardiso<TVar>::Decompose(const DecomposeType dt)
   }
 
   if(!fPardisoControl.HasCustomSettings()){
-    const auto sysType = this->IsSymmetric();
+    const auto sysType = this->GetSymmetry();
     typename TPZPardisoSolver<TVar>::MProperty prop =
       this->IsDefPositive() ?
       TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:

--- a/Matrix/TPZYSMPPardiso.cpp
+++ b/Matrix/TPZYSMPPardiso.cpp
@@ -99,7 +99,17 @@ TPZFYsmpMatrixPardiso<TVar>::MultAdd(const TPZFMatrix<TVar> &x,
 			sparse_index_base_t idx = SPARSE_INDEX_BASE_ZERO;
 			sparse_matrix_t A;
 			matrix_descr descr;
-			descr.type = SPARSE_MATRIX_TYPE_GENERAL;
+      switch(this->IsSymmetric()){
+      case SymProp::NonSym:
+        descr.type = SPARSE_MATRIX_TYPE_GENERAL;
+        break;
+      case SymProp::Sym:
+        descr.type = SPARSE_MATRIX_TYPE_SYMMETRIC;
+        break;
+      case SymProp::Herm:
+        descr.type = SPARSE_MATRIX_TYPE_HERMITIAN;
+        break;
+      }
 			descr.mode = SPARSE_FILL_MODE_FULL;
 			descr.diag = SPARSE_DIAG_NON_UNIT;
 
@@ -205,13 +215,11 @@ int TPZFYsmpMatrixPardiso<TVar>::Decompose(const DecomposeType dt)
   }
 
   if(!fPardisoControl.HasCustomSettings()){
-    typename TPZPardisoSolver<TVar>::MStructure str = this->IsSymmetric() ? TPZPardisoSolver<TVar>::MStructure::ESymmetric : TPZPardisoSolver<TVar>::MStructure::ENonSymmetric;
-    typename TPZPardisoSolver<TVar>::MSystemType sysType = this->IsSymmetric() ? TPZPardisoSolver<TVar>::MSystemType::ESymmetric : TPZPardisoSolver<TVar>::MSystemType::ENonSymmetric;
+    const auto sysType = this->IsSymmetric();
     typename TPZPardisoSolver<TVar>::MProperty prop =
       this->IsDefPositive() ?
       TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:
       TPZPardisoSolver<TVar>::MProperty::EIndefinite;
-    fPardisoControl.SetStructure(str);
     fPardisoControl.SetMatrixType(sysType,prop);
   }
   fPardisoControl.Decompose(this);

--- a/Matrix/pzbasematrix.cpp
+++ b/Matrix/pzbasematrix.cpp
@@ -3,6 +3,14 @@
 #include "Hash/TPZHash.h"
 
 
+void TPZBaseMatrix::SetSymmetry(SymProp sp){
+  if(fRow!=fCol && sp != SymProp::NonSym){
+    PZError<<__PRETTY_FUNCTION__
+           <<"\nTrying to set a non-square matrix as symmetric/hermitian\n"
+           <<"Aborting..."<<std::endl;
+    DebugStop();
+  }
+}
 void TPZBaseMatrix::Read(TPZStream &buf, void *context){
   buf.Read(&fRow);
   buf.Read(&fCol);

--- a/Matrix/pzbasematrix.h
+++ b/Matrix/pzbasematrix.h
@@ -111,7 +111,7 @@ public:
 
   /** @brief Gets symmetry property of current matrix
       @note This flag is set by the user. Use VerifySymmetry for actually checking values.*/
-  SymProp IsSymmetric() const{ return fSymProp; }
+  SymProp GetSymmetry() const{ return fSymProp; }
 
   /** @brief Performs a check to ensure if current matrix value is symmetric */
   virtual SymProp VerifySymmetry(REAL tol) const = 0;

--- a/Matrix/pzblockdiag.h
+++ b/Matrix/pzblockdiag.h
@@ -143,7 +143,7 @@ public:
 	static int main();
     
     /** Fill the matrix with random values (non singular matrix) */
-    void AutoFill(int64_t dim, int64_t dimj, int symmetric) override;
+    void AutoFill(int64_t dim, int64_t dimj, SymProp symmetric) override;
 	
 private:
 	

--- a/Matrix/pzbndmat.cpp
+++ b/Matrix/pzbndmat.cpp
@@ -254,7 +254,7 @@ TPZFBMatrix<TVar>::operator*=(const TVar value )
 }
 
 template <class TVar>
-void TPZFBMatrix<TVar>::AutoFill(int64_t nrow, int64_t ncol, int symmetric) {
+void TPZFBMatrix<TVar>::AutoFill(int64_t nrow, int64_t ncol, SymProp sp) {
     if (nrow != ncol) {
         DebugStop();
     }
@@ -276,11 +276,11 @@ void TPZFBMatrix<TVar>::AutoFill(int64_t nrow, int64_t ncol, int symmetric) {
         }
         TVar sum = 0.;
         int64_t j = jmin;
-        if (symmetric) {
+        if (sp != SymProp::NonSym) {
             for (; j<i; j++) {
                 if constexpr (is_complex<TVar>::value){
-                    //hermitian matrices
-                    PutVal(i, j, std::conj(GetVal(j,i)));
+                    if(sp == SymProp::Herm){PutVal(i, j, std::conj(GetVal(j,i)));}
+                    else {PutVal(i, j, GetVal(j,i));}
                 }else{
                     PutVal(i, j, GetVal(j,i));
                 }

--- a/Matrix/pzbndmat.h
+++ b/Matrix/pzbndmat.h
@@ -87,7 +87,7 @@ public:
       }                                                       
   }
   
-  void AutoFill(int64_t nrow, int64_t ncol, int symmetric) override;
+  void AutoFill(int64_t nrow, int64_t ncol, SymProp symmetric) override;
 
     
 	int    Put(const int64_t row,const int64_t col,const TVar& value ) override;

--- a/Matrix/pzfmatrix.cpp
+++ b/Matrix/pzfmatrix.cpp
@@ -90,7 +90,7 @@ TPZMatrix<TVar>( A.fRow, A.fCol ), fElem(0), fGiven(0), fSize(0) {
     TVar * p = fElem;
     for(int64_t i = 0; i< size; i++) p[i]=src[i];
 //    memcpy((void *)(p),(void *)(src),(size_t)size*sizeof(TVar));
-    this->fSymProp = A.IsSymmetric();
+    this->fSymProp = A.GetSymmetry();
 }
 
 
@@ -2909,7 +2909,7 @@ void TPZFMatrix<TVar>::Symetrize() {
   int64_t row,col;
   int64_t fDim1 = this->Rows();
   const bool must_conj =
-    is_complex<TVar>::value && this->IsSymmetric() == SymProp::Herm;
+    is_complex<TVar>::value && this->GetSymmetry() == SymProp::Herm;
   for(row=0; row<fDim1; row++) {
     if(must_conj){
       if constexpr (is_complex<TVar>::value){

--- a/Matrix/pzfmatrix.cpp
+++ b/Matrix/pzfmatrix.cpp
@@ -90,6 +90,7 @@ TPZMatrix<TVar>( A.fRow, A.fCol ), fElem(0), fGiven(0), fSize(0) {
     TVar * p = fElem;
     for(int64_t i = 0; i< size; i++) p[i]=src[i];
 //    memcpy((void *)(p),(void *)(src),(size_t)size*sizeof(TVar));
+    this->fSymProp = A.IsSymmetric();
 }
 
 
@@ -2907,10 +2908,23 @@ void TPZFMatrix<TVar>::Symetrize() {
   
   int64_t row,col;
   int64_t fDim1 = this->Rows();
+  const bool must_conj =
+    is_complex<TVar>::value && this->IsSymmetric() == SymProp::Herm;
   for(row=0; row<fDim1; row++) {
-    for(col=row+1; col<fDim1; col++) {
-      this->s(col,row) = this->s(row,col);
+    if(must_conj){
+      if constexpr (is_complex<TVar>::value){
+        for(col=row+1; col<fDim1; col++) {
+          this->s(col,row) = std::conj(this->s(row,col));
+        }
+      }else{
+        DebugStop();//unreachable
+      }
+    }else{
+      for(col=row+1; col<fDim1; col++) {
+        this->s(col,row) = this->s(row,col);
+      }
     }
+    
   }
   
 }

--- a/Matrix/pzmatred.cpp
+++ b/Matrix/pzmatred.cpp
@@ -64,7 +64,7 @@ void TPZMatRed<TVar, TSideMatrix>::SimetrizeMatRed() {
 	// considering fK00 is simetric, only half of the object is assembled.
 	// this method simetrizes the matrix object
 	
-	if(!fK00 || this->IsSymmetric() == SymProp::NonSym) return;
+	if(!fK00 || this->GetSymmetry() == SymProp::NonSym) return;
 	fK01.Transpose(&fK10);
 	
 	fK11.Symetrize();
@@ -84,10 +84,10 @@ int
 TPZMatRed<TVar, TSideMatrix>::PutVal(const int64_t r,const int64_t c,const TVar& value ){
 	int64_t row(r),col(c);
   auto val = value;
-	if (this->IsSymmetric() != SymProp::NonSym && row > col ) {
+	if (this->GetSymmetry() != SymProp::NonSym && row > col ) {
     Swap( &row, &col );
     if constexpr (is_complex<TVar>::value){
-      if (this->IsSymmetric() == SymProp::Herm){
+      if (this->GetSymmetry() == SymProp::Herm){
         val = std::conj(val);
       }
     }
@@ -104,7 +104,7 @@ template<class TVar, class TSideMatrix>
 const TVar
 TPZMatRed<TVar,TSideMatrix>::GetVal(const int64_t r,const int64_t c ) const {
 	int64_t row(r),col(c);
-	const auto sp = this->IsSymmetric();
+	const auto sp = this->GetSymmetry();
 	if (sp != SymProp::NonSym && row > col ) Swap( &row, &col );
 
   TVar val = -1;
@@ -122,7 +122,7 @@ TPZMatRed<TVar,TSideMatrix>::GetVal(const int64_t r,const int64_t c ) const {
 template<class TVar, class TSideMatrix>
 TVar& TPZMatRed<TVar,TSideMatrix>::s(const int64_t r,const int64_t c ) {
 	int64_t row(r),col(c);
-	const auto sp = this->IsSymmetric();
+	const auto sp = this->GetSymmetry();
   if constexpr (is_complex<TVar>::value) {
     if(sp == SymProp::Herm && row > col){
       PZError<<__PRETTY_FUNCTION__
@@ -179,7 +179,7 @@ void
 TPZMatRed<TVar, TSideMatrix>::SetK00(TPZAutoPointer<TPZMatrix<TVar> > K00)
 {
 	fK00=K00;
-  this->fSymProp = fK00->IsSymmetric();
+  this->fSymProp = fK00->GetSymmetry();
 }
 
 template<class TVar, class TSideMatrix>

--- a/Matrix/pzmatred.h
+++ b/Matrix/pzmatred.h
@@ -23,6 +23,7 @@ class TPZVerySparseMatrix;
 /**
  * @brief Implements a simple substructuring of a linear system of equations, composed of 4 submatrices. \ref matrix "Matrix"
  * @ingroup matrix
+ * @note Its symmetry properties are given by its K00 matrix
  */
 /**
  * Implements a matrix composed of 4 submatrices:
@@ -78,9 +79,6 @@ public:
   }
 	/** @brief Simple destructor */
 	~TPZMatRed();
-	
-	/** @brief returns 1 or 0 depending on whether the fK00 matrix is zero or not */
-	virtual int IsSymmetric() const override;
 	
     // decomposition methods create an interrupt
     /** @brief decompose the system of equations acording to the decomposition

--- a/Matrix/pzmatrix.cpp
+++ b/Matrix/pzmatrix.cpp
@@ -361,7 +361,7 @@ void TPZMatrix<TVar>::Print(const char *name, std::ostream& out,const MatrixOutp
         }
     else if( form == EMatrixMarket)
         {
-            const auto symprop = IsSymmetric();
+            const auto symprop = GetSymmetry();
             //@fran better to have a DebugStop than to output an incorrect format
             if constexpr(is_complex<TVar>::value){
               std::cout<<__PRETTY_FUNCTION__
@@ -407,7 +407,7 @@ void TPZMatrix<TVar>::AddKel(TPZFMatrix<TVar> &elmat, TPZVec<int64_t> &destinati
 	
 	int64_t nelem = elmat.Rows();
   int64_t icoef,jcoef,ieq,jeq;
-	const auto symprop = IsSymmetric();  
+	const auto symprop = GetSymmetry();  
 	if(symprop == SymProp::Herm || symprop == SymProp::Sym){
 		for(icoef=0; icoef<nelem; icoef++) {
 			ieq = destinationindex[icoef];
@@ -437,7 +437,7 @@ void TPZMatrix<TVar>::AddKel(TPZFMatrix<TVar> &elmat, TPZVec<int64_t> &source, T
 	int64_t nelem = source.NElements();
   int64_t icoef,jcoef,ieq,jeq,ieqs,jeqs;
   TVar prevval;
-  const auto symprop = IsSymmetric();  
+  const auto symprop = GetSymmetry();  
 	if(symprop == SymProp::Herm || symprop == SymProp::Sym){
 		for(icoef=0; icoef<nelem; icoef++) {
 			ieq = destinationindex[icoef];
@@ -1455,7 +1455,7 @@ int TPZMatrix<TVar>::Inverse(TPZFMatrix<TVar>&Inv, DecomposeType dec){
     }
     else
     {
-        const bool isHermitian = this->IsSymmetric() == SymProp::Herm;
+        const bool isHermitian = this->GetSymmetry() == SymProp::Herm;
         if (isHermitian)  return this->SolveDirect(Inv, ELDLt);
         if (!isHermitian) return this->SolveDirect(Inv, ELU);
     }

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -104,10 +104,10 @@ public:
   
 	/** @brief Fill matrix storage with randomic values */
 	/** This method use GetVal and PutVal which are implemented by each type matrices */
-	void AutoFill(int64_t nrow, int64_t ncol, int symmetric) override;
+	void AutoFill(int64_t nrow, int64_t ncol, SymProp sym) override;
 	
 	/** @brief Checks if current matrix value is symmetric */
-	int VerifySymmetry(REAL tol = ZeroTolerance()) const override;
+	SymProp VerifySymmetry(REAL tol = ZeroTolerance()) const override;
 	
 	/**
      * @brief Put value with bounds checking

--- a/Matrix/pzsbndmat.cpp
+++ b/Matrix/pzsbndmat.cpp
@@ -470,8 +470,8 @@ TPZSBMatrix<TVar>::Decompose_Cholesky()
 
 #ifdef PZDEBUG
     const bool cond =
-        (is_complex<TVar>::value && this->IsSymmetric() == SymProp::Sym) ||
-        this->IsSymmetric() == SymProp::NonSym;
+        (is_complex<TVar>::value && this->GetSymmetry() == SymProp::Sym) ||
+        this->GetSymmetry() == SymProp::NonSym;
     if (cond){
         PZError<<__PRETTY_FUNCTION__
                <<"\nCalling Cholesky decomposition on non symmetric matrix! Aborting..."

--- a/Matrix/pzsbndmat.h
+++ b/Matrix/pzsbndmat.h
@@ -33,7 +33,7 @@ class TPZSBMatrix : public TPZMatrix<TVar>
     friend class TPZLapackEigenSolver<TVar>;
 public:
     TPZSBMatrix() : TPZRegisterClassId(&TPZSBMatrix::ClassId),
-    TPZMatrix<TVar>() , fStorage() { fBand = 0; }
+    TPZMatrix<TVar>() , fStorage() { fBand = 0; this->fSymProp = SymProp::Herm;}
     TPZSBMatrix(const int64_t dim,const int64_t band );
     TPZSBMatrix(const TPZSBMatrix<TVar> &A ) = default;
     TPZSBMatrix(TPZSBMatrix<TVar> &&A ) = default;
@@ -48,11 +48,8 @@ public:
     
     TVar &operator()(int64_t row, int64_t col);
     
-    /** @brief Checks if the current matrix is symmetric */
-    virtual int IsSymmetric() const override
-    {
-        return 1;
-    }
+    /** @brief Sets symmetry property of current matrix (only hermitian/symmetric allowed)*/
+    void SetSymmetry (SymProp sp) override;
 
     friend class TPZSBMatrix<float>;
     friend class TPZSBMatrix<double>;
@@ -95,7 +92,7 @@ public:
     template<class TT>friend std::ostream & operator<< (std::ostream& out,const TPZSBMatrix<TT>  &A);
     
     /** Fill the matrix with random values (non singular matrix) */
-    void AutoFill(int64_t nrow, int64_t ncol, int symmetric) override;
+    void AutoFill(int64_t nrow, int64_t ncol, SymProp symmetric) override;
     
     
     /// Operadores com matrizes SKY LINE.

--- a/Matrix/pzsfulmat.cpp
+++ b/Matrix/pzsfulmat.cpp
@@ -33,6 +33,7 @@ TPZMatrix<TVar>( dim, dim )
 	
 	// Zera a Matriz.
 	Zero();
+	this->fSymProp = SymProp::Herm;
 }
 
 /*********************************/
@@ -53,6 +54,7 @@ TPZMatrix<TVar> ( A.Dim(), A.Dim() )
 	TVar *end = &fElem[Size()];
 	while ( dst < end )
 		*dst++ = *src++;
+	this->fSymProp = A.IsSymmetric();
 }
 
 /*** Constructor( TPZSFMatrix& ) ***/
@@ -96,6 +98,16 @@ TPZSFMatrix<TVar> ::~TPZSFMatrix ()
 {
 	if ( fElem != NULL )
 		delete []fElem;
+}
+
+template<class TVar>
+void TPZSFMatrix<TVar>::SetSymmetry (SymProp sp){
+    if(sp == SymProp::NonSym){
+        PZError<<__PRETTY_FUNCTION__
+               <<"\nTrying to set matrix with symmetric storage as non symmetric\n"
+               <<"Aborting..."<<std::endl;
+        DebugStop();
+    }
 }
 
 
@@ -643,7 +655,7 @@ TPZSFMatrix<TVar> ::Subst_Forward( TPZFMatrix<TVar>  *B ) const
 	if ( (B->Rows() != this->Dim()) || !this->fDecomposed )
 		return( 0 );
 	
-	if ( B->IsSymmetric() )
+	if ( B->IsSymmetric()!=SymProp::NonSym )
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__, "Subst_Forward <the matrix result can not be simetric>" );
 	
 	TVar *ptr_k = fElem;
@@ -679,7 +691,7 @@ TPZSFMatrix<TVar> ::Subst_Backward( TPZFMatrix<TVar>  *B ) const
 	if ( (B->Rows() != this->Dim()) || !this->fDecomposed )
 		return( 0 );
 	
-	if ( B->IsSymmetric() )
+	if ( B->IsSymmetric()!= SymProp::NonSym )
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__, "Subst_Backward <the matrix result can not be simetric>" );
 	
 	TVar *ptr_k = &fElem[ Size()-1 ];
@@ -719,7 +731,7 @@ TPZSFMatrix<TVar> ::Subst_LForward( TPZFMatrix<TVar>  *B ) const
 	if ( (B->Rows() != this->Dim()) || !this->fDecomposed )
 		return( 0 );
 	
-	if ( B->IsSymmetric() )
+	if ( B->IsSymmetric() != SymProp::NonSym )
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__, "Subst_LForward <the matrix result can not be simetric>" );
 	
 	TVar *ptr_k = fElem;
@@ -753,7 +765,7 @@ TPZSFMatrix<TVar> ::Subst_LBackward( TPZFMatrix<TVar>  *B ) const
 	if ( (B->Rows() != this->Dim()) || !this->fDecomposed )
 		return( 0 );
 	
-	if ( B->IsSymmetric() )
+	if ( B->IsSymmetric()!=SymProp::NonSym )
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__, "Subst_LBackward <the matrix result can not be simetric>" );
 	
 	TVar *ptr_k = &fElem[ Size()-1 ];

--- a/Matrix/pzsfulmat.cpp
+++ b/Matrix/pzsfulmat.cpp
@@ -54,7 +54,7 @@ TPZMatrix<TVar> ( A.Dim(), A.Dim() )
 	TVar *end = &fElem[Size()];
 	while ( dst < end )
 		*dst++ = *src++;
-	this->fSymProp = A.IsSymmetric();
+	this->fSymProp = A.GetSymmetry();
 }
 
 /*** Constructor( TPZSFMatrix& ) ***/
@@ -655,7 +655,7 @@ TPZSFMatrix<TVar> ::Subst_Forward( TPZFMatrix<TVar>  *B ) const
 	if ( (B->Rows() != this->Dim()) || !this->fDecomposed )
 		return( 0 );
 	
-	if ( B->IsSymmetric()!=SymProp::NonSym )
+	if ( B->GetSymmetry()!=SymProp::NonSym )
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__, "Subst_Forward <the matrix result can not be simetric>" );
 	
 	TVar *ptr_k = fElem;
@@ -691,7 +691,7 @@ TPZSFMatrix<TVar> ::Subst_Backward( TPZFMatrix<TVar>  *B ) const
 	if ( (B->Rows() != this->Dim()) || !this->fDecomposed )
 		return( 0 );
 	
-	if ( B->IsSymmetric()!= SymProp::NonSym )
+	if ( B->GetSymmetry()!= SymProp::NonSym )
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__, "Subst_Backward <the matrix result can not be simetric>" );
 	
 	TVar *ptr_k = &fElem[ Size()-1 ];
@@ -731,7 +731,7 @@ TPZSFMatrix<TVar> ::Subst_LForward( TPZFMatrix<TVar>  *B ) const
 	if ( (B->Rows() != this->Dim()) || !this->fDecomposed )
 		return( 0 );
 	
-	if ( B->IsSymmetric() != SymProp::NonSym )
+	if ( B->GetSymmetry() != SymProp::NonSym )
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__, "Subst_LForward <the matrix result can not be simetric>" );
 	
 	TVar *ptr_k = fElem;
@@ -765,7 +765,7 @@ TPZSFMatrix<TVar> ::Subst_LBackward( TPZFMatrix<TVar>  *B ) const
 	if ( (B->Rows() != this->Dim()) || !this->fDecomposed )
 		return( 0 );
 	
-	if ( B->IsSymmetric()!=SymProp::NonSym )
+	if ( B->GetSymmetry()!=SymProp::NonSym )
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__, "Subst_LBackward <the matrix result can not be simetric>" );
 	
 	TVar *ptr_k = &fElem[ Size()-1 ];

--- a/Matrix/pzsfulmat.h
+++ b/Matrix/pzsfulmat.h
@@ -39,10 +39,8 @@ public:
 	
 	~TPZSFMatrix();
 	
-    /** @brief Checks if the current matrix is symmetric */
-    virtual int IsSymmetric() const  override {
-        return 1;
-    }
+    /** @brief Sets symmetry property of current matrix (only hermitian/symmetric allowed)*/
+    void SetSymmetry (SymProp sp) override;
 
     friend class TPZSFMatrix<float>;
     friend class TPZSFMatrix<double>;

--- a/Matrix/pzskylmat.cpp
+++ b/Matrix/pzskylmat.cpp
@@ -948,8 +948,8 @@ TPZSkylMatrix<TVar>::Decompose_Cholesky()
 {
 #ifdef PZDEBUG
     const bool cond =
-        (is_complex<TVar>::value && this->IsSymmetric() == SymProp::Sym) ||
-        this->IsSymmetric() == SymProp::NonSym;
+        (is_complex<TVar>::value && this->GetSymmetry() == SymProp::Sym) ||
+        this->GetSymmetry() == SymProp::NonSym;
     if (cond){
         PZError<<__PRETTY_FUNCTION__
                <<"\nCalling Cholesky decomposition on non symmetric matrix! Aborting..."

--- a/Matrix/pzskylmat.h
+++ b/Matrix/pzskylmat.h
@@ -31,7 +31,8 @@ template<class TVar>
 class TPZSkylMatrix : public TPZMatrix<TVar>
 {
 public:
-	TPZSkylMatrix() : TPZRegisterClassId(&TPZSkylMatrix::ClassId),TPZMatrix<TVar>(0,0),fElem(0),fStorage(0) { }
+	TPZSkylMatrix() : TPZRegisterClassId(&TPZSkylMatrix::ClassId),TPZMatrix<TVar>(0,0),fElem(0),fStorage(0) {
+    this->fSymProp = SymProp::Herm;}
 	TPZSkylMatrix(const int64_t dim);
 	/**
      @brief Construct a skyline matrix of dimension dim
@@ -70,8 +71,8 @@ public:
 	 */
 	void AddSameStruct(TPZSkylMatrix<TVar> &B, double k = 1.);
 	
-	/** @brief declare the object as simetric matrix*/
-	virtual int IsSymmetric() const  override {return 1;}
+	/** @brief Sets symmetry property of current matrix (only hermitian/symmetric allowed)*/
+  void SetSymmetry (SymProp sp) override;
     
     /**
 	 * @brief Updates the values of the matrix based on the values of the matrix
@@ -286,7 +287,7 @@ public:
 	// @}
 	
 	//void TestSpeed(int col, int prevcol);
-	virtual void AutoFill(int64_t nrow, int64_t ncol, int symmetric) override;
+	virtual void AutoFill(int64_t nrow, int64_t ncol, SymProp symmetric) override;
 	
 	public:
 int ClassId() const override;

--- a/Matrix/pzskylnsymmat.cpp
+++ b/Matrix/pzskylnsymmat.cpp
@@ -1570,7 +1570,7 @@ void TPZSkylNSymMatrix<TVar>::Write( TPZStream &buf, int withclassid ) const
 
 /** Fill the matrix with random values (non singular matrix) */
 template <class TVar>
-void TPZSkylNSymMatrix<TVar>::AutoFill(int64_t nrow, int64_t ncol, int symmetric) {
+void TPZSkylNSymMatrix<TVar>::AutoFill(int64_t nrow, int64_t ncol, SymProp sp) {
     if (nrow != ncol) {
         DebugStop();
     }
@@ -1595,10 +1595,10 @@ void TPZSkylNSymMatrix<TVar>::AutoFill(int64_t nrow, int64_t ncol, int symmetric
             {
 				this->Error("AutoFill (TPZMatrix) failed.");
             }
-            if (symmetric == 0) {
+            if (sp == SymProp::NonSym) {
               val = this->GetRandomVal();
             }else if constexpr(is_complex<TVar>::value){
-              val = std::conj(val);
+              if(sp == SymProp::Herm) val = std::conj(val);
             }
 			if(!PutVal(j,i,val))
             {

--- a/Matrix/pzskylnsymmat.h
+++ b/Matrix/pzskylnsymmat.h
@@ -89,9 +89,6 @@ class TPZSkylNSymMatrix : public TPZMatrix<TVar>
    */
   //void AddSameStruct(TPZSkylNSymMatrix &B, double k = 1.);
 
-  /**declare the object as non-symmetric matrix*/
-  virtual int IsSymmetric() const  override {return 0;}
-
   int PutVal(const int64_t row,const int64_t col,const TVar &element ) override;
 
   const TVar GetVal(const int64_t row,const int64_t col ) const override;
@@ -213,7 +210,7 @@ int ClassId() const override;
     
     /** @brief Fill matrix storage with randomic values */
 	/** This method use GetVal and PutVal which are implemented by each type matrices */
-	void AutoFill(int64_t nrow, int64_t ncol, int symmetric) override;
+	void AutoFill(int64_t nrow, int64_t ncol, SymProp sym) override;
 
 
  protected:

--- a/Solvers/EigenSolvers/TPZKrylovEigenSolver.cpp
+++ b/Solvers/EigenSolvers/TPZKrylovEigenSolver.cpp
@@ -98,7 +98,7 @@ int TPZKrylovEigenSolver<TVar>::SolveImpl(TPZVec<CTVar> &w,
 #ifdef USING_MKL
     auto prdscfg = this->GetPardisoControlA();
     if(prdscfg && !prdscfg->HasCustomSettings()){
-      const auto sys = this->MatrixA()->IsSymmetric();
+      const auto sys = this->MatrixA()->GetSymmetry();
       const auto prop =
         this->MatrixA()->IsDefPositive() ?
         TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:
@@ -119,7 +119,7 @@ int TPZKrylovEigenSolver<TVar>::SolveImpl(TPZVec<CTVar> &w,
 #ifdef USING_MKL
       auto prdscfg = this->GetPardisoControlB();
       if(prdscfg && !prdscfg->HasCustomSettings()){
-      const auto sys = this->MatrixB()->IsSymmetric();
+      const auto sys = this->MatrixB()->GetSymmetry();
       const auto prop =
         this->MatrixB()->IsDefPositive() ?
         TPZPardisoSolver<TVar>::MProperty::EPositiveDefinite:
@@ -129,7 +129,7 @@ int TPZKrylovEigenSolver<TVar>::SolveImpl(TPZVec<CTVar> &w,
 #else
         DebugStop();
 #endif
-      const auto sp= this->MatrixB()->IsSymmetric();
+      const auto sp= this->MatrixB()->GetSymmetry();
       const bool use_lu = sp == SymProp::Herm || (!std::is_same_v<TVar,RTVar> && sp == SymProp::Sym);
       if (use_lu) this->MatrixB()->Decompose(ELU);
       else this->MatrixB()->Decompose(ELDLt);

--- a/Solvers/EigenSolvers/TPZSpectralTransform.cpp
+++ b/Solvers/EigenSolvers/TPZSpectralTransform.cpp
@@ -19,8 +19,10 @@ template<class TVar>
 TPZAutoPointer<TPZMatrix<TVar>>
 TPZSTShiftOrigin<TVar>::CalcMatrix(TPZAutoPointer<TPZMatrix<TVar>>A, TPZAutoPointer<TPZMatrix<TVar>>B) const
 {
-  if (B->IsSymmetric()) B->Decompose(ELDLt);
-  else B->Decompose(ELU);
+  const auto sp= B->IsSymmetric();
+  const bool use_lu = sp == SymProp::Herm || (!std::is_same_v<TVar,RTVar> && sp == SymProp::Sym);
+  if (use_lu) B->Decompose(ELU);
+  else B->Decompose(ELDLt);
   TPZAutoPointer<TPZMatrix<TVar>> shiftedMat = A;
   //b-1 * shiftedA will be computed at the arnoldi iteration
   const auto &shift = Shift();
@@ -82,8 +84,10 @@ TPZSTShiftAndInvert<TVar>::CalcMatrix(TPZAutoPointer<TPZMatrix<TVar>>A, TPZAutoP
   }
   shiftedMat->Storage() -= B->Storage() * shift;
 
-  if (shiftedMat->IsSymmetric()) shiftedMat->Decompose(ELDLt);
-  else shiftedMat->Decompose(ELU);
+  const auto sp= shiftedMat->IsSymmetric();
+  const bool use_lu = sp == SymProp::Herm || (!std::is_same_v<TVar,RTVar> && sp == SymProp::Sym);
+  if (use_lu) shiftedMat->Decompose(ELU);
+  else shiftedMat->Decompose(ELDLt);
   return shiftedMat;
 }
 
@@ -95,8 +99,10 @@ TPZSTShiftAndInvert<TVar>::CalcMatrix(TPZAutoPointer<TPZMatrix<TVar>>A) const
   const auto &shift = this->Shift();
   const auto nRows = A->Rows();
   for(int i = 0; i < nRows; i++) shiftedMat->PutVal(i,i,A->GetVal(i,i)-shift);
-  if (shiftedMat->IsSymmetric()) shiftedMat->Decompose(ELDLt);
-  else shiftedMat->Decompose(ELU);
+  const auto sp= shiftedMat->IsSymmetric();
+  const bool use_lu = sp == SymProp::Herm || (!std::is_same_v<TVar,RTVar> && sp == SymProp::Sym);
+  if (use_lu) shiftedMat->Decompose(ELU);
+  else shiftedMat->Decompose(ELDLt);
   return shiftedMat;
 }
 

--- a/Solvers/EigenSolvers/TPZSpectralTransform.cpp
+++ b/Solvers/EigenSolvers/TPZSpectralTransform.cpp
@@ -19,7 +19,7 @@ template<class TVar>
 TPZAutoPointer<TPZMatrix<TVar>>
 TPZSTShiftOrigin<TVar>::CalcMatrix(TPZAutoPointer<TPZMatrix<TVar>>A, TPZAutoPointer<TPZMatrix<TVar>>B) const
 {
-  const auto sp= B->IsSymmetric();
+  const auto sp= B->GetSymmetry();
   const bool use_lu = sp == SymProp::Herm || (!std::is_same_v<TVar,RTVar> && sp == SymProp::Sym);
   if (use_lu) B->Decompose(ELU);
   else B->Decompose(ELDLt);
@@ -84,7 +84,7 @@ TPZSTShiftAndInvert<TVar>::CalcMatrix(TPZAutoPointer<TPZMatrix<TVar>>A, TPZAutoP
   }
   shiftedMat->Storage() -= B->Storage() * shift;
 
-  const auto sp= shiftedMat->IsSymmetric();
+  const auto sp= shiftedMat->GetSymmetry();
   const bool use_lu = sp == SymProp::Herm || (!std::is_same_v<TVar,RTVar> && sp == SymProp::Sym);
   if (use_lu) shiftedMat->Decompose(ELU);
   else shiftedMat->Decompose(ELDLt);
@@ -99,7 +99,7 @@ TPZSTShiftAndInvert<TVar>::CalcMatrix(TPZAutoPointer<TPZMatrix<TVar>>A) const
   const auto &shift = this->Shift();
   const auto nRows = A->Rows();
   for(int i = 0; i < nRows; i++) shiftedMat->PutVal(i,i,A->GetVal(i,i)-shift);
-  const auto sp= shiftedMat->IsSymmetric();
+  const auto sp= shiftedMat->GetSymmetry();
   const bool use_lu = sp == SymProp::Herm || (!std::is_same_v<TVar,RTVar> && sp == SymProp::Sym);
   if (use_lu) shiftedMat->Decompose(ELU);
   else shiftedMat->Decompose(ELDLt);

--- a/Solvers/TPZPardisoSolver.cpp
+++ b/Solvers/TPZPardisoSolver.cpp
@@ -92,7 +92,7 @@ void TPZPardisoSolver<TVar>::SetMatrix(TPZAutoPointer<TPZBaseMatrix> refmat)
     fDecomposed = refmat->IsDecomposed();
     const MProperty prop = refmat->IsDefPositive() ?
         MProperty::EPositiveDefinite : MProperty::EIndefinite;
-    SetMatrixType(refmat->IsSymmetric(),prop);
+    SetMatrixType(refmat->GetSymmetry(),prop);
     TPZMatrixSolver<TVar>::SetMatrix(refmat);
 }
 

--- a/Solvers/TPZPardisoSolver.h
+++ b/Solvers/TPZPardisoSolver.h
@@ -34,17 +34,11 @@ class TPZPardisoSolver : public TPZMatrixSolver<TVar>
     friend class TPZFYsmpMatrixPardiso<TVar>;
     friend class TPZSYsmpMatrixPardiso<TVar>;
 public:
-    /*!Symmetry of the algebraic system*/
-    enum class MSystemType {ENonInitialized=0, ESymmetric, ENonSymmetric};
-    /*! Storage format*/
-    enum class MStructure {ENonInitialized=0, ESymmetric, ENonSymmetric};
     /*! Whether the algebraic system is positive definite*/
     enum class MProperty {ENonInitialized=0, EPositiveDefinite, EIndefinite};
     
     /// Default constructor.
     TPZPardisoSolver();
-    /*!Constructor with info on the algebraic system*/
-    TPZPardisoSolver(MSystemType systemtype, MStructure structure, MProperty prop);
     /*!Copy constructor*/
     TPZPardisoSolver(const TPZPardisoSolver &copy) = default;
     /*!Move constructor*/
@@ -70,9 +64,9 @@ public:
 
     /**
        @brief Change the matrix type
-       @note  This method should only be called by the userbefore a matrix has been set.
+       @note  This method should only be called by the user before a matrix has been set.
     */
-    void SetMatrixType(MSystemType systemtype, MProperty prop);
+    void SetMatrixType(SymProp symtype, MProperty prop);
 
     //! Changes only PARDISO's matrix type param
     void SetMatrixType(long long type) {fMatrixType = type;} 
@@ -80,11 +74,7 @@ public:
      Anything different than zero results in statistical information being printed.*/
     void SetMessageLevel(int lvl);
     //! Clones the current object returning a pointer of type TPZSolver
-	TPZPardisoSolver<TVar> *Clone() const override;
-    //! Sets matrix structure
-    void SetStructure(MStructure str){
-        fStructure = str;
-    }
+	  TPZPardisoSolver<TVar> *Clone() const override;
     /** @brief Gets copy of Pardiso param array
         @note It is strongly suggested to call SetStructure and SetMatrixType before
         customising the param array.*/
@@ -114,9 +104,7 @@ protected:
      This method assumes that the matrix has been decomposed.*/
     void Solve(const TPZMatrix<TVar> *mat, const TPZFMatrix<TVar> &rhs, TPZFMatrix<TVar> &sol) const;
     
-    MSystemType fSystemType{MSystemType::ENonInitialized};
-    
-    MStructure fStructure{MStructure::ENonInitialized};
+    SymProp fSymmetry{SymProp::NonSym};
     
     MProperty fProperty{MProperty::ENonInitialized};
     

--- a/SubStruct/tpzdohrsubstructCondense.cpp
+++ b/SubStruct/tpzdohrsubstructCondense.cpp
@@ -47,7 +47,8 @@ void TPZDohrSubstructCondense<TVar>::Contribute_Kc(TPZMatrix<TVar> &Kc, TPZVec<i
 	int j;
 	for (i=0;i<fCoarseNodes.NElements();i++) {
 		for (j=0;j<fCoarseNodes.NElements();j++) {
-			if ((Kc.IsSymmetric() && coarseindex[j] >= coarseindex[i]) || !Kc.IsSymmetric()) {
+			if ((Kc.IsSymmetric() != SymProp::NonSym && coarseindex[j] >= coarseindex[i]) ||
+          Kc.IsSymmetric() == SymProp::NonSym) {
 				Kc(coarseindex[i],coarseindex[j]) += fKCi(i,j);				
 			}
 		}

--- a/SubStruct/tpzdohrsubstructCondense.cpp
+++ b/SubStruct/tpzdohrsubstructCondense.cpp
@@ -47,8 +47,8 @@ void TPZDohrSubstructCondense<TVar>::Contribute_Kc(TPZMatrix<TVar> &Kc, TPZVec<i
 	int j;
 	for (i=0;i<fCoarseNodes.NElements();i++) {
 		for (j=0;j<fCoarseNodes.NElements();j++) {
-			if ((Kc.IsSymmetric() != SymProp::NonSym && coarseindex[j] >= coarseindex[i]) ||
-          Kc.IsSymmetric() == SymProp::NonSym) {
+			if ((Kc.GetSymmetry() != SymProp::NonSym && coarseindex[j] >= coarseindex[i]) ||
+          Kc.GetSymmetry() == SymProp::NonSym) {
 				Kc(coarseindex[i],coarseindex[j]) += fKCi(i,j);				
 			}
 		}

--- a/UnitTest_PZ/TestEigenSolvers/TestEigenSolver.cpp
+++ b/UnitTest_PZ/TestEigenSolvers/TestEigenSolver.cpp
@@ -35,7 +35,7 @@ std::string Catch::StringMaker<long double>::convert(long double value) {
 /**tests if the H matrix is Hessenberg, 
 and if the vectors are an orthonormal basis*/
 template<class matx, class TVar>
-void TestArnoldiIteration(bool sym);
+void TestArnoldiIteration(SymProp sp);
 
 
 /**solves an EVP and ensures that
@@ -46,30 +46,43 @@ void TestArnoldiSolver(TPZAutoPointer<matx> A, const TPZFMatrix<CTVar> &sol);
 TEMPLATE_TEST_CASE("Arnoldi Iteration", "[eigen_tests]",
                    double)
 {
-  bool isSym{true};
   SECTION("Sym")
     {
       SECTION("TPZFMatrix")
-        {TestArnoldiIteration<TPZFMatrix<TestType>,TestType>(isSym);}
+        {
+          TestArnoldiIteration<TPZFMatrix<TestType>,TestType>(SymProp::Sym);
+          TestArnoldiIteration<TPZFMatrix<TestType>,TestType>(SymProp::Herm);
+        }
       SECTION("TPZSkylNSymMatrix")
-        {TestArnoldiIteration<TPZSkylNSymMatrix<TestType>,TestType>(isSym);}
+        {
+          TestArnoldiIteration<TPZSkylNSymMatrix<TestType>,TestType>(SymProp::Sym);
+          TestArnoldiIteration<TPZSkylNSymMatrix<TestType>,TestType>(SymProp::Herm);
+        }
       SECTION("TPZSkylMatrix")
-        {TestArnoldiIteration<TPZSkylMatrix<TestType>,TestType>(isSym);}
+      {
+        TestArnoldiIteration<TPZSkylMatrix<TestType>,TestType>(SymProp::Sym);
+        TestArnoldiIteration<TPZSkylMatrix<TestType>,TestType>(SymProp::Herm);
+      }
       SECTION("TPZFYsmpMatrix")
-        {TestArnoldiIteration<TPZFYsmpMatrix<TestType>,TestType>(isSym);}
+      {
+        TestArnoldiIteration<TPZFYsmpMatrix<TestType>,TestType>(SymProp::Sym);
+        TestArnoldiIteration<TPZFYsmpMatrix<TestType>,TestType>(SymProp::Herm);
+      }
       SECTION("TPZSYsmpMatrix")
-        {TestArnoldiIteration<TPZSYsmpMatrix<TestType>,TestType>(isSym);}
+      {
+        TestArnoldiIteration<TPZSYsmpMatrix<TestType>,TestType>(SymProp::Sym);
+        TestArnoldiIteration<TPZSYsmpMatrix<TestType>,TestType>(SymProp::Herm);
+      }
     }
-  isSym = false;
   
   SECTION("NSym")
     {
       SECTION("TPZFMatrix")
-        {TestArnoldiIteration<TPZFMatrix<TestType>,TestType>(isSym);}
+        {TestArnoldiIteration<TPZFMatrix<TestType>,TestType>(SymProp::NonSym);}
       SECTION("TPZSkylNSymMatrix")
-        {TestArnoldiIteration<TPZSkylNSymMatrix<TestType>,TestType>(isSym);}
+        {TestArnoldiIteration<TPZSkylNSymMatrix<TestType>,TestType>(SymProp::NonSym);}
       SECTION("TPZFYsmpMatrix")
-        {TestArnoldiIteration<TPZFYsmpMatrix<TestType>,TestType>(isSym);}
+        {TestArnoldiIteration<TPZFYsmpMatrix<TestType>,TestType>(SymProp::NonSym);}
     }
 }
 
@@ -192,8 +205,8 @@ TEMPLATE_TEST_CASE("Arnoldi Solver 2", "[eigen_tests]",
   TPZAutoPointer<TestType> A = new TestType;
   constexpr int64_t dim{20};
   constexpr int dimKrylov{20};
-  constexpr bool isSym{true};
-  A->AutoFill(dim,dim,isSym);//generates adequate storage
+  constexpr SymProp sp{SymProp::Herm};
+  A->AutoFill(dim,dim,sp);//generates adequate storage
   
   for(int i = 0; i < dim; i++){
     for(int j = 0; j < dim; j++){
@@ -212,7 +225,7 @@ TEMPLATE_TEST_CASE("Arnoldi Solver 2", "[eigen_tests]",
 #endif
 
 template<class matx, class TVar>
-void TestArnoldiIteration(bool sym)
+void TestArnoldiIteration(SymProp sp)
 {
 
   const auto oldPrecision = Catch::StringMaker<RTVar>::precision;
@@ -221,7 +234,7 @@ void TestArnoldiIteration(bool sym)
   matx A;
   constexpr int dim{100};
   int dimKrylov{100};
-  A.AutoFill(dim,dim,sym);
+  A.AutoFill(dim,dim,sp);
   TPZKrylovEigenSolver<TVar> arnoldi;
   arnoldi.SetKrylovDim(dimKrylov);
   TPZVec<TPZAutoPointer<TPZFMatrix<TVar>>> qVecs;

--- a/UnitTest_PZ/TestMaterial/TestDarcyFlow.cpp
+++ b/UnitTest_PZ/TestMaterial/TestDarcyFlow.cpp
@@ -88,8 +88,8 @@ TEST_CASE("test_matriz_darcy","[material_tests]")
     TPZFNMatrix<16,STATE> stiff;
     computeStiffnessH1(stiff);
 	REAL tol = 1.e-8;
-	bool sym = stiff.VerifySymmetry(tol);
-	REQUIRE(sym==1);		// Verify the symmetry of the stiffness matrix
+	auto sym = stiff.VerifySymmetry(tol);
+	REQUIRE(sym!=SymProp::NonSym);		// Verify the symmetry of the stiffness matrix
     REAL RightStiff[4][4] = {
         {2./3.,-1./6,-1./3.,-1./6.},
         {-1./6.,2./3.,-1./6,-1./3.},
@@ -113,8 +113,8 @@ TEST_CASE("test_matriz_hybriddarcy","[material_tests]")
     TPZFNMatrix<36,STATE> stiff;
     computeStiffnessHybrid(stiff);
     REAL tol = 1.e-8;
-    bool sym = stiff.VerifySymmetry(tol);
-    REQUIRE(sym==1);        // Verify the symmetry of the stiffness matrix
+    auto sym = stiff.VerifySymmetry(tol);
+    REQUIRE(sym!=SymProp::NonSym);        // Verify the symmetry of the stiffness matrix
     REAL RightStiff[6][6] = {
         {2./3.,-1./6,-1./3.,-1./6.,1,0},
         {-1./6.,2./3.,-1./6,-1./3.,1,0},

--- a/UnitTest_PZ/TestMaterial/TestMaterial.cpp
+++ b/UnitTest_PZ/TestMaterial/TestMaterial.cpp
@@ -70,9 +70,16 @@ TEST_CASE("test_matriz_rigidez_cubo","[material_tests]")
 	std::string name = "CubeStiffMatrix.txt";
 	TPZFMatrix<STATE> RightStiff(readStressStrain(name)), stiff(computeStressStrain());
 	REAL tol = 1.e-8;
-	bool sym = stiff.VerifySymmetry(tol);
-	std::cout << sym << std::endl;
-	REQUIRE(sym==1);		// Verify the symmetry of the stiffness matrix
+	const auto sp = stiff.VerifySymmetry(tol);
+	const auto str_sp = [sp](){
+		switch(sp){
+		case SymProp::NonSym: return "NonSym";
+		case SymProp::Sym: return "Sym";
+		case SymProp::Herm: return "Herm";
+		}
+	}();
+	std::cout << str_sp << std::endl;
+	REQUIRE(sp!=SymProp::NonSym);		// Verify the symmetry of the stiffness matrix
 	REAL dif;
 	for (int i = 0 ; i < 9 ; i++) 
 	{

--- a/UnitTest_PZ/TestMatrix/TestMatrix.cpp
+++ b/UnitTest_PZ/TestMatrix/TestMatrix.cpp
@@ -1165,7 +1165,7 @@ void TestingInverseWithAutoFill(int dim, SymProp sp, DecomposeType dec) {
 
 template <class matx, class TVar>
 void TestingInverse(matx ma, DecomposeType dec) {
-  const auto symmetric = SymPropName(ma.IsSymmetric());
+  const auto symmetric = SymPropName(ma.GetSymmetry());
   if(ma.Rows() != ma.Cols()){
     const bool is_square_mat{false};
     REQUIRE(is_square_mat);

--- a/UnitTest_PZ/TestMatrix/TestMatrix.cpp
+++ b/UnitTest_PZ/TestMatrix/TestMatrix.cpp
@@ -46,7 +46,7 @@ template <class matx>
 void CheckDiagonalDominantMatrix(matx &matr);
 
 template <class matx>
-void TestGeneratingDiagonalDominantMatrix(bool isSymmetric);
+void TestGeneratingDiagonalDominantMatrix(SymProp sp);
 
 template <class matx, class TVar>
 void TestGeneratingHermitianMatrix();
@@ -66,7 +66,7 @@ void TestGeneratingHermitianMatrix();
  * NOTE3: The first function is for square matrices and the second function is for rectangular matrices.
  */
 template <class matx, class TVar>
-void TestingInverseWithAutoFill(int dim, int symmetric, DecomposeType dec);
+void TestingInverseWithAutoFill(int dim, SymProp sp, DecomposeType dec);
 
 /**
  * @brief Tests the Inverse method of the matrix to any matrix types.
@@ -86,7 +86,7 @@ void TestingInverse(matx mat, DecomposeType dec);
  * @note Process: build square matrix with randomic values, compute its square twice using * operator with two different copies of itself and checks whether the result is the same
  */
 template <class matx, class TVar>
-void TestingMultiplyOperatorWithAutoFill(int dim, int symmetric);
+void TestingMultiplyOperatorWithAutoFill(int dim, SymProp sp);
 /**
  * @brief Tests the Multiply method of the matrix, using AutoFill to build a square matrix of dimension dim (user defined)
  * @param dim Dimension of the square matrix to be build.
@@ -98,7 +98,7 @@ void TestingMultiplyOperatorWithAutoFill(int dim, int symmetric);
  * Check if the result is a identity matrix.
  */
 template <class matx, class TVar>
-void TestingMultiplyWithAutoFill(int dim, int symmetric);
+void TestingMultiplyWithAutoFill(int dim, SymProp sp);
 /**
  * @brief Tests the Multiply method of the matrix, using AutoFill to build a square matrix of dimension dim (user defined)
  * @param dim Dimension of the square matrix to be build.
@@ -115,35 +115,35 @@ void TestingDotNorm(int dim);
 Test Add operation
 */
 template <class matx, class TVar>
-void TestingAdd(int row, int col, int symmetric);
+void TestingAdd(int row, int col, SymProp sp);
 /*
 Test Subtract operation
 */
 template <class matx, class TVar>
-void TestingSubtract(int row, int col, int symmetric);
+void TestingSubtract(int row, int col, SymProp sp);
 /*
 Test MultiplyByScalar operation
 */
 template <class matx, class TVar>
-void TestingMultiplyByScalar(int row, int col, int symmetric);
+void TestingMultiplyByScalar(int row, int col, SymProp sp);
 
 template <class matx, class TVar>
-void TestingAddOperator(int row, int col, int symmetric);
+void TestingAddOperator(int row, int col, SymProp sp);
 /*
 Test Subtract operation
 */
 template <class matx, class TVar>
-void TestingSubtractOperator(int row, int col, int symmetric);
+void TestingSubtractOperator(int row, int col, SymProp sp);
 /*
 Test MultiplyByScalar operation
 */
 template <class matx, class TVar>
-void TestingMultiplyByScalarOperator(int row, int col, int symmetric);
+void TestingMultiplyByScalarOperator(int row, int col, SymProp sp);
 /**
  * Check if the result is a identity matrix.
  */
 template <class matx, class TVar>
-void TestingTransposeMultiply(int row, int col, int symmetric);
+void TestingTransposeMultiply(int row, int col, SymProp sp);
 /**
  * @brief Tests the Transpose method of the matrix, using AutoFill to build a matrix of dimension row x cols (user defined)
  * @param rows Number of rows
@@ -152,7 +152,7 @@ void TestingTransposeMultiply(int row, int col, int symmetric);
  * @note Process: build matrix with randomic values, compute its transpose and transpose again then compare the first and last matrices.
  */
 template <class matx, class TVar>
-void TestingTransposeWithAutoFill(int rows, int cols, int symmetric);
+void TestingTransposeWithAutoFill(int rows, int cols, SymProp sp);
 /**
  * @brief Tests the MultAdd method of the matrix, that calculates z = beta * y + alpha * A * x , using AutoFill to build a square matrix of dimension dim (user defined)
  * @param dim Dimension of the square matrix to be build.
@@ -161,7 +161,7 @@ void TestingTransposeWithAutoFill(int rows, int cols, int symmetric);
  * @note Process: build square matrix with randomic values, compute its inverse and uses MultAdd for calculating I - A*A^-1 and check whether you have any non-zero entries on the result
  */
 template <class matx, class TVar>
-void TestingMultAdd(int dim, int symmetric, DecomposeType dec);
+void TestingMultAdd(int dim, SymProp sp, DecomposeType dec);
 #ifdef PZ_USING_LAPACK
 
 /**
@@ -170,7 +170,7 @@ void TestingMultAdd(int dim, int symmetric, DecomposeType dec);
  * @param symmetric Whether to build a symmetric matrix
  * @note Process: uses LAPACK's routine */
 template <class matx, class TVar>
-void TestingGeneralisedEigenValuesWithAutoFill(int dim, int symmetric);
+void TestingGeneralisedEigenValuesWithAutoFill(int dim, SymProp sp);
 
 /**
  * @brief Tests the Eigenvalues/eigenvectors of a couple of known matrices
@@ -185,7 +185,7 @@ void BasicEigenTests();
  * @param symmetric Whether to build a symmetric matrix
  * @note Process: uses LAPACK's routine */
 template <class matx, class TVar>
-void TestingEigenDecompositionAutoFill(int dim, int symmetric);
+void TestingEigenDecompositionAutoFill(int dim, SymProp sp);
 
 /** @brief Check if, for an auto generated matrix A, 
 * U and VT are orthogonal;
@@ -225,27 +225,27 @@ void TestSVD(int nrows, int ncols);
 #ifdef PZ_USING_MKL
             if constexpr (std::is_same<RTVar,double>::value){
                 SECTION("TPZSYsmpMatrix"){
-                    TestingInverseWithAutoFill<TPZSYsmpMatrixPardiso<TVar>,TVar>(dim, 1, ECholesky);
+                  TestingInverseWithAutoFill<TPZSYsmpMatrixPardiso<TVar>,TVar>(dim, SymProp::Herm, ECholesky);
                 }
             }
 #endif
             SECTION("TPZFMatrix"){
-                TestingInverseWithAutoFill<TPZFMatrix<TVar>,TVar>(dim, 1, ECholesky);
+                TestingInverseWithAutoFill<TPZFMatrix<TVar>,TVar>(dim, SymProp::Herm, ECholesky);
             }
             SECTION("TPZSFMatrix"){
-                TestingInverseWithAutoFill<TPZSFMatrix<TVar>,TVar>(dim, 1, ECholesky);
+                TestingInverseWithAutoFill<TPZSFMatrix<TVar>,TVar>(dim, SymProp::Herm, ECholesky);
             }
 //            SECTION("TPZFBMatrix"){
-//                TestingInverseWithAutoFill<TPZFBMatrix<TVar>,TVar>(dim, 1, ECholesky);
+//                TestingInverseWithAutoFill<TPZFBMatrix<TVar>,TVar>(dim, SymProp::Herm, ECholesky);
 //            }
             SECTION("TPZSBMatrix"){
-                TestingInverseWithAutoFill<TPZSBMatrix<TVar>,TVar>(dim, 1,ECholesky);
+                TestingInverseWithAutoFill<TPZSBMatrix<TVar>,TVar>(dim, SymProp::Herm,ECholesky);
             }
             SECTION("TPZSkylMatrix"){
-                TestingInverseWithAutoFill<TPZSkylMatrix<TVar>,TVar>(dim, 1,ECholesky);
+                TestingInverseWithAutoFill<TPZSkylMatrix<TVar>,TVar>(dim, SymProp::Herm,ECholesky);
             }
             SECTION("TPZNSymSkylMatrix"){
-                TestingInverseWithAutoFill<TPZSkylMatrix<TVar>,TVar>(dim, 1,ECholesky);
+                TestingInverseWithAutoFill<TPZSkylMatrix<TVar>,TVar>(dim, SymProp::Herm,ECholesky);
             }
             
         }
@@ -253,59 +253,59 @@ void TestSVD(int nrows, int ncols);
 #ifdef PZ_USING_MKL
             if constexpr (std::is_same<RTVar,double>::value){
                 SECTION("TPZSYsmpMatrix"){
-                    TestingInverseWithAutoFill<TPZSYsmpMatrixPardiso<TVar>,TVar>(dim, 1, ELDLt);
+                  TestingInverseWithAutoFill<TPZSYsmpMatrixPardiso<TVar>,TVar>(dim, SymProp::Herm, ELDLt);
                 }
             }
 #endif
             SECTION("TPZFMatrix"){
-                TestingInverseWithAutoFill<TPZFMatrix<TVar>,TVar>(dim, 1, ELDLt);
+                TestingInverseWithAutoFill<TPZFMatrix<TVar>,TVar>(dim, SymProp::Herm, ELDLt);
             }
             SECTION("TPZSFMatrix"){
-                TestingInverseWithAutoFill<TPZSFMatrix<TVar>,TVar>(dim, 1, ELDLt);
+                TestingInverseWithAutoFill<TPZSFMatrix<TVar>,TVar>(dim, SymProp::Herm, ELDLt);
             }
 //            SECTION("TPZFBMatrix"){
-//                TestingInverseWithAutoFill<TPZFBMatrix<TVar>,TVar>(dim, 1, ECholesky);
+//                TestingInverseWithAutoFill<TPZFBMatrix<TVar>,TVar>(dim, SymProp::Herm, ECholesky);
 //            }
             SECTION("TPZSBMatrix"){
-                TestingInverseWithAutoFill<TPZSBMatrix<TVar>,TVar>(dim, 1, ELDLt);
+                TestingInverseWithAutoFill<TPZSBMatrix<TVar>,TVar>(dim, SymProp::Herm, ELDLt);
             }
             SECTION("TPZSkylMatrix"){
-                TestingInverseWithAutoFill<TPZSkylMatrix<TVar>,TVar>(dim, 1,ELDLt);
+                TestingInverseWithAutoFill<TPZSkylMatrix<TVar>,TVar>(dim, SymProp::Herm,ELDLt);
             }
             SECTION("TPZNSymSkylMatrix"){
-                TestingInverseWithAutoFill<TPZSkylMatrix<TVar>,TVar>(dim, 1,ELDLt);
+                TestingInverseWithAutoFill<TPZSkylMatrix<TVar>,TVar>(dim, SymProp::Herm,ELDLt);
             }
         }
         SECTION("LU"){
             SECTION("TPZFMatrix"){
-                TestingInverseWithAutoFill<TPZFMatrix<TVar>,TVar>(dim, 0, ELU);
-                TestingInverseWithAutoFill<TPZFMatrix<TVar>,TVar>(dim, 1, ELU);
+                TestingInverseWithAutoFill<TPZFMatrix<TVar>,TVar>(dim, SymProp::NonSym, ELU);
+                TestingInverseWithAutoFill<TPZFMatrix<TVar>,TVar>(dim, SymProp::Herm, ELU);
             }
             SECTION("TPZFBMatrix"){
-                TestingInverseWithAutoFill<TPZFBMatrix<TVar>,TVar>(dim, 0, ELU);
-                TestingInverseWithAutoFill<TPZFBMatrix<TVar>,TVar>(dim, 1, ELU);
+                TestingInverseWithAutoFill<TPZFBMatrix<TVar>,TVar>(dim, SymProp::NonSym, ELU);
+                TestingInverseWithAutoFill<TPZFBMatrix<TVar>,TVar>(dim, SymProp::Herm, ELU);
             }
             SECTION("TPZBlockDiagonal"){
-                TestingInverseWithAutoFill<TPZBlockDiagonal<TVar>,TVar>(dim, 0,ELU);
-                TestingInverseWithAutoFill<TPZBlockDiagonal<TVar>,TVar>(dim, 1,ELU);
+                TestingInverseWithAutoFill<TPZBlockDiagonal<TVar>,TVar>(dim, SymProp::NonSym,ELU);
+                TestingInverseWithAutoFill<TPZBlockDiagonal<TVar>,TVar>(dim, SymProp::Herm,ELU);
             }
         
             SECTION("TPZFNMatrix"){
-                TestingInverseWithAutoFill<TPZFNMatrix<9,TVar>,TVar>(dim, 0, ELU);
-                TestingInverseWithAutoFill<TPZFNMatrix<9,TVar>,TVar>(dim, 1, ELU);
+                TestingInverseWithAutoFill<TPZFNMatrix<9,TVar>,TVar>(dim, SymProp::NonSym, ELU);
+                TestingInverseWithAutoFill<TPZFNMatrix<9,TVar>,TVar>(dim, SymProp::Herm, ELU);
             }
         
             SECTION("TPZSkylNSymMatrix"){
-                TestingInverseWithAutoFill<TPZSkylNSymMatrix<TVar>,TVar>(dim, 0,ELU);
-                TestingInverseWithAutoFill<TPZSkylNSymMatrix<TVar>,TVar>(dim, 1,ELU);
+                TestingInverseWithAutoFill<TPZSkylNSymMatrix<TVar>,TVar>(dim, SymProp::NonSym,ELU);
+                TestingInverseWithAutoFill<TPZSkylNSymMatrix<TVar>,TVar>(dim, SymProp::Herm,ELU);
             }
 #ifdef PZ_USING_MKL
             if constexpr (std::is_same<RTVar,double>::value){
                 SECTION("TPZFYsmpMatrix"){
-                    TestingInverseWithAutoFill<TPZFYsmpMatrixPardiso<TVar>,TVar>(dim, 0, ELU);
+                    TestingInverseWithAutoFill<TPZFYsmpMatrixPardiso<TVar>,TVar>(dim, SymProp::NonSym, ELU);
                 }
                 SECTION("TPZFYsmpMatrix"){
-                    TestingInverseWithAutoFill<TPZFYsmpMatrixPardiso<TVar>,TVar>(dim, 1, ELU);
+                    TestingInverseWithAutoFill<TPZFYsmpMatrixPardiso<TVar>,TVar>(dim, SymProp::Herm, ELU);
                 }
             }
             
@@ -327,28 +327,32 @@ void TestSVD(int nrows, int ncols);
     void Add(){
       for (auto dim = 5; dim < 100; dim += 500) {
           SECTION("TPZFMatrix"){
-              TestingAdd<TPZFMatrix<TVar>, TVar>(10, dim, 0);
+              TestingAdd<TPZFMatrix<TVar>, TVar>(10, dim, SymProp::NonSym);
           }
           SECTION("TPZSFMatrix"){
-              TestingAdd<TPZSFMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingAdd<TPZSFMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingAdd<TPZSFMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           SECTION("TPZFBMatrix"){
-              TestingAdd<TPZFBMatrix<TVar>,TVar>(dim, dim, 0);
+              TestingAdd<TPZFBMatrix<TVar>,TVar>(dim, dim, SymProp::NonSym);
           }
           SECTION("TPZSBMatrix"){
-              TestingAdd<TPZSBMatrix<TVar>,TVar>(dim, dim,1);
+              TestingAdd<TPZSBMatrix<TVar>,TVar>(dim, dim,SymProp::Herm);
+              TestingAdd<TPZSBMatrix<TVar>,TVar>(dim, dim,SymProp::Sym);
           }
           SECTION("TPZFYsmpMatrix"){
-              TestingAdd<TPZFYsmpMatrix<TVar>, TVar>(10, dim, 0);
+              TestingAdd<TPZFYsmpMatrix<TVar>, TVar>(10, dim, SymProp::NonSym);
           }
           SECTION("TPZSYsmpMatrix"){
-              TestingAdd<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingAdd<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingAdd<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           // SECTION("TPZSkylNSymMatrix"){
-          //     TestingAdd<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, 0);
+          //     TestingAdd<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, SymProp::NonSym);
           // }
           SECTION("TPZSkylMatrix"){
-              TestingAdd<TPZSkylMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingAdd<TPZSkylMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingAdd<TPZSkylMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
       }
     }
@@ -357,28 +361,32 @@ void TestSVD(int nrows, int ncols);
     void Subtract(){
       for (auto dim = 5; dim < 100; dim += 500) {
           SECTION("TPZFMatrix"){
-              TestingSubtract<TPZFMatrix<TVar>, TVar>(10, dim, 0);
+              TestingSubtract<TPZFMatrix<TVar>, TVar>(10, dim, SymProp::NonSym);
           }
           SECTION("TPZSFMatrix"){
-              TestingSubtract<TPZSFMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingSubtract<TPZSFMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingSubtract<TPZSFMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           SECTION("TPZFBMatrix"){
-              TestingSubtract<TPZFBMatrix<TVar>,TVar>(dim, dim, 0);
+              TestingSubtract<TPZFBMatrix<TVar>,TVar>(dim, dim, SymProp::NonSym);
           }
           SECTION("TPZSBMatrix"){
-              TestingSubtract<TPZSBMatrix<TVar>,TVar>(dim, dim,1);
+              TestingSubtract<TPZSBMatrix<TVar>,TVar>(dim, dim,SymProp::Herm);
+              TestingSubtract<TPZSBMatrix<TVar>,TVar>(dim, dim,SymProp::Sym);
           }
           SECTION("TPZFYsmpMatrix"){
-              TestingSubtract<TPZFYsmpMatrix<TVar>, TVar>(10, dim, 0);
+              TestingSubtract<TPZFYsmpMatrix<TVar>, TVar>(10, dim, SymProp::NonSym);
           }
           SECTION("TPZSYsmpMatrix"){
-              TestingSubtract<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingSubtract<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingSubtract<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           // SECTION("TPZSkylNSymMatrix"){
-          //     TestingSubtract<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, 0);
+          //     TestingSubtract<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, SymProp::NonSym);
           // }
           SECTION("TPZSkylMatrix"){
-              TestingSubtract<TPZSkylMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingSubtract<TPZSkylMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingSubtract<TPZSkylMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
       }
     }
@@ -386,28 +394,32 @@ template<class TVar>
     void MultiplyByScalar(){
       for (auto dim = 5; dim < 100; dim += 500) {
           SECTION("TPZFMatrix"){
-              TestingMultiplyByScalar<TPZFMatrix<TVar>, TVar>(10, dim, 0);
+              TestingMultiplyByScalar<TPZFMatrix<TVar>, TVar>(10, dim, SymProp::NonSym);
           }
           SECTION("TPZSFMatrix"){
-              TestingMultiplyByScalar<TPZSFMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingMultiplyByScalar<TPZSFMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingMultiplyByScalar<TPZSFMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           SECTION("TPZFBMatrix"){
-              TestingMultiplyByScalar<TPZFBMatrix<TVar>,TVar>(dim, dim, 0);
+              TestingMultiplyByScalar<TPZFBMatrix<TVar>,TVar>(dim, dim, SymProp::NonSym);
           }
           SECTION("TPZSBMatrix"){
-              TestingMultiplyByScalar<TPZSBMatrix<TVar>,TVar>(dim, dim,1);
+              TestingMultiplyByScalar<TPZSBMatrix<TVar>,TVar>(dim, dim,SymProp::Herm);
+              TestingMultiplyByScalar<TPZSBMatrix<TVar>,TVar>(dim, dim,SymProp::Sym);
           }
           SECTION("TPZFYsmpMatrix"){
-              TestingMultiplyByScalar<TPZFYsmpMatrix<TVar>, TVar>(10, dim, 0);
+              TestingMultiplyByScalar<TPZFYsmpMatrix<TVar>, TVar>(10, dim, SymProp::NonSym);
           }
           SECTION("TPZSYsmpMatrix"){
-              TestingMultiplyByScalar<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingMultiplyByScalar<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingMultiplyByScalar<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           // SECTION("TPZSkylNSymMatrix"){
-          //     TestingMultiplyByScalar<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, 0);
+          //     TestingMultiplyByScalar<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, SymProp::NonSym);
           // }
           SECTION("TPZSkylMatrix"){
-              TestingMultiplyByScalar<TPZSkylMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingMultiplyByScalar<TPZSkylMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingMultiplyByScalar<TPZSkylMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
       }
     }
@@ -415,28 +427,32 @@ template<class TVar>
     void AddOperator(){
       for (auto dim = 5; dim < 100; dim += 500) {
           SECTION("TPZFMatrix"){
-              TestingAddOperator<TPZFMatrix<TVar>, TVar>(10, dim, 0);
+              TestingAddOperator<TPZFMatrix<TVar>, TVar>(10, dim, SymProp::NonSym);
           }
           SECTION("TPZSFMatrix"){
-              TestingAddOperator<TPZSFMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingAddOperator<TPZSFMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingAddOperator<TPZSFMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           SECTION("TPZFBMatrix"){
-              TestingAddOperator<TPZFBMatrix<TVar>,TVar>(dim, dim, 0);
+              TestingAddOperator<TPZFBMatrix<TVar>,TVar>(dim, dim, SymProp::NonSym);
           }
           SECTION("TPZSBMatrix"){
-              TestingAddOperator<TPZSBMatrix<TVar>,TVar>(dim, dim,1);
+              TestingAddOperator<TPZSBMatrix<TVar>,TVar>(dim, dim,SymProp::Herm);
+              TestingAddOperator<TPZSBMatrix<TVar>,TVar>(dim, dim,SymProp::Sym);
           }
           SECTION("TPZFYsmpMatrix"){
-              TestingAddOperator<TPZFYsmpMatrix<TVar>, TVar>(10, dim, 0);
+              TestingAddOperator<TPZFYsmpMatrix<TVar>, TVar>(10, dim, SymProp::NonSym);
           }
           SECTION("TPZSYsmpMatrix"){
-              TestingAddOperator<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingAddOperator<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingAddOperator<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           // SECTION("TPZSkylNSymMatrix"){
-          //     TestingAddOperator<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, 0);
+          //     TestingAddOperator<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, SymProp::NonSym);
           // }
           SECTION("TPZSkylMatrix"){
-              TestingAddOperator<TPZSkylMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingAddOperator<TPZSkylMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingAddOperator<TPZSkylMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
       }
     }
@@ -445,28 +461,32 @@ template<class TVar>
     void SubtractOperator(){
       for (auto dim = 5; dim < 100; dim += 500) {
           SECTION("TPZFMatrix"){
-              TestingSubtractOperator<TPZFMatrix<TVar>, TVar>(10, dim, 0);
+              TestingSubtractOperator<TPZFMatrix<TVar>, TVar>(10, dim, SymProp::NonSym);
           }
           SECTION("TPZSFMatrix"){
-              TestingSubtractOperator<TPZSFMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingSubtractOperator<TPZSFMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingSubtractOperator<TPZSFMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           SECTION("TPZFBMatrix"){
-              TestingSubtractOperator<TPZFBMatrix<TVar>,TVar>(dim, dim, 0);
+              TestingSubtractOperator<TPZFBMatrix<TVar>,TVar>(dim, dim, SymProp::NonSym);
           }
           SECTION("TPZSBMatrix"){
-              TestingSubtractOperator<TPZSBMatrix<TVar>,TVar>(dim, dim,1);
+              TestingSubtractOperator<TPZSBMatrix<TVar>,TVar>(dim, dim,SymProp::Herm);
+              TestingSubtractOperator<TPZSBMatrix<TVar>,TVar>(dim, dim,SymProp::Sym);
           }
           SECTION("TPZFYsmpMatrix"){
-              TestingSubtractOperator<TPZFYsmpMatrix<TVar>, TVar>(10, dim, 0);
+              TestingSubtractOperator<TPZFYsmpMatrix<TVar>, TVar>(10, dim, SymProp::NonSym);
           }
           SECTION("TPZSYsmpMatrix"){
-              TestingSubtractOperator<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingSubtractOperator<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingSubtractOperator<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           // SECTION("TPZSkylNSymMatrix"){
-          //     TestingSubtractOperator<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, 0);
+          //     TestingSubtractOperator<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, SymProp::NonSym);
           // }
           SECTION("TPZSkylMatrix"){
-              TestingSubtractOperator<TPZSkylMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingSubtractOperator<TPZSkylMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingSubtractOperator<TPZSkylMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
       }
     }
@@ -474,28 +494,32 @@ template<class TVar>
     void MultiplyByScalarOperator(){
       for (auto dim = 5; dim < 100; dim += 500) {
           SECTION("TPZFMatrix"){
-              TestingMultiplyByScalarOperator<TPZFMatrix<TVar>, TVar>(10, dim, 0);
+              TestingMultiplyByScalarOperator<TPZFMatrix<TVar>, TVar>(10, dim, SymProp::NonSym);
           }
           SECTION("TPZSFMatrix"){
-              TestingMultiplyByScalarOperator<TPZSFMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingMultiplyByScalarOperator<TPZSFMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingMultiplyByScalarOperator<TPZSFMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           SECTION("TPZFBMatrix"){
-              TestingMultiplyByScalarOperator<TPZFBMatrix<TVar>,TVar>(dim, dim, 0);
+              TestingMultiplyByScalarOperator<TPZFBMatrix<TVar>,TVar>(dim, dim, SymProp::NonSym);
           }
           SECTION("TPZSBMatrix"){
-              TestingMultiplyByScalarOperator<TPZSBMatrix<TVar>,TVar>(dim, dim,1);
+              TestingMultiplyByScalarOperator<TPZSBMatrix<TVar>,TVar>(dim, dim,SymProp::Herm);
+              TestingMultiplyByScalarOperator<TPZSBMatrix<TVar>,TVar>(dim, dim,SymProp::Sym);
           }
           SECTION("TPZFYsmpMatrix"){
-              TestingMultiplyByScalarOperator<TPZFYsmpMatrix<TVar>, TVar>(10, dim, 0);
+              TestingMultiplyByScalarOperator<TPZFYsmpMatrix<TVar>, TVar>(10, dim, SymProp::NonSym);
           }
           SECTION("TPZSYsmpMatrix"){
-              TestingMultiplyByScalarOperator<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingMultiplyByScalarOperator<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingMultiplyByScalarOperator<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           // SECTION("TPZSkylNSymMatrix"){
-          //     TestingMultiplyByScalarOperator<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, 0);
+          //     TestingMultiplyByScalarOperator<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, SymProp::NonSym);
           // }
           SECTION("TPZSkylMatrix"){
-              TestingMultiplyByScalarOperator<TPZSkylMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingMultiplyByScalarOperator<TPZSkylMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingMultiplyByScalarOperator<TPZSkylMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
       }
     }
@@ -504,31 +528,35 @@ template<class TVar>
     void MultiplyTranspose(){
       for (auto dim = 5; dim < 100; dim += 500) {
           SECTION("TPZFMatrix"){
-              TestingTransposeMultiply<TPZFMatrix<TVar>, TVar>(10, dim, 0);
+              TestingTransposeMultiply<TPZFMatrix<TVar>, TVar>(10, dim, SymProp::NonSym);
           }
           SECTION("TPZSFMatrix"){
-              TestingTransposeMultiply<TPZSFMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingTransposeMultiply<TPZSFMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingTransposeMultiply<TPZSFMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           SECTION("TPZFBMatrix"){
-              TestingTransposeMultiply<TPZFBMatrix<TVar>,TVar>(dim, dim, 0);
+              TestingTransposeMultiply<TPZFBMatrix<TVar>,TVar>(dim, dim, SymProp::NonSym);
           }
           SECTION("TPZSBMatrix"){
-              TestingTransposeMultiply<TPZSBMatrix<TVar>,TVar>(dim, dim,1);
+              TestingTransposeMultiply<TPZSBMatrix<TVar>,TVar>(dim, dim,SymProp::Herm);
+              TestingTransposeMultiply<TPZSBMatrix<TVar>,TVar>(dim, dim,SymProp::Sym);
           }
           SECTION("TPZFYsmpMatrix"){
-              TestingTransposeMultiply<TPZFYsmpMatrix<TVar>, TVar>(10, dim, 0);
+              TestingTransposeMultiply<TPZFYsmpMatrix<TVar>, TVar>(10, dim, SymProp::NonSym);
           }
           SECTION("TPZSYsmpMatrix"){
-              TestingTransposeMultiply<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingTransposeMultiply<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingTransposeMultiply<TPZSYsmpMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           SECTION("TPZSkylNSymMatrix"){
-              TestingTransposeMultiply<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, 0);
+              TestingTransposeMultiply<TPZSkylNSymMatrix<TVar>, TVar>(dim, dim, SymProp::NonSym);
           }
           SECTION("TPZSkylMatrix"){
-              TestingTransposeMultiply<TPZSkylMatrix<TVar>, TVar>(dim, dim, 1);
+              TestingTransposeMultiply<TPZSkylMatrix<TVar>, TVar>(dim, dim, SymProp::Herm);
+              TestingTransposeMultiply<TPZSkylMatrix<TVar>, TVar>(dim, dim, SymProp::Sym);
           }
           SECTION("TPZBlockDiagonal"){
-              TestingTransposeMultiply<TPZBlockDiagonal<TVar>, TVar>(dim, dim, 0);
+              TestingTransposeMultiply<TPZBlockDiagonal<TVar>, TVar>(dim, dim, SymProp::NonSym);
           }
 #ifdef PZ_USING_MKL
           //suported MKL types
@@ -539,10 +567,11 @@ template<class TVar>
                           (std::is_same_v<TVar,std::complex<double>>)
                          )){
             SECTION("TPZFYsmpMatrixPardiso"){
-              TestingTransposeMultiply<TPZFYsmpMatrixPardiso<TVar>, TVar>(dim, dim, 0);
+              TestingTransposeMultiply<TPZFYsmpMatrixPardiso<TVar>, TVar>(dim, dim, SymProp::NonSym);
             }
             SECTION("TPZSYsmpMatrixPardiso"){
-              TestingTransposeMultiply<TPZSYsmpMatrixPardiso<TVar>, TVar>(dim, dim, 1);
+                TestingTransposeMultiply<TPZSYsmpMatrixPardiso<TVar>, TVar>(dim, dim, SymProp::Herm);
+                TestingTransposeMultiply<TPZSYsmpMatrixPardiso<TVar>, TVar>(dim, dim, SymProp::Sym);
             }
           }
 #endif
@@ -553,28 +582,32 @@ template<class TVar>
     void Multiply(){
       for (auto dim = 20; dim < 100; dim += 500) {
           SECTION("TPZFMatrix"){
-              TestingMultiplyWithAutoFill<TPZFMatrix<TVar>, TVar>(dim, 0);
+              TestingMultiplyWithAutoFill<TPZFMatrix<TVar>, TVar>(dim, SymProp::NonSym);
           }
           SECTION("TPZSFMatrix"){
-              TestingMultiplyWithAutoFill<TPZSFMatrix<TVar>, TVar>(dim, 1);
+              TestingMultiplyWithAutoFill<TPZSFMatrix<TVar>, TVar>(dim, SymProp::Herm);
+              TestingMultiplyWithAutoFill<TPZSFMatrix<TVar>, TVar>(dim, SymProp::Sym);
           }
           SECTION("TPZFBMatrix"){
-              TestingMultiplyWithAutoFill<TPZFBMatrix<TVar>,TVar>(dim, 0);
+              TestingMultiplyWithAutoFill<TPZFBMatrix<TVar>,TVar>(dim, SymProp::NonSym);
           }
           SECTION("TPZSBMatrix"){
-              TestingMultiplyWithAutoFill<TPZSBMatrix<TVar>,TVar>(dim,1);
+              TestingMultiplyWithAutoFill<TPZSBMatrix<TVar>,TVar>(dim,SymProp::Herm);
+              TestingMultiplyWithAutoFill<TPZSBMatrix<TVar>,TVar>(dim,SymProp::Sym);
           }
           SECTION("TPZFYsmpMatrix"){
-              TestingMultiplyWithAutoFill<TPZFYsmpMatrix<TVar>, TVar>(dim, 0);
+              TestingMultiplyWithAutoFill<TPZFYsmpMatrix<TVar>, TVar>(dim, SymProp::NonSym);
           }
           SECTION("TPZSYsmpMatrix"){
-              TestingMultiplyWithAutoFill<TPZSYsmpMatrix<TVar>, TVar>(dim, 1);
+              TestingMultiplyWithAutoFill<TPZSYsmpMatrix<TVar>, TVar>(dim, SymProp::Herm);
+              TestingMultiplyWithAutoFill<TPZSYsmpMatrix<TVar>, TVar>(dim, SymProp::Sym);
           }
           SECTION("TPZSkylNSymMatrix"){
-              TestingMultiplyWithAutoFill<TPZSkylNSymMatrix<TVar>, TVar>(dim, 0);
+              TestingMultiplyWithAutoFill<TPZSkylNSymMatrix<TVar>, TVar>(dim, SymProp::NonSym);
           }
           SECTION("TPZSkylMatrix"){
-              TestingMultiplyWithAutoFill<TPZSkylMatrix<TVar>, TVar>(dim, 1);
+              TestingMultiplyWithAutoFill<TPZSkylMatrix<TVar>, TVar>(dim, SymProp::Herm);
+              TestingMultiplyWithAutoFill<TPZSkylMatrix<TVar>, TVar>(dim, SymProp::Sym);
           }
 #ifdef PZ_USING_MKL
           //suported MKL types
@@ -585,10 +618,11 @@ template<class TVar>
                           (std::is_same_v<TVar,std::complex<double>>)
                          )){
             SECTION("TPZFYsmpMatrixPardiso"){
-              TestingMultiplyWithAutoFill<TPZFYsmpMatrixPardiso<TVar>, TVar>(dim, 0);
+              TestingMultiplyWithAutoFill<TPZFYsmpMatrixPardiso<TVar>, TVar>(dim, SymProp::NonSym);
             }
             SECTION("TPZSYsmpMatrixPardiso"){
-              TestingMultiplyWithAutoFill<TPZSYsmpMatrixPardiso<TVar>, TVar>(dim, 1);
+                TestingMultiplyWithAutoFill<TPZSYsmpMatrixPardiso<TVar>, TVar>(dim, SymProp::Herm);
+                TestingMultiplyWithAutoFill<TPZSYsmpMatrixPardiso<TVar>, TVar>(dim, SymProp::Sym);
             }
           }
 #endif
@@ -627,31 +661,35 @@ template<class TVar>
     
     template<class TVar>
     void DiagonalDominant(){
-        bool isSymmetric{false};
+        auto sp = SymProp::NonSym;
         SECTION("TPZFMatrix"){            
-            TestGeneratingDiagonalDominantMatrix<TPZFMatrix<TVar>>(isSymmetric);
+            TestGeneratingDiagonalDominantMatrix<TPZFMatrix<TVar>>(SymProp::NonSym);
         }
         SECTION("TPZFBMatrix"){
-            TestGeneratingDiagonalDominantMatrix<TPZFBMatrix<TVar>>(isSymmetric);
+            TestGeneratingDiagonalDominantMatrix<TPZFBMatrix<TVar>>(SymProp::NonSym);
         }
         SECTION("TPZSkylNSymMatrix"){
-            TestGeneratingDiagonalDominantMatrix<TPZSkylNSymMatrix<TVar>>(isSymmetric);
+            TestGeneratingDiagonalDominantMatrix<TPZSkylNSymMatrix<TVar>>(SymProp::NonSym);
         }
         SECTION("TPZFYsmpMatrix"){
-            TestGeneratingDiagonalDominantMatrix<TPZFYsmpMatrix<TVar>>(isSymmetric);
+            TestGeneratingDiagonalDominantMatrix<TPZFYsmpMatrix<TVar>>(SymProp::NonSym);
         }
-        isSymmetric = true;
+
         SECTION("TPZSFMatrix"){
-            TestGeneratingDiagonalDominantMatrix<TPZSFMatrix<TVar>>(isSymmetric);
+            TestGeneratingDiagonalDominantMatrix<TPZSFMatrix<TVar>>(SymProp::Sym);
+            TestGeneratingDiagonalDominantMatrix<TPZSFMatrix<TVar>>(SymProp::Herm);
         }
         SECTION("TPZSBMatrix"){
-            TestGeneratingDiagonalDominantMatrix<TPZSBMatrix<TVar>>(isSymmetric);
+            TestGeneratingDiagonalDominantMatrix<TPZSBMatrix<TVar>>(SymProp::Sym);
+            TestGeneratingDiagonalDominantMatrix<TPZSBMatrix<TVar>>(SymProp::Herm);
         }
         SECTION("TPZSkylMatrix"){
-            TestGeneratingDiagonalDominantMatrix<TPZSkylMatrix<TVar>>(isSymmetric);
+            TestGeneratingDiagonalDominantMatrix<TPZSkylMatrix<TVar>>(SymProp::Sym);
+            TestGeneratingDiagonalDominantMatrix<TPZSkylMatrix<TVar>>(SymProp::Herm);
         }
         SECTION("TPZSYsmpMatrix"){
-            TestGeneratingDiagonalDominantMatrix<TPZSYsmpMatrix<TVar>>(isSymmetric);
+            TestGeneratingDiagonalDominantMatrix<TPZSYsmpMatrix<TVar>>(SymProp::Sym);
+            TestGeneratingDiagonalDominantMatrix<TPZSYsmpMatrix<TVar>>(SymProp::Herm);
         }
         SECTION("TPZBlockDiagonal"){
             // Unit Test for block diagonal matrix
@@ -659,7 +697,7 @@ template<class TVar>
             for (int i = 0; i < 13; i++)
                 blocks[i] = 15 + (i % 4);
             TPZBlockDiagonal<TVar> mabd(blocks);
-            mabd.AutoFill(50, 50, 0);
+            mabd.AutoFill(50, 50, SymProp::NonSym);
             CheckDiagonalDominantMatrix(mabd);
         }
     }
@@ -667,8 +705,8 @@ template<class TVar>
     template <class TVar>
     void MultiplyOperatorWithAutoFill() {
       for (int dim = 3; dim < 100; dim += 5) {
-        TestingMultiplyOperatorWithAutoFill<TPZFMatrix<TVar>, TVar>(dim, 0);
-        TestingMultiplyOperatorWithAutoFill<TPZFNMatrix<20,TVar>, TVar>(dim, 0);
+        TestingMultiplyOperatorWithAutoFill<TPZFMatrix<TVar>, TVar>(dim, SymProp::NonSym);
+        TestingMultiplyOperatorWithAutoFill<TPZFNMatrix<20,TVar>, TVar>(dim, SymProp::NonSym);
       }
     }
     
@@ -676,7 +714,7 @@ template<class TVar>
     void TransposeWithAutoFill() {
       for (int rows = 3; rows < 4; rows += 5) {
         for (int cols = 3; cols < 100; cols += 5) {
-          TestingTransposeWithAutoFill<TPZFMatrix<TVar>, TVar>(rows, cols, 0);
+          TestingTransposeWithAutoFill<TPZFMatrix<TVar>, TVar>(rows, cols, SymProp::NonSym);
         }
       }
     }
@@ -685,31 +723,31 @@ template<class TVar>
     void TestMultAdd(){
       for (int dim = 5; dim < 6; dim += 10) {
           SECTION("TPZFMatrix"){
-              TestingMultAdd<TPZFMatrix<TVar>, TVar>(dim, 0, ELU);
+              TestingMultAdd<TPZFMatrix<TVar>, TVar>(dim, SymProp::NonSym, ELU);
           }
           SECTION("TPZSFMatrix"){
-              TestingMultAdd<TPZSFMatrix<TVar>, TVar>(dim, 1, ECholesky);
+              TestingMultAdd<TPZSFMatrix<TVar>, TVar>(dim, SymProp::Herm, ECholesky);
           }
           SECTION("TPZFBMatrix"){
-              TestingMultAdd<TPZFBMatrix<TVar>, TVar>(dim, 0, ELU);
+              TestingMultAdd<TPZFBMatrix<TVar>, TVar>(dim, SymProp::NonSym, ELU);
           }
           SECTION("TPZSBMatrix"){
-              TestingMultAdd<TPZSBMatrix<TVar>, TVar>(dim, 1, ECholesky);
+              TestingMultAdd<TPZSBMatrix<TVar>, TVar>(dim, SymProp::Herm, ECholesky);
           }
           SECTION("TPZSkylMatrix"){
-              TestingMultAdd<TPZSkylMatrix<TVar>, TVar>(dim, 1, ECholesky);
+              TestingMultAdd<TPZSkylMatrix<TVar>, TVar>(dim, SymProp::Herm, ECholesky);
           }
           SECTION("TPZSkylNSymMatrix"){
-              TestingMultAdd<TPZSkylNSymMatrix<TVar>, TVar>(dim, 0, ELU);
+              TestingMultAdd<TPZSkylNSymMatrix<TVar>, TVar>(dim, SymProp::NonSym, ELU);
           }
           SECTION("TPZSYsmpMatrix"){
-              TestingMultAdd<TPZSYsmpMatrix<TVar>, TVar>(dim, 1, ECholesky);
+              TestingMultAdd<TPZSYsmpMatrix<TVar>, TVar>(dim, SymProp::Herm, ECholesky);
           }
           SECTION("TPZFYsmpMatrix"){
-              TestingMultAdd<TPZFYsmpMatrix<TVar>, TVar>(dim, 0, ELU);
+              TestingMultAdd<TPZFYsmpMatrix<TVar>, TVar>(dim, SymProp::NonSym, ELU);
           }
           SECTION("TPZBlockDiagonal"){
-              TestingMultAdd<TPZBlockDiagonal<TVar>, TVar>(dim, 0, ELU);
+              TestingMultAdd<TPZBlockDiagonal<TVar>, TVar>(dim, SymProp::NonSym, ELU);
           }
 #ifdef PZ_USING_MKL
           //suported MKL types
@@ -720,10 +758,10 @@ template<class TVar>
                           (std::is_same_v<TVar,std::complex<double>>)
                          )){
             SECTION("TPZFYsmpMatrixPardiso"){
-              TestingMultAdd<TPZFYsmpMatrixPardiso<TVar>, TVar>(dim, 0, ELU);
+              TestingMultAdd<TPZFYsmpMatrixPardiso<TVar>, TVar>(dim, SymProp::NonSym, ELU);
             }
             SECTION("TPZSYsmpMatrixPardiso"){
-              TestingMultAdd<TPZSYsmpMatrixPardiso<TVar>, TVar>(dim, 1, ECholesky);
+              TestingMultAdd<TPZSYsmpMatrixPardiso<TVar>, TVar>(dim, SymProp::Herm, ECholesky);
             }
           }
 #endif
@@ -733,10 +771,12 @@ template<class TVar>
     template <class TVar> void GeneralisedEigenvaluesAutoFill() {
         for (int dim = 5; dim < 6; dim += 10) {
             SECTION("TPZFMatrix"){
-                TestingGeneralisedEigenValuesWithAutoFill<TPZFMatrix<TVar>, TVar>(dim, 1);
+                TestingGeneralisedEigenValuesWithAutoFill<TPZFMatrix<TVar>, TVar>(dim, SymProp::Sym);
+                TestingGeneralisedEigenValuesWithAutoFill<TPZFMatrix<TVar>, TVar>(dim, SymProp::Herm);
             }
             SECTION("TPZSBMatrix"){
-                TestingGeneralisedEigenValuesWithAutoFill<TPZSBMatrix<TVar>, TVar>(dim, 1);
+                TestingGeneralisedEigenValuesWithAutoFill<TPZSBMatrix<TVar>, TVar>(dim, SymProp::Sym);
+                TestingGeneralisedEigenValuesWithAutoFill<TPZSBMatrix<TVar>, TVar>(dim, SymProp::Herm);
             }
         }
     }
@@ -744,14 +784,17 @@ template<class TVar>
     template<class TVar>
     void EigenDecompositionAutoFill(){
         for (int dim = 5; dim < 6; dim += 10) {
+            
             SECTION("TPZSBMatrix sym"){
-                TestingEigenDecompositionAutoFill<TPZSBMatrix<TVar>, TVar>(dim, 1);
+                TestingEigenDecompositionAutoFill<TPZSBMatrix<TVar>, TVar>(dim, SymProp::Sym);
+                TestingEigenDecompositionAutoFill<TPZSBMatrix<TVar>, TVar>(dim, SymProp::Herm);
             }
             SECTION("TPZFMatrix sym"){
-                TestingEigenDecompositionAutoFill<TPZFMatrix<TVar>, TVar>(dim, 1);
+                TestingEigenDecompositionAutoFill<TPZFMatrix<TVar>, TVar>(dim, SymProp::Sym);
+                TestingEigenDecompositionAutoFill<TPZFMatrix<TVar>, TVar>(dim, SymProp::Herm);
             }
             SECTION("TPZFMatrix nsym"){
-                TestingEigenDecompositionAutoFill<TPZFMatrix<TVar>, TVar>(dim, 0);
+                TestingEigenDecompositionAutoFill<TPZFMatrix<TVar>, TVar>(dim, SymProp::NonSym);
             }
         }
     }
@@ -1082,12 +1125,12 @@ void CheckDiagonalDominantMatrix(matx &matr) {
 }
 
 template<class matx>
-void TestGeneratingDiagonalDominantMatrix(bool symmetric){
+void TestGeneratingDiagonalDominantMatrix(SymProp sp){
     for(int dim = 3; dim<100;dim+=7){
         const auto nrows = dim;
         const auto ncols = dim;
         matx mat;
-        mat.AutoFill(nrows,ncols,symmetric);
+        mat.AutoFill(nrows,ncols,sp);
         CheckDiagonalDominantMatrix(mat);
     }
 }
@@ -1096,9 +1139,8 @@ template <class matx, class TVar>
 void TestGeneratingHermitianMatrix() {
     const auto nrows = 10;
     const auto ncols = 10;
-    constexpr bool symmetric{true};
     matx mat;
-    mat.AutoFill(nrows,ncols,symmetric);
+    mat.AutoFill(nrows,ncols,SymProp::Herm);
     for (auto i = 0; i < nrows; i++) {
         auto j = i;
         if constexpr (is_complex<TVar>::value){
@@ -1114,16 +1156,16 @@ void TestGeneratingHermitianMatrix() {
 }
 
 template <class matx, class TVar>
-void TestingInverseWithAutoFill(int dim, int symmetric, DecomposeType dec) {
+void TestingInverseWithAutoFill(int dim, SymProp sp, DecomposeType dec) {
   int i, j;
   matx ma;
-  ma.AutoFill(dim, dim, symmetric);
+  ma.AutoFill(dim, dim, sp);
   TestingInverse<matx,TVar>(ma,dec);
 }
 
 template <class matx, class TVar>
 void TestingInverse(matx ma, DecomposeType dec) {
-  const bool symmetric = ma.IsSymmetric();
+  const auto symmetric = SymPropName(ma.IsSymmetric());
   if(ma.Rows() != ma.Cols()){
     const bool is_square_mat{false};
     REQUIRE(is_square_mat);
@@ -1166,10 +1208,10 @@ void TestingInverse(matx ma, DecomposeType dec) {
 }
 
 template <class matx, class TVar>
-void TestingMultiplyOperatorWithAutoFill(int dim, int symmetric) {
+void TestingMultiplyOperatorWithAutoFill(int dim, SymProp sp) {
     // ma times inv must to be a identity matrix
     matx ma;
-    ma.AutoFill(dim, dim, symmetric);
+    ma.AutoFill(dim, dim, sp);
 
     TPZFNMatrix<10,TVar> duplicate(ma);
     TPZFNMatrix<10,TVar> square, square2;
@@ -1194,10 +1236,11 @@ void TestingMultiplyOperatorWithAutoFill(int dim, int symmetric) {
 }
 
 template <class matx, class TVar>
-void TestingMultiplyWithAutoFill(int dim, int symmetric) {
+void TestingMultiplyWithAutoFill(int dim, SymProp sp) {
+    const auto sp_str = SymPropName(sp);
     // ma times inv must to be a identity matrix
     matx ma;
-    ma.AutoFill(dim, dim, symmetric);
+    ma.AutoFill(dim, dim, sp);
 
     TPZFMatrix<TVar> duplicate(ma), square, square2;
 
@@ -1213,7 +1256,7 @@ void TestingMultiplyWithAutoFill(int dim, int symmetric) {
     for (int i = 0; i < dim; i++) {
         for (int j = 0; j < dim; j++) {
             const auto diff = fabs(square(i, j) - square2(i, j));
-            CAPTURE(i,j,square(i,j), square2(i,j), diff, tol, dim, symmetric, typeid(matx).name());
+            CAPTURE(i,j,square(i,j), square2(i,j), diff, tol, dim, sp_str, typeid(matx).name());
             REQUIRE((diff == Approx(0).margin(tol)));
             if(diff > tol){
                 check = false;
@@ -1296,7 +1339,7 @@ void TestingDotNorm(int dim){
 
   
 template <class matx, class TVar>
-void TestingAdd(int row, int col, int symmetric) {
+void TestingAdd(int row, int col, SymProp symmetric) {
   auto oldPrecision = Catch::StringMaker<RTVar>::precision;
   Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
   matx ma1, res;
@@ -1325,11 +1368,11 @@ void TestingAdd(int row, int col, int symmetric) {
 }
 
 template <class matx, class TVar>
-void TestingSubtract(int row, int col, int symmetric) {
+void TestingSubtract(int row, int col, SymProp sp) {
   auto oldPrecision = Catch::StringMaker<RTVar>::precision;
   Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
   matx ma1, res;
-  ma1.AutoFill(row, col, symmetric);
+  ma1.AutoFill(row, col, sp);
   //this is to ensure that they have the same sparsity pattern
   matx ma2(ma1);
 
@@ -1354,11 +1397,11 @@ void TestingSubtract(int row, int col, int symmetric) {
 }
 
 template <class matx, class TVar>
-void TestingMultiplyByScalar(int row, int col, int symmetric) {
+void TestingMultiplyByScalar(int row, int col, SymProp sp) {
   auto oldPrecision = Catch::StringMaker<RTVar>::precision;
   Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
   matx ma1, res;
-  ma1.AutoFill(row, col, symmetric);
+  ma1.AutoFill(row, col, sp);
   
   const TVar val = [](){
     constexpr RTVar lower_bound = 0;
@@ -1390,11 +1433,11 @@ void TestingMultiplyByScalar(int row, int col, int symmetric) {
 }
 
 template <class matx, class TVar>
-void TestingAddOperator(int row, int col, int symmetric) {
+void TestingAddOperator(int row, int col, SymProp sp) {
   auto oldPrecision = Catch::StringMaker<RTVar>::precision;
   Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
   matx ma1;
-  ma1.AutoFill(row, col, symmetric);
+  ma1.AutoFill(row, col, sp);
   //this is to ensure that they have the same sparsity pattern
   matx ma2(ma1);
 
@@ -1420,11 +1463,11 @@ void TestingAddOperator(int row, int col, int symmetric) {
 }
 
 template <class matx, class TVar>
-void TestingSubtractOperator(int row, int col, int symmetric) {
+void TestingSubtractOperator(int row, int col, SymProp sp) {
   auto oldPrecision = Catch::StringMaker<RTVar>::precision;
   Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
   matx ma1;
-  ma1.AutoFill(row, col, symmetric);
+  ma1.AutoFill(row, col, sp);
   //this is to ensure that they have the same sparsity pattern
   matx ma2(ma1);
 
@@ -1449,11 +1492,11 @@ void TestingSubtractOperator(int row, int col, int symmetric) {
 }
 
 template <class matx, class TVar>
-void TestingMultiplyByScalarOperator(int row, int col, int symmetric) {
+void TestingMultiplyByScalarOperator(int row, int col, SymProp sp) {
   auto oldPrecision = Catch::StringMaker<RTVar>::precision;
   Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
   matx ma1;
-  ma1.AutoFill(row, col, symmetric);
+  ma1.AutoFill(row, col, sp);
   
   const TVar val = [](){
     constexpr RTVar lower_bound = 0;
@@ -1486,9 +1529,9 @@ void TestingMultiplyByScalarOperator(int row, int col, int symmetric) {
 
   
 template <class matx, class TVar>
-void TestingTransposeMultiply(int row, int col, int symmetric) {
+void TestingTransposeMultiply(int row, int col, SymProp sp) {
     matx ma;
-    ma.AutoFill(row, col, symmetric);
+    ma.AutoFill(row, col, sp);
 
     TPZFMatrix<TVar> duplicate(ma);
     TPZFMatrix<TVar> dup2(ma), square(col, col), square2(col, col);
@@ -1526,11 +1569,11 @@ void TestingTransposeMultiply(int row, int col, int symmetric) {
 }
 
 template <class matx, class TVar>
-void TestingTransposeWithAutoFill(int rows, int cols, int symmetric) {
+void TestingTransposeWithAutoFill(int rows, int cols, SymProp sp) {
     int i, j;
 
     matx ma;
-    ma.AutoFill(rows, cols, symmetric);
+    ma.AutoFill(rows, cols, sp);
 
     matx matransp(cols, rows);
     matx matransptransp(ma);
@@ -1546,11 +1589,13 @@ void TestingTransposeWithAutoFill(int rows, int cols, int symmetric) {
 }
 
 template <class matx, class TVar>
-void TestingMultAdd(int dim, int symmetric, DecomposeType dec) {
+void TestingMultAdd(int dim, SymProp sp, DecomposeType dec) {
+    const auto str_sp = SymPropName(sp);
+    
     int i, j;
 
     matx ma;
-    ma.AutoFill(dim, dim, symmetric);
+    ma.AutoFill(dim, dim, sp);
 
     TPZFMatrix<TVar> cpy(ma), cpy2(ma);
     TPZFMatrix<TVar> inv(dim, dim);
@@ -1575,7 +1620,7 @@ void TestingMultAdd(int dim, int symmetric, DecomposeType dec) {
         for (j = 0; j < dim; j++) {
             TVar zval = z(i, j);
             if (!IsZero(zval/tol)) {
-                CAPTURE(dim,symmetric,dec);
+                CAPTURE(dim,str_sp,dec);
                 CAPTURE(zval,tol);
                 std::cout << "i " << i << " j " << j << " zval " << zval << std::endl;
                 if(check) {
@@ -1594,12 +1639,12 @@ void TestingMultAdd(int dim, int symmetric, DecomposeType dec) {
 #ifdef PZ_USING_LAPACK
 
 template <class matx, class TVar>
-void TestingGeneralisedEigenValuesWithAutoFill(int dim, int symmetric) {
+void TestingGeneralisedEigenValuesWithAutoFill(int dim, SymProp sp) {
   auto oldPrecision = Catch::StringMaker<RTVar>::precision;
   Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
   matx ma,mb;
-  ma.AutoFill(dim, dim, symmetric);
-  mb.AutoFill(dim, dim, symmetric);
+  ma.AutoFill(dim, dim, sp);
+  mb.AutoFill(dim, dim, sp);
 
   TPZFMatrix<CTVar> cpma(dim, dim), cpmb(dim,dim);
   for (int i = 0; i < dim; i++) {
@@ -1731,11 +1776,11 @@ void BasicEigenTests() {
 }
   
 template <class matx, class TVar>
-void TestingEigenDecompositionAutoFill(int dim, int symmetric) {
+void TestingEigenDecompositionAutoFill(int dim, SymProp sp) {
   auto oldPrecision = Catch::StringMaker<RTVar>::precision;
   Catch::StringMaker<RTVar>::precision = std::numeric_limits<RTVar>::max_digits10;
   matx ma;
-  ma.AutoFill(dim, dim, symmetric);
+  ma.AutoFill(dim, dim, sp);
 
   TPZFMatrix<CTVar> cpma(dim, dim);
   for (int i = 0; i < dim; i++) {
@@ -1792,7 +1837,7 @@ void TestSVD_Simple(int nrows, int ncols) {
 
 	
 	mA.Resize(nrows,ncols);
-	mA.AutoFill(nrows,ncols,false);
+	mA.AutoFill(nrows,ncols,SymProp::NonSym);
 	mA_copy = mA;
 	mA.SingularValueDecomposition(U,S,VT,'A','A');
 	// S only gets the diagonal of Sigma
@@ -1997,7 +2042,7 @@ void TestSVD_Projection(int nrows, int ncols){
 		attempts++;
 
 		// Auto generate a random matrix
-		mA.AutoFill(nrows,ncols,false);
+		mA.AutoFill(nrows,ncols,SymProp::NonSym);
 			min = std::min(nrows,ncols);
 		    max = std::max(nrows,ncols);
 		for(int i=0; i<max; i++){
@@ -2073,7 +2118,7 @@ void TestSVD_Resizing(int nrows, int ncols){
 
 	TMatrix Sigma(nrows,ncols); 
 
-	mA.AutoFill(nrows,ncols,false);
+	mA.AutoFill(nrows,ncols,SymProp::NonSym);
 	mA_copy = mA;
 	int m = mA.Rows();
 	int n = mA.Cols();
@@ -2175,7 +2220,7 @@ void SparseBlockDiagInverse(){
   constexpr int bsize = 2;
 
   TPZFMatrix<TVar> fmat(neq,neq);
-  fmat.AutoFill(neq, neq, 0);
+  fmat.AutoFill(neq, neq, SymProp::NonSym);
   //now we will extract a few blocks from the full matrix
   //non-null equations
   TPZVec<int64_t> blockgraph =
@@ -2215,7 +2260,7 @@ void SparseBlockDiagInverse(){
   //rhs, initial solution, residual and sol update
   TPZFMatrix<TVar> rhs(neq,1,0), u0(neq,1,0), res(neq,1,0),
     du(neq,1,0), resblck(neq,1,0);
-  rhs.AutoFill(neq,1,0);
+  rhs.AutoFill(neq,1,SymProp::NonSym);
 
   fmat.Residual(u0, rhs, res);
 

--- a/UnitTest_PZ/TestTensor/TestTensor.cpp
+++ b/UnitTest_PZ/TestTensor/TestTensor.cpp
@@ -84,7 +84,7 @@ void TestingEigenDecompositionThreeDistinct() {
 template <class TTensor, class TNumber>
 void TestingEigenDecompositionAutoFill() {
     TPZFMatrix<TNumber> ma;
-    ma.AutoFill(3, 3, true);
+    ma.AutoFill(3, 3, SymProp::Herm);
 
     TTensor tensor(ma);
 


### PR DESCRIPTION
This PR aims to adopt the distinction between symmetric and hermitian properties for complex-valued matrices.

The biggest changes are listed below

- enum class `SymProp` for symmetry properties ( `NonSym`, `Sym`, `Herm`)
- `TPZBaseMatrix::IsSymmetric()` is now `TPZBaseMatrix::GetSymmetry()`
- Adds `TPZBaseMatrix::SetSymmetry(SymProp)` and correspondent `TPZBaseMatrix::fSymProp` attribute
- `TPZBaseMatrix::AutoFill` now generates matrices with the three symmetry properties
- `PardisoSolver<T>::SetMatrixType` will always assume symmetric sparsity pattern

Adjustments were made in the library and additional unit tests for new matrix types (complex symmetric) were added.

Regarding the `TPZBaseMatrix::fSymProp` attribute, checks were performed in symmetric storage matrices as to prevent setting them to `SymProp::NonSym`. Therefore, the `GetSymmetry`(formed `IsSymmetric`) method is no longer virtual, however the `SetSymmetry` method is.

Setting symmetry properties of the matrix after the assemble and before additional operations (multiplying, decomposing, *etc*) is a user responsibility that may allow for optimisations.