### PR TITLE
Symmetry property fix

### DIFF
--- a/Matrix/TPZSYSMPMatrix.cpp
+++ b/Matrix/TPZSYSMPMatrix.cpp
@@ -310,6 +310,7 @@ void TPZSYsmpMatrix<TVar>::SetSymmetry (SymProp sp){
                <<"Aborting..."<<std::endl;
         DebugStop();
     }
+    TPZBaseMatrix::SetSymmetry(sp);
 }
 
 /** @brief Fill matrix storage with randomic values */

--- a/Matrix/pzbasematrix.cpp
+++ b/Matrix/pzbasematrix.cpp
@@ -10,6 +10,7 @@ void TPZBaseMatrix::SetSymmetry(SymProp sp){
            <<"Aborting..."<<std::endl;
     DebugStop();
   }
+  fSymProp = sp;
 }
 void TPZBaseMatrix::Read(TPZStream &buf, void *context){
   buf.Read(&fRow);

--- a/Matrix/pzmatrix.cpp
+++ b/Matrix/pzmatrix.cpp
@@ -1472,7 +1472,8 @@ int TPZMatrix<TVar>::Inverse(TPZFMatrix<TVar>&Inv, DecomposeType dec){
 /** Fill the matrix with random values (non singular matrix) */
 template <class TVar>
 void TPZMatrix<TVar>::AutoFill(int64_t nrow, int64_t ncol, SymProp sym) {
-    Resize(nrow,ncol);
+  Resize(nrow,ncol);
+  this->SetSymmetry(sym);  
 	int64_t i, j;
 	TVar val, sum;
 	/** Fill data */

--- a/Matrix/pzsbndmat.cpp
+++ b/Matrix/pzsbndmat.cpp
@@ -53,6 +53,7 @@ void TPZSBMatrix<TVar>::SetSymmetry (SymProp sp){
                <<"Aborting..."<<std::endl;
         DebugStop();
     }
+    TPZBaseMatrix::SetSymmetry(sp);
 }
 
 /** Fill the matrix with random values (non singular matrix) */

--- a/Matrix/pzsfulmat.cpp
+++ b/Matrix/pzsfulmat.cpp
@@ -41,7 +41,7 @@ TPZMatrix<TVar>( dim, dim )
 template<class TVar>
 TPZSFMatrix<TVar> ::TPZSFMatrix (const TPZSFMatrix<TVar>  & A)
 : TPZRegisterClassId(&TPZSFMatrix::ClassId),
-TPZMatrix<TVar> ( A.Dim(), A.Dim() )
+TPZMatrix<TVar> ( A )
 {
     int64_t size = Size();
 	fElem = new TVar[size] ;
@@ -108,6 +108,7 @@ void TPZSFMatrix<TVar>::SetSymmetry (SymProp sp){
                <<"Aborting..."<<std::endl;
         DebugStop();
     }
+		TPZBaseMatrix::SetSymmetry(sp);
 }
 
 
@@ -126,7 +127,7 @@ TPZSFMatrix<TVar> ::operator=(const TPZSFMatrix<TVar>  &A )
 		if ( fElem == NULL )
 			TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__, "Operator= <memory allocation error>." );
     }
-	
+	this->fSymProp = A.fSymProp;
 	this->fRow = this->fCol =  A.Dim();
 	
 	// Copia a matriz
@@ -167,6 +168,7 @@ TPZSFMatrix<TVar> ::operator+(const TPZSFMatrix<TVar>  &A ) const
 		TPZMatrix<TVar> ::Error(__PRETTY_FUNCTION__, "Operator+ <matrixs with different dimensions>" );
 	
 	TPZSFMatrix<TVar>  res( this->Dim() );
+	res.SetSymmetry(this->GetSymmetry());
 	TVar *pm  = fElem;
 	TVar *pa  = A.fElem;
 	TVar *pr  = res.fElem;

