### PR TITLE
Autopointer comparison fix

### DIFF
--- a/Material/TPZMatError.h
+++ b/Material/TPZMatError.h
@@ -38,6 +38,7 @@ public:
     TPZMatError &operator = (const TPZMatError & copy) {
         fExactSol = copy.fExactSol;
         fExactPOrder = copy.fExactPOrder;
+        return *this;
 //        std::cout << __PRETTY_FUNCTION__ << std::endl;
     }
     //!@name Error

--- a/Mesh/TPZCompElDisc.cpp
+++ b/Mesh/TPZCompElDisc.cpp
@@ -1012,7 +1012,7 @@ const TPZIntPoints &TPZCompElDisc::GetIntegrationRule() const {
 }
 
 TPZIntPoints &TPZCompElDisc::GetIntegrationRule() {
-	if(this->fIntRule == 0){
+	if(this->fIntRule == nullptr){
 		DebugStop();
 	}
   if (fIntegrationRule)

--- a/Post/pzgradientreconstruction.h
+++ b/Post/pzgradientreconstruction.h
@@ -128,10 +128,10 @@ class TPZGradientReconstruction
         }
         int HasExactSol() {
             if(fUseForcinfFuncion){
-                return (fExactSol != 0);
+                return (fExactSol != nullptr);
             }
             else{
-                fExactSol = 0;
+                fExactSol = nullptr;
                 return 0;
             }
         }

--- a/Pre/TPZH1ApproxCreator.h
+++ b/Pre/TPZH1ApproxCreator.h
@@ -67,10 +67,11 @@ private:
     /// Creates the rotation space for elasticity problems
     TPZCompMesh * CreateRotationSpace(){
         DebugStop();
+        return nullptr;
     }
 
     /// Group and condense computational elements
-    void GroupAndCondenseElements(TPZMultiphysicsCompMesh *mcmesh);
+    void GroupAndCondenseElements(TPZMultiphysicsCompMesh *mcmesh) override;
 
     /// Associate elements with a volumetric element in hybridized spaces;
     /// Groups volumetric, wrap and interface elements in standard hybridizations;

--- a/UnitTest_PZ/TestAutoPointer/AutoPointerTest.cpp
+++ b/UnitTest_PZ/TestAutoPointer/AutoPointerTest.cpp
@@ -15,6 +15,8 @@ namespace autoptrtest{
     void AutoPointerStressTest();
     //! conversion tests
     void AutoPointerConversionTest();
+    //! comparison tests
+    void AutoPointerComparisonTest();
 };
 
 
@@ -26,7 +28,9 @@ TEST_CASE("conversion_test","[autoptr_test]"){
     autoptrtest::AutoPointerConversionTest();
 }
 
-
+TEST_CASE("comparison_test","[autoptr_test]"){
+    autoptrtest::AutoPointerComparisonTest();
+}
 
 namespace autoptrtest{
     void ThreadTask(TPZAutoPointer<TPZFMatrix<REAL>> object) {
@@ -71,5 +75,46 @@ void autoptrtest::AutoPointerConversionTest(){
         TPZAutoPointer<TPZMatrix<STATE>> mat_ptr = nullptr;
         mat_ptr = fmat_ptr;
         REQUIRE(mat_ptr);
+    }
+}
+
+
+void autoptrtest::AutoPointerComparisonTest(){
+    /*
+      In order for these tests to run as required, double
+      parentheses are required, otherwise the
+      TPZAutoPointer<T>::operator== will not be called
+      See https://github.com/catchorg/Catch2/blob/devel/docs/assertions.md
+     */
+    
+    SECTION("Testing nullptr nullptr comparison"){
+        TPZAutoPointer<TPZFMatrix<STATE>> ap1, ap2;
+        REQUIRE((ap1==ap2));
+    }
+    SECTION("Testing nullptr non-null comparison"){
+        TPZAutoPointer<TPZFMatrix<STATE>> ap1, ap2;
+        ap2 = new TPZFMatrix<STATE>(2,2,0.);
+        REQUIRE((ap1!=ap2));
+    }
+    //same content, same pointer
+    SECTION("Testing non-null non-null (equal ptr) comparison"){
+        TPZAutoPointer<TPZFMatrix<STATE>> ap1, ap2;
+        ap2 = new TPZFMatrix<STATE>(2,2,0.);
+        ap1 = ap2;
+        REQUIRE((ap1==ap2));
+    }
+    //same content, different pointers
+    SECTION("Testing non-null non-null (diff ptr) comparison"){
+        TPZAutoPointer<TPZFMatrix<STATE>> ap1, ap2;
+        ap1 = new TPZFMatrix<STATE>(2,2,0.);
+        ap2 = new TPZFMatrix<STATE>(2,2,0.);
+        REQUIRE((ap1!=ap2));
+    }
+    //different content
+    SECTION("Testing non-null non-null (diff) comparison"){
+        TPZAutoPointer<TPZFMatrix<STATE>> ap1, ap2;
+        ap1 = new TPZFMatrix<STATE>(1,1,0.);
+        ap2 = new TPZFMatrix<STATE>(2,2,0.);
+        REQUIRE((ap1!=ap2));
     }
 }

--- a/Util/tpzautopointer.h
+++ b/Util/tpzautopointer.h
@@ -256,7 +256,20 @@ public:
 	{
 		return;
 	}    
-    
+
+
+  /** @brief Comparison operator, checks for equality of references*/
+  bool operator==(const TPZAutoPointer<T> &b){
+    if(!fRef && !b.fRef){return true;}
+    else if(!fRef || !b.fRef){ return false;}
+    else { return fRef->fPointer == b.fRef->fPointer;}
+  }
+
+  /** @brief Comparison operator, checks for equality of references*/
+  bool operator!=(const TPZAutoPointer<T> &b){
+    return ! this->operator==(b);
+  }
+  
 	/** @brief Returns if pointer was attributed */
 	operator bool() const{
 		return (fRef && fRef->fPointer != nullptr);


### PR DESCRIPTION
Comparisons between `TPZAutoPointer` would often not work as expected.

```
TPZAutoPointer<T> a;
TPZAutoPointer<T> b;

if(a==b){
  //code
}
```

In the above example, `a` would be converted to `bool`, evaluating to `true` if its reference is a valid pointer. The same would apply to `b`. Therefore, if both `a` and `b` point to valid - but different - memory areas, the check would still evaluate to `true`.