--- a/Matrix/pzsfulmat.h
+++ b/Matrix/pzsfulmat.h
@@ -255,12 +255,17 @@ template<class TVar>
 inline int
 TPZSFMatrix<TVar> ::PutVal(const int64_t row,const int64_t col,const TVar &value )
 {
-	int64_t locrow = row, loccol = col;
-	if ( locrow < loccol )
-		this->Swap( &locrow, &loccol );
+  int64_t locrow = row, loccol = col;
+  TVar val = value;
+  if ( locrow < loccol ){
+    this->Swap( &locrow, &loccol );
+    if constexpr (is_complex<TVar>::value){
+      if(this->GetSymmetry() == SymProp::Herm){ val = std::conj(value);}
+    }
+  }
 	
-	this->fElem[ ((locrow*(locrow+1)) >> 1) + loccol ] = value;
-	return( 1 );
+  this->fElem[ ((locrow*(locrow+1)) >> 1) + loccol ] = val;
+  return( 1 );
 }
 
 /**************/
@@ -269,15 +274,19 @@ template<class TVar>
 inline const TVar 
 TPZSFMatrix<TVar> ::GetVal(const int64_t row,const int64_t col ) const
 {
-	if ( row < col ){
-        if constexpr (is_complex<TVar>::value){
-            return( std::conj(fElem[ ((col*(col+1)) >> 1) + row ]) );
-        }else{
-            return( fElem[ ((col*(col+1)) >> 1) + row ] );
-        }
+  if ( row < col ){
+    if constexpr (is_complex<TVar>::value){
+      if(this->GetSymmetry() == SymProp::Herm){
+        return( std::conj(fElem[ ((col*(col+1)) >> 1) + row ]) );
+      }else{
+        return(fElem[ ((col*(col+1)) >> 1) + row ]);
+      }
+    }else{
+      return( fElem[ ((col*(col+1)) >> 1) + row ] );
     }
+  }
 	
-	return( fElem[ ((row*(row+1)) >> 1) + col ] );
+  return( fElem[ ((row*(row+1)) >> 1) + col ] );
 }
 
 /**************************/

--- a/Matrix/pzskylmat.cpp
+++ b/Matrix/pzskylmat.cpp
@@ -264,8 +264,15 @@ TPZSkylMatrix<TVar>::PutVal(const int64_t r,const int64_t c,const TVar & value )
 {
 	// inicializando row e col para trabalhar com a triangular superior
 	int64_t row(r),col(c);
-	if ( row > col )
+  TVar val = value;
+	if ( row > col ){
 		this->Swap( &row, &col );
+    if constexpr (is_complex<TVar>::value){
+      if(this->fSymProp == SymProp::Herm){
+        val = std::conj(value);
+      }
+    }
+  }
 	
 	// Indice do vetor coluna.
 	int64_t index = col - row;
@@ -276,7 +283,7 @@ TPZSkylMatrix<TVar>::PutVal(const int64_t r,const int64_t c,const TVar & value )
 		cout.flush();
 		TPZMatrix<TVar>::Error(__PRETTY_FUNCTION__,"Index out of range");
 	} else if(index >= Size(col)) return 1;
-	fElem[col][index] = value;
+	fElem[col][index] = val;
 	//  delete[]newVet;
 	return( 1 );
 }
@@ -1792,6 +1799,7 @@ void TPZSkylMatrix<TVar>::SetSymmetry (SymProp sp){
                <<"Aborting..."<<std::endl;
         DebugStop();
     }
+    TPZBaseMatrix::SetSymmetry(sp);
 }
 
 template <class TVar>


### PR DESCRIPTION
The introduction of `SymProp` enum in #177 resulted in a few bugs being introduced due to lack of unit tests.

This was made clear by debugging the MKL sparse matrix-vector multiplication and realising that symmetry properties were not being set by `SetSymmetry`.

This PR aims to fix this issue and adds a few unit tests that hopefully can prevent against this type of bug.