### PR TITLE
Iterative changes

### DIFF
--- a/Analysis/TPZAnalysis.cpp
+++ b/Analysis/TPZAnalysis.cpp
@@ -63,6 +63,7 @@
 #ifdef PZ_LOG
 static TPZLogger logger("pz.analysis");
 static TPZLogger loggerError("pz.analysis.error");
+static TPZLogger loggerPrecond("pz.analysis.precondgraph");
 #endif
 
 //@orlandini: does anyone know if boost renumbering still works?
@@ -188,6 +189,7 @@ void TPZAnalysis::SetCompMeshInit(TPZCompMesh *mesh, bool mustOptimizeBandwidth)
         }
         if(mustOptimizeBandwidth)
         {
+            TPZSimpleTimer bd("Optimize bandwidth",false);
             OptimizeBandwidth();
         }
         if(neq > 20000 && mustOptimizeBandwidth)
@@ -1039,12 +1041,14 @@ TPZMatrixSolver<TVar> *TPZAnalysis::BuildPreconditioner(Precond::Type preconditi
 #endif
 		
 	}
-	if(preconditioner == Precond::Jacobi)
-	{
+  /*
+    First we treat two special cases in which the precond
+    is simpler to create
+   */
+	if(preconditioner == Precond::Jacobi){
     return new TPZJacobiPrecond<TVar>(mySolver->Matrix());
 	}
-  else if(preconditioner == Precond::BlockJacobi && overlap == true)
-  {
+  else if(preconditioner == Precond::BlockJacobi && overlap){
     TPZSimpleTimer build("BuildPreconditioner::Create");
     TPZBlockDiagonalStructMatrix<TVar> blstr(fCompMesh);
     //now we check if equation filter is active
@@ -1053,22 +1057,29 @@ TPZMatrixSolver<TVar> *TPZAnalysis::BuildPreconditioner(Precond::Type preconditi
       auto active_eqs = fStructMatrix->EquationFilter().GetActiveEquations();
       blstr.EquationFilter().SetActiveEquations(active_eqs);
     }
+    TPZVec<int> blocksizes;
+    blstr.BlockSizes(blocksizes);
     TPZBlockDiagonal<TVar> *sp = new TPZBlockDiagonal<TVar>();
-    blstr.AssembleBlockDiagonal(*sp);
+    sp->Initialize(blocksizes);
     TPZStepSolver<TVar> *step = new TPZStepSolver<TVar>(sp);
     step->SetDirect(ELU);
     step->SetReferenceMatrix(mySolver->Matrix());
     return step;
   }
-	else
-	{
+  else{
 		TPZNodesetCompute nodeset;
 		TPZStack<int64_t> elementgraph,elementgraphindex;
 		int64_t nindep = fCompMesh->NIndependentConnects();
 		int64_t neq = fCompMesh->NEquations();
+    /*
+      note: this graph will have even elements with no active connects.
+      if such an element is at position i, then elemengraphindex[i] = elementgraphindex[i+1]
+     */
 		fCompMesh->ComputeElGraph(elementgraph,elementgraphindex);
 		int64_t nel = elementgraphindex.NElements()-1;
 		TPZRenumbering renum(nel,nindep);
+        //this call will generate, based on the element graph, a graph that illustrates
+        //connectivity between nodes
 		renum.ConvertGraph(elementgraph,elementgraphindex,nodeset.Nodegraph(),nodeset.Nodegraphindex());
 		nodeset.AnalyseGraph();
 
@@ -1087,17 +1098,20 @@ TPZMatrixSolver<TVar> *TPZAnalysis::BuildPreconditioner(Precond::Type preconditi
 				nodeset.BuildVertexGraph(blockgraph,blockgraphindex);
 				break;
 		}
-		TPZStack<int64_t> expblockgraph,expblockgraphindex;
-		
-		nodeset.ExpandGraph(blockgraph,blockgraphindex,fCompMesh->Block(),expblockgraph,expblockgraphindex);
 
-    if(this->StructMatrix()->EquationFilter().IsActive()){
-      //now we need to convert the graphs as we have a filtered system,
-      //therefore the eq nums have changed
-      TPZStack<int64_t> bgcp = expblockgraph,bgicp = expblockgraphindex;
-      TPZNodesetCompute::FilterGraph(bgcp,bgicp,this->StructMatrix()->EquationFilter(),
-                                     expblockgraph,expblockgraphindex);
-    }
+    
+		TPZStack<int64_t> expblockgraph,expblockgraphindex;
+		/*
+      blockgraph and blockgraph indexes refer to CONNECTS (or equation blocks)
+      now we expand them to equation numbers
+     */
+        {
+            TPZManVector<int64_t> removed_blocks;
+            nodeset.ExpandGraph(blockgraph,blockgraphindex,fCompMesh->Block(),
+                                expblockgraph,expblockgraphindex,removed_blocks);
+            TPZNodesetCompute::UpdateGraph(blockgraph,blockgraphindex,removed_blocks);
+        }
+    
 #ifdef PZ_LOG
 #ifdef PZDEBUG2
         if (logger.isDebugEnabled())
@@ -1122,22 +1136,30 @@ TPZMatrixSolver<TVar> *TPZAnalysis::BuildPreconditioner(Precond::Type preconditi
         }
 #endif
 #endif
-    //update neq
     if(this->StructMatrix()->EquationFilter().IsActive()){
+      //now we need to convert the graphs as we have a filtered system,
+      //therefore the eq nums have changed
+      TPZManVector<int64_t> removed_blocks;
+      TPZNodesetCompute::FilterGraph(this->StructMatrix()->EquationFilter(),
+                                     expblockgraph,expblockgraphindex, removed_blocks);
+      TPZNodesetCompute::UpdateGraph(blockgraph, blockgraphindex, removed_blocks);
       neq = fStructMatrix->NReducedEquations();
     }
+      
+    std::cout<<"Building "<<expblockgraphindex.size()-1<<" blocks"<<std::endl;
     if(overlap)
 		{
-#ifdef PZDEBUG
-      if(preconditioner == Precond::BlockJacobi){
-        //why did the function reach here? with BlockJacobi + overlap
-        //there is no need to create all these graphs
-        DebugStop();
+#ifdef PZ_LOG
+      if(loggerPrecond.isDebugEnabled()){
+        std::stringstream sout;
+        sout << "Precond type :" <<Precond::Name(preconditioner)<<'\n';
+        sout << "Overlap : true\n";
+        TPZNodesetCompute::Print(sout,blockgraphindex,blockgraph);
+        LOGPZ_DEBUG(loggerPrecond,sout.str());
       }
 #endif
       TPZSimpleTimer build("BuildPreconditioner::Create");
-      /*this create a sparse block diagonal matrix structure! the values are not initialized yet*/
-			TPZSparseBlockDiagonal<TVar> *sp = new TPZSparseBlockDiagonal<TVar>(expblockgraph,expblockgraphindex,neq);
+      TPZSparseBlockDiagonal<TVar> *sp = new TPZSparseBlockDiagonal<TVar>(expblockgraph,expblockgraphindex,neq);
 			TPZStepSolver<TVar> *step = new TPZStepSolver<TVar>(sp);
 			step->SetDirect(ELU);
       //this will allow the TPZAnalysis::Solve to call UpdateFrom and insert values
@@ -1147,8 +1169,25 @@ TPZMatrixSolver<TVar> *TPZAnalysis::BuildPreconditioner(Precond::Type preconditi
     else
 		{
       TPZSimpleTimer build("BuildPreconditioner::Create");
-			TPZVec<int> blockcolor;
-			int numcolors = nodeset.ColorGraph(expblockgraph,expblockgraphindex,neq,blockcolor);
+      TPZVec<int> blockcolor;
+      //we must use the number of INDEPENDENT connects!
+      int numcolors = nodeset.ColorGraph(blockgraph,blockgraphindex,nindep,blockcolor);
+#ifdef PZ_LOG
+      if(loggerPrecond.isDebugEnabled()){
+        std::stringstream sout;
+        sout << "Precond type :" <<Precond::Name(preconditioner)<<'\n';
+        sout << "Overlap : false\n";
+        sout << "Number of precond colors :"<<numcolors<<'\n';
+        TPZNodesetCompute::Print(sout,blockgraphindex,blockgraph,blockcolor);
+        LOGPZ_DEBUG(loggerPrecond,sout.str());
+      }else if(loggerPrecond.isInfoEnabled()){
+        std::stringstream sout;
+        sout << "Precond type :" <<Precond::Name(preconditioner)<<'\n';
+        sout << "Number of precond colors :"<<numcolors<<'\n';
+        LOGPZ_INFO(loggerPrecond,sout.str());
+      }
+#endif
+      std::cout<<"Blocks divided into "<<numcolors<<" colors"<<std::endl;
 			return BuildSequenceSolver<TVar>(expblockgraph,expblockgraphindex,neq,numcolors,blockcolor);
 		}
 	}
@@ -1157,7 +1196,10 @@ TPZMatrixSolver<TVar> *TPZAnalysis::BuildPreconditioner(Precond::Type preconditi
 
 /** @brief Build a sequence solver based on the block graph and its colors */
 template<class TVar>
-TPZMatrixSolver<TVar> *TPZAnalysis::BuildSequenceSolver(TPZVec<int64_t> &graph, TPZVec<int64_t> &graphindex, int64_t neq, int numcolors, TPZVec<int> &colors)
+TPZMatrixSolver<TVar> *TPZAnalysis::BuildSequenceSolver(const TPZVec<int64_t> &graph,
+                                                        const TPZVec<int64_t> &graphindex,
+                                                        const int64_t neq, const int numcolors,
+                                                        const TPZVec<int> &colors)
 {
 	TPZVec<TPZMatrix<TVar> *> blmat(numcolors);
 	TPZVec<TPZStepSolver<TVar> *> steps(numcolors);
@@ -1174,13 +1216,23 @@ TPZMatrixSolver<TVar> *TPZAnalysis::BuildSequenceSolver(TPZVec<int64_t> &graph, 
 	if(numcolors == 1) return steps[0];
 	TPZSequenceSolver<TVar> *result = new TPZSequenceSolver<TVar>;
   result->SetMatrix(mySolver->Matrix());
-	for(c=numcolors-1; c>=0; c--)
+  for(c=0; c<numcolors; c++)
 	{
 		result->AppendSolver(*steps[c]);
 	}
-	for(c=1; c<numcolors; c++)
+  for(c=numcolors-2; c>=0; c--)
 	{
-		steps[c]->SetReferenceMatrix(0);
+    /*
+      append solver will copy the solver
+      steps[c] has already been added to the
+      sequence solver
+      there is no need to update the matrix
+      twice
+
+      setting SetReferenceMatrix to nullptr
+      will prevent this duplicate update
+     */
+		steps[c]->SetReferenceMatrix(nullptr);
 		result->AppendSolver(*steps[c]);
 	}
 	for(c=0; c<numcolors; c++)

--- a/Analysis/TPZAnalysis.cpp
+++ b/Analysis/TPZAnalysis.cpp
@@ -1092,7 +1092,10 @@ TPZMatrixSolver<TVar> *TPZAnalysis::BuildPreconditioner(Precond::Type preconditi
 				nodeset.BuildNodeGraph(blockgraph,blockgraphindex);
 				break;
     case Precond::Element:
-				nodeset.BuildElementGraph(blockgraph,blockgraphindex);
+                blockgraph = elementgraph;
+                blockgraphindex = elementgraphindex;
+                //@orlandini: BuildElementGraph is broken. elgraph should temporarily suffice
+				//nodeset.BuildElementGraph(blockgraph,blockgraphindex);
 				break;
     case Precond::NodeCentered:
 				nodeset.BuildVertexGraph(blockgraph,blockgraphindex);

--- a/Analysis/TPZAnalysis.h
+++ b/Analysis/TPZAnalysis.h
@@ -167,12 +167,15 @@ protected:
   
   /** @} */
 
-  /** @name Utils */
-  /** @{ */
-  /** @brief Define the type of preconditioner used */
-	/** This method will create the stiffness matrix but without assembling */
+  /** @name Utils 
+      @{ */
+  /** @brief Define the type of preconditioner used 
+      @param preconditioner [input] precond type
+      @param overlap [input] if false, matrix will be colored and Gauss Seidel-like iteration will happen
+  */
   template<class TVar>
-	TPZMatrixSolver<TVar> *BuildPreconditioner(Precond::Type preconditioner, bool overlap);
+	TPZMatrixSolver<TVar> *BuildPreconditioner(Precond::Type preconditioner,
+                                             bool overlap);
   /// deletes all data structures
   void CleanUp();
     
@@ -351,12 +354,12 @@ protected:
 
   /** @brief Common steps in setting a computational mesh. */
 	void SetCompMeshInit(TPZCompMesh * mesh, bool mustOptimizeBandwidth);
-private:
   /** @brief Build a sequence solver based on the block graph and its colors */
   template <class TVar>
   TPZMatrixSolver<TVar> *
-  BuildSequenceSolver(TPZVec<int64_t> &graph, TPZVec<int64_t> &graphindex,
-                      int64_t neq, int numcolors, TPZVec<int> &colors);
+  BuildSequenceSolver(const TPZVec<int64_t> &graph, const TPZVec<int64_t> &graphindex,
+                      const int64_t neq, const int numcolors, const TPZVec<int> &colors);
+private:
 
   template <class TVar>
   void

--- a/External/CMakeLists.txt
+++ b/External/CMakeLists.txt
@@ -7,6 +7,9 @@ target_include_directories(pz PUBLIC
 
 set(public_headers
     TPZRenumbering.h
+    TPZCutHillMcKee.h
+    TPZSloanRenumbering.h
+    tpznodesetcompute.h
     )
 set(headers
     TPZBoostGraph.h

--- a/External/TPZRenumbering.cpp
+++ b/External/TPZRenumbering.cpp
@@ -143,6 +143,8 @@ void TPZRenumbering::ConvertGraph(const TPZVec<int64_t> &elgraph, const TPZVec<i
         
         nodegraphindex[nod + 1] = nextfreeindex;
     }
+    //we want to avoid a zero sized nodegraph. nodegraphindex will have all entries 0
+    if(nodegraph.size() == 0){nodegraph.Resize(1,-1);}
     //    std::cout << convert.processName().c_str()  << convert << std::endl;
 }
 

--- a/External/TPZRenumbering.cpp
+++ b/External/TPZRenumbering.cpp
@@ -7,13 +7,14 @@
 #include "pzvec.h"
 #include "pzerror.h"
 #include "pzstack.h"
+#include "pzvec_extras.h"
 #include <map>
 #include <set>
 #include <algorithm>
 #include "pzlog.h"
 #include <algorithm>
 
-#include "TPZTimer.h"
+#include "TPZSimpleTimer.h"
 #include "Hash/TPZHash.h"
 #include "TPZStream.h"
 #include "pzcmesh.h"
@@ -27,24 +28,34 @@ static TPZLogger logger("pz.renumbering");
 
 using namespace std;
 
-void TPZRenumbering::NodeToElGraph(TPZVec<int64_t> &elgraph, TPZVec<int64_t> &elgraphindex, TPZVec<int64_t> &nodtoelgraph, TPZVec<int64_t> &nodtoelgraphindex) {
-	
+void TPZRenumbering::NodeToElGraph(const TPZVec<int64_t> &elgraph, const TPZVec<int64_t> &elgraphindex,
+                                   TPZVec<int64_t> &nodtoelgraph, TPZVec<int64_t> &nodtoelgraphindex) {
+    
+    /*
+      nelcon: number of elements connected to a given node
+     */
 	TPZVec<int64_t> nelcon(fNNodes+1,0);
   	int64_t nod,last = elgraphindex[fNElements];
   	for(nod = 0; nod<last; nod++) {
 		nelcon[elgraph[nod]]++;
   	}
 	nodtoelgraphindex = nelcon;
-	
+	//shifts one position to the right
   	for(nod=fNNodes; nod>0; nod--) nodtoelgraphindex[nod] = nodtoelgraphindex[nod-1];
   	nodtoelgraphindex[0] = 0;
+    //accumulate values
   	for(nod=1;nod<=fNNodes;nod++) nodtoelgraphindex[nod] += nodtoelgraphindex[nod-1];
 	
 	nodtoelgraph.Resize(nodtoelgraphindex[fNNodes]);
 	nodtoelgraph.Fill (-1);
 	
+
+    //this structure has the first (free) position for a given node on nodetoelgraph
+    //initially, it coincides with nodetoelgraphindex (but we will ignore last position)
     TPZVec<int64_t> nodtoelgraphposition(nodtoelgraphindex);
-    
+    nodtoelgraphposition.Resize(fNNodes);
+
+    //now we just need to figure out which elements are connected to each node
 	int64_t el;
   	for(el=0; el<fNElements; el++) {
 		int64_t firstnode = elgraphindex[el];
@@ -71,41 +82,67 @@ void TPZRenumbering::NodeToElGraph(TPZVec<int64_t> &elgraph, TPZVec<int64_t> &el
             */
 		}
   	}
+#ifdef PZDEBUG
+    for(int in = 0; in < fNNodes; in++){
+        if(nodtoelgraphposition[in] != nodtoelgraphindex[in+1]){
+            DebugStop();
+        }
+    }
+#endif
 }
 
-void TPZRenumbering::ConvertGraph(TPZVec<int64_t> &elgraph, TPZVec<int64_t> &elgraphindex, TPZManVector<int64_t> &nodegraph, TPZManVector<int64_t> &nodegraphindex) {
-    TPZTimer convert("Converting graph ");
-    convert.start();
+void TPZRenumbering::ConvertGraph(const TPZVec<int64_t> &elgraph, const TPZVec<int64_t> &elgraphindex,
+                                  TPZManVector<int64_t> &nodegraph, TPZManVector<int64_t> &nodegraphindex) {
+    TPZSimpleTimer convert("TPZRenumbering::ConvertGraph");
     int64_t nod, el;
     TPZVec<int64_t> nodtoelgraphindex;
     TPZVec<int64_t> nodtoelgraph;
 
+    //now we have a graph that states, for each node, which elements are connected to it
     NodeToElGraph(elgraph, elgraphindex, nodtoelgraph, nodtoelgraphindex);
 
     nodegraphindex.Resize(fNNodes + 1);
     nodegraphindex.Fill(0);
 
-    int64_t nodegraphincrement = 100000;
+    /** MEMORY ALLOC
+        a small test (80k elements) didn't show a lot of difference,
+        since now TPZVec will always allocate memory with a given margin.
+        therefore we are allocating the correct size
+
+        
+    constexpr int64_t nodegraphincrement = 100000;
     nodegraph.Resize(nodegraphincrement);
+    */
     int64_t nextfreeindex = 0;
     for (nod = 0; nod < fNNodes; nod++) {
         int64_t firstel = nodtoelgraphindex[nod];
         int64_t lastel = nodtoelgraphindex[nod + 1];
-        std::set<int64_t> nodecon;
+        TPZManVector<int64_t,1000> nodecon;
         for (el = firstel; el < lastel; el++) {
             int64_t gel = nodtoelgraph[el];
             int64_t firstelnode = elgraphindex[gel];
             int64_t lastelnode = elgraphindex[gel + 1];
-            nodecon.insert(&elgraph[firstelnode], &elgraph[(lastelnode - 1)] + 1);
+            for(auto in = firstelnode; in < lastelnode; in++){
+                nodecon.push_back(elgraph[in]);
+            }
         }
-        nodecon.erase(nod);
+        {
+            //we erase ourselves from the node graph
+            auto new_end = std::remove(nodecon.begin(),nodecon.end(),nod);
+            auto new_size = new_end - nodecon.begin();
+            nodecon.Resize(new_size);
+            RemoveDuplicates(nodecon);
+            std::sort(nodecon.begin(),nodecon.end());
+        }
+        /** MEMORY ALLOC
         while (nextfreeindex + nodecon.size() >= nodegraph.size()) nodegraph.Resize(nodegraph.NElements() + nodegraphincrement,0);
-        std::set<int64_t>::iterator it;
-        for (it = nodecon.begin(); it != nodecon.end(); it++) nodegraph[nextfreeindex++] = *it;
+        */
+        nodegraph.Resize(nodegraph.size()+nodecon.size());
+        
+        for (auto it = nodecon.begin(); it != nodecon.end(); it++) nodegraph[nextfreeindex++] = *it;
         
         nodegraphindex[nod + 1] = nextfreeindex;
     }
-    convert.stop();
     //    std::cout << convert.processName().c_str()  << convert << std::endl;
 }
 

--- a/External/TPZRenumbering.h
+++ b/External/TPZRenumbering.h
@@ -76,15 +76,17 @@ public:
 	
 	/**
 	 * @brief Will convert an element graph defined by elgraph and elgraphindex
-	 * into a node graph defined by nodegraph and nodegraphindex
+	 * into a node (connect) graph defined by nodegraph and nodegraphindex providing node connectivity
 	 */
-	void ConvertGraph(TPZVec<int64_t> &elgraph, TPZVec<int64_t> &elgraphindex, TPZManVector<int64_t> &nodegraph, TPZManVector<int64_t> &nodegraphindex);
+	void ConvertGraph(const TPZVec<int64_t> &elgraph, const TPZVec<int64_t> &elgraphindex,
+										TPZManVector<int64_t> &nodegraph, TPZManVector<int64_t> &nodegraphindex);
 	
 	/** @brief Convert a traditional elgraph to an element to element graph */
 	void ConvertToElementoToElementGraph(TPZVec<int64_t> &elgraph, TPZVec<int64_t> &elgraphindex, TPZVec<int64_t> &eltotelgraph, TPZVec<int> &eltoelweight, TPZVec<int64_t> &eltoelgraphindex);
 
 	/** @brief Stores the graph of nodes to elements */
-	void NodeToElGraph(TPZVec<int64_t> &elgraph, TPZVec<int64_t> &elgraphindex, TPZVec<int64_t> &nodetoelgraph, TPZVec<int64_t> &nodetoelgraphindex);
+	void NodeToElGraph(const TPZVec<int64_t> &elgraph, const TPZVec<int64_t> &elgraphindex,
+										 TPZVec<int64_t> &nodetoelgraph, TPZVec<int64_t> &nodetoelgraphindex);
 	
 	/**
 	 * @brief Will assign a color to the nodes in the graph such that no two connected nodes have the same color

--- a/External/tpznodesetcompute.cpp
+++ b/External/tpznodesetcompute.cpp
@@ -411,6 +411,10 @@ void TPZNodesetCompute::AnalyseForElements(std::set<int64_t> &vertices, std::set
 
 void TPZNodesetCompute::BuildElementGraph(TPZStack<int64_t> &blockgraph, TPZStack<int64_t> &blockgraphindex)
 {
+  PZError<<__PRETTY_FUNCTION__
+         <<"\nThis function is currently broken! Use TPZCompMesh::BuildElementGraph for now\n"
+         <<"(or fix it, if you are feeling really good today)"<<std::endl;
+  DebugStop();
   TPZSimpleTimer timer("TPZNodesetCompute::BuildElementGraph");
 #ifdef PZ_LOG
 	{

--- a/External/tpznodesetcompute.cpp
+++ b/External/tpznodesetcompute.cpp
@@ -720,7 +720,8 @@ void TPZNodesetCompute::UpdateGraph(TPZVec<int64_t> &graph,
   * Color the graph into mutually independent blocks
   */
 int TPZNodesetCompute::ColorGraph(TPZVec<int64_t> &graph, TPZVec<int64_t> &graphindex,
-                                  const int64_t nnodes, TPZVec<int> &colors)
+                                  const int64_t nnodes, TPZVec<int> &colors,
+                                  bool strictcolor)
 {
 #ifdef PZDEBUG
   if(nnodes != fNodegraphindex.size() - 1){
@@ -754,14 +755,16 @@ int TPZNodesetCompute::ColorGraph(TPZVec<int64_t> &graph, TPZVec<int64_t> &graph
         auto node = graph[inode];
         if(nodecolor[node] == color) break;
         //now we check the connected nodes
-        const int fneigh = fNodegraphindex[node];
-        const int lneigh = fNodegraphindex[node+1];
-        int in;
-        for(in = fneigh; in < lneigh; in++){
-          auto neigh = fNodegraph[in];
-          if(nodecolor[neigh] == color) break;
+        if(strictcolor){
+          const int fneigh = fNodegraphindex[node];
+          const int lneigh = fNodegraphindex[node+1];
+          int in;
+          for(in = fneigh; in < lneigh; in++){
+            auto neigh = fNodegraph[in];
+            if(nodecolor[neigh] == color) break;
+          }
+          if(in != lneigh){break;}
         }
-        if(in != lneigh){break;}
       }
       if(inode != last)
       {

--- a/External/tpznodesetcompute.cpp
+++ b/External/tpznodesetcompute.cpp
@@ -153,9 +153,9 @@ void TPZNodesetCompute::AnalyseNode(int64_t node, TPZVec< std::set<int64_t> > &n
   fSeqNumber[node] = fMaxSeqNum;
 #ifdef PZ_LOG
 	{
-		std::stringstream sout;
-		sout << "Assigning Seq Number " << fMaxSeqNum << " and level " << minlevel << " to nodes " << node << " " << equalnodes;
-    if(logger.isDebugEnabled()){
+		if(logger.isDebugEnabled()){
+      std::stringstream sout;
+      sout << "Assigning Seq Number " << fMaxSeqNum << " and level " << minlevel << " to nodes " << node << " " << equalnodes;
       LOGPZ_DEBUG(logger,sout.str());
     }
 	}
@@ -308,10 +308,10 @@ void TPZNodesetCompute::AnalyseForElements(std::set<int64_t> &vertices, std::set
 #ifdef PZ_LOG
     if(logger.isDebugEnabled())
 	{
-		std::stringstream sout;
-		sout << __PRETTY_FUNCTION__ << " Original set of nodes ";
-		Print(sout,vertices,0);
 		if(logger.isDebugEnabled()){
+      std::stringstream sout;
+      sout << __PRETTY_FUNCTION__ << " Original set of nodes ";
+      Print(sout,vertices,0);
       LOGPZ_DEBUG(logger,sout.str());
     }
 	}
@@ -354,9 +354,9 @@ void TPZNodesetCompute::AnalyseForElements(std::set<int64_t> &vertices, std::set
       set_intersection(unionset.begin(),unionset.end(),vertices.begin(),vertices.end(),inserter(diffset,diffset.begin()));
 #ifdef PZ_LOG
 		{
-			std::stringstream sout;
-			Print(sout,diffset,"First set to be reanalised");
 			if(logger.isDebugEnabled()){
+        std::stringstream sout;
+        Print(sout,diffset,"First set to be reanalised");
         LOGPZ_DEBUG(logger,sout.str());
       }
 		}
@@ -364,9 +364,9 @@ void TPZNodesetCompute::AnalyseForElements(std::set<int64_t> &vertices, std::set
       set_intersection(vertices.begin(),vertices.end(),locset.begin(),locset.end(),inserter(interset,interset.begin()));
 #ifdef PZ_LOG
 		{
-			std::stringstream sout;
-			Print(sout,interset,"Second set to be reanalised");
 			if(logger.isDebugEnabled()){
+        std::stringstream sout;
+        Print(sout,interset,"Second set to be reanalised");
         LOGPZ_DEBUG(logger,sout.str());
       }
 		}
@@ -393,10 +393,10 @@ void TPZNodesetCompute::AnalyseForElements(std::set<int64_t> &vertices, std::set
   {
 #ifdef PZ_LOG
 	  {
-		  std::stringstream sout;
-		  sout << "Discarding a vertex set as incomplete";
-		  Print(sout,vertices,0);
 		  if(logger.isDebugEnabled()){
+        std::stringstream sout;
+        sout << "Discarding a vertex set as incomplete";
+        Print(sout,vertices,0);
         LOGPZ_DEBUG(logger,sout.str());
       }
 	  }
@@ -406,9 +406,9 @@ void TPZNodesetCompute::AnalyseForElements(std::set<int64_t> &vertices, std::set
   {
 #ifdef PZ_LOG
 	  {
-		  std::stringstream sout;
-		  Print(sout,elem,"Inserted element");
 		  if(logger.isDebugEnabled()){
+        std::stringstream sout;
+        Print(sout,elem,"Inserted element");
         LOGPZ_DEBUG(logger,sout.str());
       }
 	  }
@@ -422,9 +422,9 @@ void TPZNodesetCompute::BuildElementGraph(TPZStack<int64_t> &blockgraph, TPZStac
   TPZSimpleTimer timer("TPZNodesetCompute::BuildElementGraph");
 #ifdef PZ_LOG
 	{
-		std::stringstream sout;
-		sout << __PRETTY_FUNCTION__ << " entering build element graph\n";
 		if(logger.isDebugEnabled()){
+      std::stringstream sout;
+      sout << __PRETTY_FUNCTION__ << " entering build element graph\n";
       LOGPZ_DEBUG(logger,sout.str());
     }
 	}
@@ -441,23 +441,23 @@ void TPZNodesetCompute::BuildElementGraph(TPZStack<int64_t> &blockgraph, TPZStac
     BuildNodeSet(in,nodeset);
 #ifdef PZ_LOG
 	  {
-		  std::stringstream sout;
-		  sout << "Nodeset for " << in << ' ';
-		  Print(sout,nodeset,"Nodeset");
 		  if(logger.isDebugEnabled()){
+        std::stringstream sout;
+        sout << "Nodeset for " << in << ' ';
+        Print(sout,nodeset,"Nodeset");
         LOGPZ_DEBUG(logger,sout.str());
       }
 	  }
 #endif
     SubtractLowerNodes(in,nodeset);
 #ifdef PZ_LOG
-		  {
-			  std::stringstream sout;
-			  Print(sout,nodeset,"LowerNodes result");
-			  if(logger.isDebugEnabled()){
-          LOGPZ_DEBUG(logger,sout.str());
-        }
-		  }
+    {
+      if(logger.isDebugEnabled()){
+        std::stringstream sout;
+        Print(sout,nodeset,"LowerNodes result");
+        LOGPZ_DEBUG(logger,sout.str());
+      }
+    }
 #endif
     AnalyseForElements(nodeset,elements);
     std::set< std::set<int64_t> >::iterator itel;
@@ -479,10 +479,10 @@ void TPZNodesetCompute::SubtractLowerNodes(int64_t node, std::set<int64_t> &node
   std::set<int64_t>::iterator it;
 #ifdef PZ_LOG
 	{
-		std::stringstream sout;
-		sout << __PRETTY_FUNCTION__;
-		Print(sout,nodeset," Incoming nodeset");
 		if(logger.isDebugEnabled()){
+      std::stringstream sout;
+      sout << __PRETTY_FUNCTION__;
+      Print(sout,nodeset," Incoming nodeset");
       LOGPZ_DEBUG(logger,sout.str());
     }
 	}
@@ -497,9 +497,9 @@ void TPZNodesetCompute::SubtractLowerNodes(int64_t node, std::set<int64_t> &node
     inserter(lownode,lownode.begin()));
 #ifdef PZ_LOG
 	{
-		std::stringstream sout;
-		Print(sout,lownode," What is left after substracting the influence of lower numbered nodes ");
 		if(logger.isDebugEnabled()){
+      std::stringstream sout;
+      Print(sout,lownode," What is left after substracting the influence of lower numbered nodes ");
       LOGPZ_DEBUG(logger,sout.str());
     }
 	}
@@ -516,9 +516,9 @@ void TPZNodesetCompute::SubtractLowerNodes(int64_t node, std::set<int64_t> &node
     inserter(lownode,lownode.begin()));
 #ifdef PZ_LOG
 	{
-		std::stringstream sout;
-		Print(sout,lownode," Resulting lower nodeset");
 		if(logger.isDebugEnabled()){
+      std::stringstream sout;
+      Print(sout,lownode," Resulting lower nodeset");
       LOGPZ_DEBUG(logger,sout.str());
     }
 	}

--- a/External/tpznodesetcompute.h
+++ b/External/tpznodesetcompute.h
@@ -52,10 +52,6 @@ public:
 	
 	/** @brief Expand the graph acording to the block structure */
 	static void ExpandGraph(TPZVec<int64_t> &graph, TPZVec<int64_t> &graphindex, TPZBlock &block,
-	/** @brief Color the graph into mutually independent blocks */
-	static int ColorGraph(TPZVec<int64_t> &graph, TPZVec<int64_t> &graphindex, int64_t neq,
-						  TPZVec<int> &colors);
-	
 							TPZVec<int64_t> &expgraph, TPZVec<int64_t> &expgraphindex,
 							TPZVec<int64_t> &removed_blocks);
 	/** @brief Filter the graph according to a given equation filter
@@ -65,6 +61,10 @@ public:
 	/** @brief Filter the graph based on removed blocks(should be called after filtergraph)*/
 	static void UpdateGraph(TPZVec<int64_t> &graphindex,TPZVec<int64_t> &graph,
 													const TPZVec<int64_t> &removed_blocks);
+	/** @brief Color the graph into mutually independent blocks
+			@note Should be called before expanding the connect graph*/
+	int ColorGraph(TPZVec<int64_t> &graph, TPZVec<int64_t> &graphindex,
+								 const int64_t nnodes, TPZVec<int> &colors);
 	/** @brief Returns the level of the nodes */
 	TPZVec<int> &Levels()
 	{

--- a/External/tpznodesetcompute.h
+++ b/External/tpznodesetcompute.h
@@ -52,14 +52,19 @@ public:
 	
 	/** @brief Expand the graph acording to the block structure */
 	static void ExpandGraph(TPZVec<int64_t> &graph, TPZVec<int64_t> &graphindex, TPZBlock &block,
-							TPZVec<int64_t> &expgraph, TPZVec<int64_t> &expgraphindex);
-	/** @brief Filter the graph according to a given equation filter*/
-	static void FilterGraph(TPZVec<int64_t> &graph, TPZVec<int64_t> &graphindex, TPZEquationFilter &eqfilt,
-							TPZVec<int64_t> &newgraph, TPZVec<int64_t> &newgraphindex);
 	/** @brief Color the graph into mutually independent blocks */
 	static int ColorGraph(TPZVec<int64_t> &graph, TPZVec<int64_t> &graphindex, int64_t neq,
 						  TPZVec<int> &colors);
 	
+							TPZVec<int64_t> &expgraph, TPZVec<int64_t> &expgraphindex,
+							TPZVec<int64_t> &removed_blocks);
+	/** @brief Filter the graph according to a given equation filter
+			@note UpdateGraph will likely need to be called after this call*/
+	static void FilterGraph(const TPZEquationFilter &eqfilt, TPZVec<int64_t> &newgraph,
+													TPZVec<int64_t> &newgraphindex,TPZVec<int64_t> &removed_blocks);
+	/** @brief Filter the graph based on removed blocks(should be called after filtergraph)*/
+	static void UpdateGraph(TPZVec<int64_t> &graphindex,TPZVec<int64_t> &graph,
+													const TPZVec<int64_t> &removed_blocks);
 	/** @brief Returns the level of the nodes */
 	TPZVec<int> &Levels()
 	{
@@ -75,6 +80,9 @@ public:
 	void Print(std::ostream &file) const;
 	
 	static void Print(std::ostream &file, const TPZVec<int64_t> &graphindex, const TPZVec<int64_t> &graph);
+
+	static void Print(std::ostream &file, const TPZVec<int64_t> &graphindex,
+										const TPZVec<int64_t> &graph,const TPZVec<int> &color);
 	
 	static void Print(std::ostream &file, const std::set<int64_t> &nodeset, const char *text);
 	
@@ -115,7 +123,7 @@ private:
 	 * @brief This method will analyse the set inclusion of the current node, calling the method \n
 	 * recursively if another node need to be analysed first
 	 */
-	void AnalyseNode(int64_t node, TPZVec< std::set<int64_t> > &nodeset);  
+	void AnalyseNode(const int64_t node);
 	
 	/** @brief Look for elements formed by vertices, intersecting with the intersectvertices, one by one */
 	/** If the intersection does not remove any of the intersectvertices, we found an element! */

--- a/External/tpznodesetcompute.h
+++ b/External/tpznodesetcompute.h
@@ -61,10 +61,15 @@ public:
 	/** @brief Filter the graph based on removed blocks(should be called after filtergraph)*/
 	static void UpdateGraph(TPZVec<int64_t> &graphindex,TPZVec<int64_t> &graph,
 													const TPZVec<int64_t> &removed_blocks);
-	/** @brief Color the graph into mutually independent blocks
-			@note Should be called before expanding the connect graph*/
+	/** @brief Color the graph into mutually independent blocks.
+		Set strictcoloring to true to ensure that the nodes of the same color don't
+		have any connectivity in common.
+		Otherwise, both nodes A and B might affect the residual of node C. A and B
+		can be of the same color as long as they don't affect each other's residual.
+		@note Should be called before expanding the connect graph*/
 	int ColorGraph(TPZVec<int64_t> &graph, TPZVec<int64_t> &graphindex,
-								 const int64_t nnodes, TPZVec<int> &colors);
+				   const int64_t nnodes, TPZVec<int> &colors,
+				   bool strictcoloring=false);
 	/** @brief Returns the level of the nodes */
 	TPZVec<int> &Levels()
 	{

--- a/Matrix/TPZYSMPMatrix.cpp
+++ b/Matrix/TPZYSMPMatrix.cpp
@@ -45,7 +45,7 @@ void TPZFYsmpMatrix<TVar>::MultiplyDummy(TPZFYsmpMatrix<TVar> & B, TPZFYsmpMatri
 
 template<class TVar>
 void TPZFYsmpMatrix<TVar>::GetRowIndices(const int64_t i, TPZVec<int64_t> &indices) const{
-    if (i < 0 || i >= this->Rows()) {
+	if (i < 0 || i >= this->Rows()) {
 		DebugStop();
 	}
 
@@ -632,6 +632,27 @@ void TPZFYsmpMatrix<TVar>::MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TV
     allthreads[i].join();
 	}
 	
+}
+
+
+template<class TVar>
+TVar TPZFYsmpMatrix<TVar>::RowTimesVector(const int row, const TPZFMatrix<TVar> &v) const
+{
+#ifdef PZDEBUG
+  if(v.Rows() != this->Cols()){
+    DebugStop();
+  }
+  if(row < 0 || row >= this->Rows()){
+    DebugStop();
+  }
+#endif
+  TVar res = 0;
+  const auto first = fIA[row];
+	const auto last = fIA[row+1];
+  for(int ic = first; ic < last; ic++){
+    res += fA[ic] * v.GetVal(fJA[ic],0);
+  }
+  return res;
 }
 
 // ****************************************************************************

--- a/Matrix/TPZYSMPMatrix.cpp
+++ b/Matrix/TPZYSMPMatrix.cpp
@@ -43,6 +43,19 @@ void TPZFYsmpMatrix<TVar>::MultiplyDummy(TPZFYsmpMatrix<TVar> & B, TPZFYsmpMatri
     }
 }
 
+template<class TVar>
+void TPZFYsmpMatrix<TVar>::GetRowIndices(const int64_t i, TPZVec<int64_t> &indices) const{
+    if (i < 0 || i >= this->Rows()) {
+		DebugStop();
+	}
+
+	const auto first = fIA[i];
+	const auto last = fIA[i+1];
+	const auto nv = last - first;
+	indices.Resize(nv);
+	for(int i = 0; i < nv; i++){indices[i] = fJA[first+i];}
+}
+
 // ****************************************************************************
 //
 // Constructor

--- a/Matrix/TPZYSMPMatrix.cpp
+++ b/Matrix/TPZYSMPMatrix.cpp
@@ -857,47 +857,21 @@ static int64_t  FindCol(int64_t *colf, int64_t *coll, int64_t col)
 	return -1;
 }
 
-template<class TVar>
-int TPZFYsmpMatrix<TVar>::GetSub(const int64_t sRow,const int64_t sCol,const int64_t rowSize,
-								 const int64_t colSize, TPZFMatrix<TVar> & A ) const {
-	int64_t ir;
-	for(ir=0; ir<rowSize; ir++)
-	{
-		int64_t row = sRow+ir;
-		int64_t colfirst = fIA[row];
-		int64_t collast = fIA[row+1];
-		int64_t iacol = FindCol(&fJA[0]+colfirst,&fJA[0]+collast-1,sCol);
-		int64_t ic;
-		for(ic=0; ic<colSize; ic++) A(ir,ic) = fA[iacol+colfirst];
-	}
-	return 0;
-}
-
-
-template<class TVar>
-void TPZFYsmpMatrix<TVar>::GetSub(const TPZVec<int64_t> &indices,TPZFMatrix<TVar> &block) const
-{
-	std::map<int64_t,int64_t> indord;
-	int64_t i,size = indices.NElements();
-	for(i=0; i<size; i++)
-	{
-		indord[indices[i]] = i;
-	}
-	std::map<int64_t,int64_t>::iterator itset,jtset;
-	for(itset = indord.begin(); itset != indord.end(); itset++)
-	{
-		int64_t *jfirst = &fJA[0]+fIA[(*itset).first];
-		int64_t *jlast = &fJA[0]+fIA[(*itset).first+1]-1;
-		//    int row = (*itset).first;
-		for(jtset = indord.begin(); jtset != indord.end(); jtset++)
-		{
-			int64_t col = FindCol(jfirst,jlast,(*jtset).first);
-			int64_t dist = jfirst+col-&fJA[0];
-			block((*itset).second,(*jtset).second) = fA[dist];
-			jfirst += col+1;
-		}
-	}
-}
+// template<class TVar>
+// int TPZFYsmpMatrix<TVar>::GetSub(const int64_t sRow,const int64_t sCol,const int64_t rowSize,
+// 								 const int64_t colSize, TPZFMatrix<TVar> & A ) const {
+// 	int64_t ir;
+// 	for(ir=0; ir<rowSize; ir++)
+// 	{
+// 		int64_t row = sRow+ir;
+// 		int64_t colfirst = fIA[row];
+// 		int64_t collast = fIA[row+1];
+// 		int64_t iacol = FindCol(&fJA[0]+colfirst,&fJA[0]+collast-1,sCol);
+// 		int64_t ic;
+// 		for(ic=0; ic<colSize; ic++) A(ir,ic) = fA[iacol+colfirst];
+// 	}
+// 	return 0;
+// }
 
 /*
  * Perform row update of the sparse matrix

--- a/Matrix/TPZYSMPMatrix.h
+++ b/Matrix/TPZYSMPMatrix.h
@@ -168,7 +168,8 @@ public:
 	virtual void AddKel(TPZFMatrix<TVar> & elmat, TPZVec<int64_t> & sourceindex, TPZVec<int64_t> & destinationindex) override;
 	
 	void MultiplyDummy(TPZFYsmpMatrix<TVar> & B, TPZFYsmpMatrix<TVar> & Res);
-	
+
+    void GetRowIndices(const int64_t i, TPZVec<int64_t>& indices) const override;
 	virtual int Zero() override;
 	
     /// this is a class that doesn't implement direct decompostion

--- a/Matrix/TPZYSMPMatrix.h
+++ b/Matrix/TPZYSMPMatrix.h
@@ -105,10 +105,10 @@ public:
 	virtual void MultAddMT(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> &y, TPZFMatrix<TVar> &z,
 						   const TVar alpha=1.,const TVar beta = 0., const int opt = 0);
 	/** @} */
-	virtual int GetSub(const int64_t sRow,const int64_t sCol,const int64_t rowSize,
-					   const int64_t colSize, TPZFMatrix<TVar> & A ) const override;
+	// this method is not working! default version does work
+	// virtual int GetSub(const int64_t sRow,const int64_t sCol,const int64_t rowSize,
+	// 				   const int64_t colSize, TPZFMatrix<TVar> & A ) const override;
 	
-	void GetSub(const TPZVec<int64_t> &indices,TPZFMatrix<TVar> &block) const override;
 
 
   

--- a/Matrix/TPZYSMPMatrix.h
+++ b/Matrix/TPZYSMPMatrix.h
@@ -104,6 +104,8 @@ public:
 	
 	virtual void MultAddMT(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> &y, TPZFMatrix<TVar> &z,
 						   const TVar alpha=1.,const TVar beta = 0., const int opt = 0);
+
+  TVar RowTimesVector(const int row, const TPZFMatrix<TVar> &v) const override;
 	/** @} */
 	// this method is not working! default version does work
 	// virtual int GetSub(const int64_t sRow,const int64_t sCol,const int64_t rowSize,

--- a/Matrix/pzbasematrix.cpp
+++ b/Matrix/pzbasematrix.cpp
@@ -3,6 +3,11 @@
 #include "Hash/TPZHash.h"
 
 
+void TPZBaseMatrix::GetRowIndices(const int64_t i, TPZVec<int64_t> &indices) const{
+  indices.Resize(fCol);
+  for(int i = 0; i < fCol; i++){indices[i] = i;}
+}
+
 void TPZBaseMatrix::SetSymmetry(SymProp sp){
   if(fRow!=fCol && sp != SymProp::NonSym){
     PZError<<__PRETTY_FUNCTION__

--- a/Matrix/pzbasematrix.h
+++ b/Matrix/pzbasematrix.h
@@ -37,6 +37,9 @@ enum DecomposeType { ENoDecompose, ELU, ELUPivot, ECholesky, ELDLt };
  */
 enum class SymProp{NonSym, Sym, Herm};
 
+template<class TVar>
+class TPZVec;
+
 /** @brief Root matrix class (abstract). \ref matrix "Matrix"
  * Abstract class TPZBaseMatrix which is agnostic with respect to
  * the arithmetic type being used. */
@@ -108,6 +111,7 @@ public:
   /** @brief Zeroes the matrix */
   virtual int Zero() = 0;
 
+  virtual void GetRowIndices(const int64_t i, TPZVec<int64_t> &indices) const;
 
   /** @brief Gets symmetry property of current matrix
       @note This flag is set by the user. Use VerifySymmetry for actually checking values.*/

--- a/Matrix/pzblockdiag.cpp
+++ b/Matrix/pzblockdiag.cpp
@@ -65,6 +65,18 @@ void TPZBlockDiagonal<TVar>::GetBlock(int64_t i, TPZFMatrix<TVar> &block){
         }
     }
 }
+
+template<class TVar>
+TPZAutoPointer<TPZFMatrix<TVar>>
+TPZBlockDiagonal<TVar>::GetBlockPtr(int64_t i){
+	if(i > -1 && i < this->NumberofBlocks()){
+		return fBlockMats[i];
+	}else{
+		return nullptr;
+	}
+}
+
+
 template<class TVar>
 void TPZBlockDiagonal<TVar>::Initialize(const TPZVec<int> &blocksize){
 	int64_t nblock = blocksize.NElements();

--- a/Matrix/pzblockdiag.cpp
+++ b/Matrix/pzblockdiag.cpp
@@ -39,7 +39,12 @@ template<class TVar>
 void TPZBlockDiagonal<TVar>::SetBlock(int64_t i, TPZFMatrix<TVar> &block){
 	int64_t firstpos = fBlockPos[i];
 	int64_t bsize = fBlockSize[i];
-	
+
+#ifdef PZDEBUG
+	if(block.Rows() != bsize || block.Cols() != bsize){
+		DebugStop();
+	}
+#endif
 	int64_t r,c;
 	for(r=0; r<bsize; r++) {
 		for(c=0; c<bsize; c++) {

--- a/Matrix/pzblockdiag.h
+++ b/Matrix/pzblockdiag.h
@@ -177,6 +177,12 @@ public:
      * @param block Contains returned block
 	 */
 	void GetBlock(int64_t i, TPZFMatrix<TVar> &block);
+
+    /**
+     * @brief Gets a pointer to the actual block from current matrix
+     * @param i Returns teh ith block
+	 */
+	TPZAutoPointer<TPZFMatrix<TVar>> GetBlockPtr(int64_t i);
 	
 	/**
      @brief Builds a block from matrix

--- a/Matrix/pzmatrix.cpp
+++ b/Matrix/pzmatrix.cpp
@@ -643,12 +643,20 @@ template<class TVar>
 void TPZMatrix<TVar>::SolveSOR(int64_t & numiterations, const TPZFMatrix<TVar> &F,
 							   TPZFMatrix<TVar> &result, TPZFMatrix<TVar> *residual, TPZFMatrix<TVar> &/*scratch*/, const REAL overrelax,
 							   REAL &tol,const int FromCurrent,const int direction) {
-	
+
+  auto normsq = [](const TVar var) -> RTVar {
+    if constexpr(is_complex<TVar>::value){
+      return (var * std::conj(var)).real();
+    }else{
+      return var * var;
+    }
+  };
+  
 	if(residual == &F) {
 		cout << "TPZMatrix::SolveSOR called with residual and F equal, no solution\n";
 		return;
 	}
-	TVar res = (TVar)2*(TVar)tol+(TVar)1.;
+	RTVar res = 2*tol+1;
 	if(residual) res = Norm(*residual);
 	if(!FromCurrent) {
 		result.Zero();
@@ -671,7 +679,7 @@ void TPZMatrix<TVar>::SolveSOR(int64_t & numiterations, const TPZFMatrix<TVar> &
 				for(int64_t j=0; j<r; j++) {
 					eqres -= GetVal(i,j)*result(j,ic);
 				}
-				res += eqres*eqres;
+				res += normsq(eqres);
 				result(i,ic) += (TVar)overrelax*eqres/GetVal(i,i);
 			}
 		}

--- a/Matrix/pzmatrix.cpp
+++ b/Matrix/pzmatrix.cpp
@@ -158,6 +158,25 @@ void TPZMatrix<TVar>::MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> &
 }
 
 template<class TVar>
+TVar TPZMatrix<TVar>::RowTimesVector(const int row, const TPZFMatrix<TVar> &v) const
+{
+#ifdef PZDEBUG
+  if(v.Rows() != this->Cols()){
+    DebugStop();
+  }
+  if(row < 0 || row >= this->Rows()){
+    DebugStop();
+  }
+#endif
+  TVar res = 0;
+  const int nc = this->Cols();
+  for(int ic = 0; ic < nc; ic++){
+    res += this->GetVal(row,ic)*v.GetVal(ic,0);
+  }
+  return res;
+}
+
+template<class TVar>
 void TPZMatrix<TVar>::Identity() {
 	
     if ( Cols() != Rows() ) {

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -214,6 +214,8 @@ public:
 	 */
 	virtual void MultAdd(const TPZFMatrix<TVar> & x,const TPZFMatrix<TVar>& y, TPZFMatrix<TVar>& z,
 						 const TVar alpha=1., const TVar beta = 0., const int opt = 0) const;
+
+  virtual TVar RowTimesVector(const int row, const TPZFMatrix<TVar> &v) const;
 	
 	/** @brief Computes res = rhs - this * x */
 	virtual void Residual(const TPZFMatrix<TVar>& x,const TPZFMatrix<TVar>& rhs, TPZFMatrix<TVar>& res ) ;

--- a/Matrix/tpzsparseblockdiagonal.cpp
+++ b/Matrix/tpzsparseblockdiagonal.cpp
@@ -20,7 +20,10 @@ TPZSparseBlockDiagonal<TVar>::TPZSparseBlockDiagonal() : TPZRegisterClassId(&TPZ
 {
 }
 template<class TVar>
-TPZSparseBlockDiagonal<TVar>::TPZSparseBlockDiagonal(TPZVec<int64_t> &blockgraph, TPZVec<int64_t> &blockgraphindex,int64_t rows) : TPZRegisterClassId(&TPZSparseBlockDiagonal::ClassId), fBlock(blockgraph), fBlockIndex(blockgraphindex)
+TPZSparseBlockDiagonal<TVar>::TPZSparseBlockDiagonal(const TPZVec<int64_t> &blockgraph,
+													 const TPZVec<int64_t> &blockgraphindex,
+													 const int64_t rows) :
+	TPZRegisterClassId(&TPZSparseBlockDiagonal::ClassId), fBlock(blockgraph), fBlockIndex(blockgraphindex)
 {
 	int64_t numbl = blockgraphindex.NElements()-1;
 	this->fBlockSize.Resize(numbl);
@@ -37,7 +40,11 @@ TPZSparseBlockDiagonal<TVar>::TPZSparseBlockDiagonal(TPZVec<int64_t> &blockgraph
 }
 
 template<class TVar>
-TPZSparseBlockDiagonal<TVar>::TPZSparseBlockDiagonal(TPZVec<int64_t> &blockgraph, TPZVec<int64_t> &blockgraphindex,int64_t rows, int color, TPZVec<int> &colors) : TPZRegisterClassId(&TPZSparseBlockDiagonal::ClassId)
+TPZSparseBlockDiagonal<TVar>::TPZSparseBlockDiagonal(const TPZVec<int64_t> &blockgraph,
+													 const TPZVec<int64_t> &blockgraphindex,
+													 const int64_t rows, const int color,
+													 const TPZVec<int> &colors) :
+	TPZRegisterClassId(&TPZSparseBlockDiagonal::ClassId)
 {
 #ifdef PZ_LOG
 	if(logger.isDebugEnabled()){

--- a/Matrix/tpzsparseblockdiagonal.cpp
+++ b/Matrix/tpzsparseblockdiagonal.cpp
@@ -28,6 +28,7 @@ TPZSparseBlockDiagonal<TVar>::TPZSparseBlockDiagonal(TPZVec<int64_t> &blockgraph
 	for(ibl=0; ibl<numbl; ibl++)
 	{
 		this->fBlockSize[ibl] = blockgraphindex[ibl+1]-blockgraphindex[ibl];
+		fGlobalBlockIndex[ibl] = ibl;
 	}
 	this->Initialize(this->fBlockSize);
 	//initialize from parent class will set fRow and fCol as the number of equations
@@ -62,6 +63,7 @@ TPZSparseBlockDiagonal<TVar>::TPZSparseBlockDiagonal(TPZVec<int64_t> &blockgraph
 	{
 		if(colors[ibl]==color) 
 		{
+			fGlobalBlockIndex[ibl] = iblcount;
 			int64_t first = blockgraphindex[ibl];
 			int64_t last = blockgraphindex[ibl+1];
 			int64_t firstcp = fBlockIndex[iblcount];
@@ -340,6 +342,16 @@ void TPZSparseBlockDiagonal<TVar>::UpdateFrom(TPZAutoPointer<TPZMatrix<TVar> > m
 		}
 	}
 	
+}
+
+template<class TVar>
+int64_t TPZSparseBlockDiagonal<TVar>::HasBlock(const int64_t global) const
+{
+	if(fGlobalBlockIndex.count(global)){
+		return fGlobalBlockIndex.at(global);
+	}else{
+		return -1;
+	}
 }
 
 template <class TVar>

--- a/Matrix/tpzsparseblockdiagonal.cpp
+++ b/Matrix/tpzsparseblockdiagonal.cpp
@@ -347,7 +347,7 @@ void TPZSparseBlockDiagonal<TVar>::UpdateFrom(TPZAutoPointer<TPZMatrix<TVar> > m
 			int64_t r;
 			pos = this->fBlockPos[b];
 			for(r=0; r<bsize; r++) indices[r] = fBlock[fBlockIndex[b]+r]; 
-			TPZFMatrix<TVar> block(bsize,bsize,&this->fStorage[pos],bsize*bsize);
+			auto &block = *(this->fBlockMats[b]);
 			mat->GetSub(indices,block);
 		}
 	}

--- a/Matrix/tpzsparseblockdiagonal.cpp
+++ b/Matrix/tpzsparseblockdiagonal.cpp
@@ -44,7 +44,16 @@ TPZSparseBlockDiagonal<TVar>::TPZSparseBlockDiagonal(TPZVec<int64_t> &blockgraph
 		LOGPZ_DEBUG(logger, "Constructor of TPZSparseBlockDiagonal");
 	}
 #endif
-	int64_t numbl = blockgraphindex.NElements()-1;
+	const int64_t numbl = blockgraphindex.NElements()-1;
+#ifdef PZ_LOG
+	if(numbl != colors.size()){
+		PZError<<__PRETTY_FUNCTION__
+					 <<"\nInvalid input! number of blocks "<<numbl
+					 <<"\nSize of color vec: "<<colors.size()
+					 <<std::endl;
+		DebugStop();
+	}
+#endif
 	this->fBlockSize.Resize(numbl);
 	int64_t ibl,iblcount,graphsize = 0;
 	for(ibl=0, iblcount=0; ibl<numbl; ibl++)

--- a/Matrix/tpzsparseblockdiagonal.cpp
+++ b/Matrix/tpzsparseblockdiagonal.cpp
@@ -95,12 +95,6 @@ TPZSparseBlockDiagonal<TVar>::TPZSparseBlockDiagonal(TPZVec<int64_t> &blockgraph
 	this->fCol = rows;
 }
 
-
-template<class TVar>
-TPZSparseBlockDiagonal<TVar>::~TPZSparseBlockDiagonal()
-{
-}
-
 template<class TVar>
 const TVar TPZSparseBlockDiagonal<TVar>::Get(const int64_t row, const int64_t col) const
 {
@@ -205,12 +199,6 @@ void TPZSparseBlockDiagonal<TVar>::Print(const char* message, std::ostream& out,
 			out << endl;
 		}
 	}
-}
-
-template<class TVar>
-void TPZSparseBlockDiagonal<TVar>::AddBlock(int64_t i, TPZFMatrix<TVar>& block)
-{
-    TPZBlockDiagonal<TVar>::AddBlock(i, block);
 }
 
 template<class TVar>

--- a/Matrix/tpzsparseblockdiagonal.cpp
+++ b/Matrix/tpzsparseblockdiagonal.cpp
@@ -370,6 +370,34 @@ int64_t TPZSparseBlockDiagonal<TVar>::HasBlock(const int64_t global) const
 	}
 }
 
+template<class TVar>
+void TPZSparseBlockDiagonal<TVar>::GetBlockList(TPZVec<int64_t> &loc_ind, TPZVec<int64_t> &glob_ind) const
+{
+	const int nbl = fGlobalBlockIndex.size();
+	loc_ind.Resize(nbl);
+	glob_ind.Resize(nbl);
+	int i = 0;
+	for(auto it : fGlobalBlockIndex){
+		glob_ind[i] = it.first;
+		loc_ind[i++] = it.second;
+	}
+}
+
+template<class TVar>
+void TPZSparseBlockDiagonal<TVar>::GetBlockEqs(const int64_t global_ibl, TPZVec<int64_t> &eqs) const{
+	const auto loc_ibl = HasBlock(global_ibl);
+	if (loc_ibl < 0){eqs.Resize(0);}
+	else{
+		const auto first = fBlockIndex[loc_ibl];
+		const auto last = fBlockIndex[loc_ibl+1];
+		const auto sz = last-first;
+		eqs.Resize(sz);
+		for(int i = first; i < last; i++){
+			eqs[i-first] = fBlock[i];
+		}
+	}
+}
+
 template <class TVar>
 int TPZSparseBlockDiagonal<TVar>::ClassId() const{
     return Hash("TPZSparseBlockDiagonal") ^ TPZBlockDiagonal<TVar>::ClassId() << 1;

--- a/Matrix/tpzsparseblockdiagonal.h
+++ b/Matrix/tpzsparseblockdiagonal.h
@@ -20,9 +20,10 @@ class TPZSparseBlockDiagonal : public TPZBlockDiagonal<TVar>
 {
 public:
     TPZSparseBlockDiagonal();
-    TPZSparseBlockDiagonal(TPZVec<int64_t> &blockgraph, TPZVec<int64_t> &blockgraphindex,int64_t rows);
+    TPZSparseBlockDiagonal(const TPZVec<int64_t> &blockgraph, const TPZVec<int64_t> &blockgraphindex, const int64_t rows);
     
-    TPZSparseBlockDiagonal(TPZVec<int64_t> &blockgraph, TPZVec<int64_t> &blockgraphindex,int64_t rows, int color, TPZVec<int> &colors);
+    TPZSparseBlockDiagonal(const TPZVec<int64_t> &blockgraph, const TPZVec<int64_t> &blockgraphindex,
+                           const int64_t rows, const int color, const TPZVec<int> &colors);
 
     CLONEDEF(TPZSparseBlockDiagonal)
     const TVar Get(const int64_t row, const int64_t col) const override;

--- a/Matrix/tpzsparseblockdiagonal.h
+++ b/Matrix/tpzsparseblockdiagonal.h
@@ -23,8 +23,6 @@ public:
     TPZSparseBlockDiagonal(TPZVec<int64_t> &blockgraph, TPZVec<int64_t> &blockgraphindex,int64_t rows);
     
     TPZSparseBlockDiagonal(TPZVec<int64_t> &blockgraph, TPZVec<int64_t> &blockgraphindex,int64_t rows, int color, TPZVec<int> &colors);
-	
-    ~TPZSparseBlockDiagonal();
 
     CLONEDEF(TPZSparseBlockDiagonal)
     const TVar Get(const int64_t row, const int64_t col) const override;
@@ -37,7 +35,6 @@ public:
     virtual TVar &s(const int64_t row, const int64_t col) override;
     
     virtual void Print(const char* message, std::ostream& out=std::cout, const MatrixOutputFormat=EFormatted) const override;
-    void AddBlock(int64_t i, TPZFMatrix<TVar>& block);
     void BuildFromMatrix(TPZMatrix<TVar>& matrix);
     void GetBlock(int64_t i, TPZFMatrix<TVar>& block);
     void MultAdd(const TPZFMatrix<TVar>& x, const TPZFMatrix<TVar>& y, TPZFMatrix<TVar>& z, const TVar alpha, const TVar beta, const int opt) const override;

--- a/Matrix/tpzsparseblockdiagonal.h
+++ b/Matrix/tpzsparseblockdiagonal.h
@@ -47,6 +47,11 @@ public:
     /** @brief Checks if current matrix has a given block. Returns -1 if it does not
         @note This function only makes sense for colored matrices*/
     int64_t HasBlock(const int64_t global) const;
+
+    /** @brief Gets local and global indices of blocks present in this matrix*/
+    void GetBlockList(TPZVec<int64_t> &loc, TPZVec<int64_t> &glob) const;
+    /** @brief For a given global id, returns equation numbers*/
+    void GetBlockEqs(const int64_t global_ibl, TPZVec<int64_t> &eqs) const;
     public:
 int ClassId() const override;
 

--- a/Matrix/tpzsparseblockdiagonal.h
+++ b/Matrix/tpzsparseblockdiagonal.h
@@ -42,7 +42,10 @@ public:
 	
 	/** @brief Updates the values of the matrix based on the values of the matrix */
 	virtual void UpdateFrom(TPZAutoPointer<TPZMatrix<TVar> > mat) override;
-	
+
+    /** @brief Checks if current matrix has a given block. Returns -1 if it does not
+        @note This function only makes sense for colored matrices*/
+    int64_t HasBlock(const int64_t global) const;
     public:
 int ClassId() const override;
 
@@ -51,6 +54,9 @@ protected:
     TPZVec<int64_t> fBlock;
 	/** @brief Index to first element of each block in fBlock */
     TPZVec<int64_t> fBlockIndex;
+    /** @brief keys are the global indices of blocks and values are the local indices, if present
+     @note This only really makes sense for colored matrices*/
+    std::map<int64_t,int64_t> fGlobalBlockIndex;
 	
     void ScatterAdd(const TPZFMatrix<TVar> &in, TPZFMatrix<TVar> &out) const;
     void Gather(const TPZFMatrix<TVar> &in, TPZFMatrix<TVar> &out) const;

--- a/Matrix/tpzsparseblockdiagonal.h
+++ b/Matrix/tpzsparseblockdiagonal.h
@@ -25,7 +25,8 @@ public:
     TPZSparseBlockDiagonal(TPZVec<int64_t> &blockgraph, TPZVec<int64_t> &blockgraphindex,int64_t rows, int color, TPZVec<int> &colors);
 	
     ~TPZSparseBlockDiagonal();
-	
+
+    CLONEDEF(TPZSparseBlockDiagonal)
     const TVar Get(const int64_t row, const int64_t col) const override;
     const TVar GetVal(const int64_t row, const int64_t col) const override;
     int Put(const int64_t row, const int64_t col, const TVar& value) override;

--- a/Solvers/LinearSolvers/gmres.h
+++ b/Solvers/LinearSolvers/gmres.h
@@ -21,7 +21,8 @@ template<class TVar>
 int GMRES(const TPZMatrix<TVar> &A, TPZFMatrix<TVar> &x, const TPZFMatrix<TVar> &b,
           TPZMatrixSolver<TVar> &M, TPZFMatrix<TVar> &H, const int krylovdim,
           int64_t &max_iter, RTVar &tol,
-          TPZFMatrix<TVar> *residual, const int fromcurrent){
+          TPZFMatrix<TVar> *residual, const int fromcurrent,
+          bool print_res=true){
 
   constexpr RTVar ztol = 10*std::numeric_limits<RTVar>::epsilon();
   //for printing in full precision
@@ -119,7 +120,7 @@ int GMRES(const TPZMatrix<TVar> &A, TPZFMatrix<TVar> &x, const TPZFMatrix<TVar> 
                 <<"\n\t|du|:" << du
                 << std::endl;
 #else      
-      std::cout << iter << "\t" << resid << std::endl;
+      if(print_res){std::cout << iter << "\t" << resid << std::endl;}
 #endif
     }
     Update(x, i - 1, H, s, v);
@@ -128,7 +129,7 @@ int GMRES(const TPZMatrix<TVar> &A, TPZFMatrix<TVar> &x, const TPZFMatrix<TVar> 
     M.Solve(r,r);
     beta = Norm(r);
     resid = beta/normb;
-    std::cout<<"beta "<<beta<<" resid "<<resid<<" normb "<<normb<<std::endl;
+    if(print_res){std::cout<<"beta "<<beta<<" resid "<<resid<<" normb "<<normb<<std::endl;}
     if (resid < tol) {
       break;
     }

--- a/Solvers/LinearSolvers/gmres.h
+++ b/Solvers/LinearSolvers/gmres.h
@@ -2,11 +2,13 @@
 #include "TPZSimpleTimer.h"
 #include "tpzautopointer.h"
 #include "pzvec.h"
+#include "pzfmatrix.h"
+#include "TPZMatrixSolver.h"
 
 // #define PZGMRESDEBUG
 
 template<class TVar>
-void GeneratePlaneRotation(const TVar dx, const TVar dy, TVar &cs, TVar &sn);
+void GeneratePlaneRotation(const TVar dx, const TVar dy, TVar &cs, TVar &sn, RTVar tol);
 
 template<class TVar>
 void ApplyPlaneRotation(TVar &dx, TVar &dy, const TVar cs, const TVar sn);
@@ -17,10 +19,11 @@ void Update(TPZFMatrix<TVar>&x, const int k, const TPZFMatrix<TVar>&H,
 
 template<class TVar>
 int GMRES(const TPZMatrix<TVar> &A, TPZFMatrix<TVar> &x, const TPZFMatrix<TVar> &b,
-					TPZMatrixSolver<TVar> &M, TPZFMatrix<TVar> &H, const int krylovdim,
-					int64_t &max_iter, RTVar &tol,
-					TPZFMatrix<TVar> *residual, const int fromcurrent){
+          TPZMatrixSolver<TVar> &M, TPZFMatrix<TVar> &H, const int krylovdim,
+          int64_t &max_iter, RTVar &tol,
+          TPZFMatrix<TVar> *residual, const int fromcurrent){
 
+  constexpr RTVar ztol = 10*std::numeric_limits<RTVar>::epsilon();
   //for printing in full precision
   std::ios cout_state(nullptr);
   cout_state.copyfmt(std::cout);
@@ -34,52 +37,54 @@ int GMRES(const TPZMatrix<TVar> &A, TPZFMatrix<TVar> &x, const TPZFMatrix<TVar> 
   TPZVec<TVar> cs(krylovdim+1), sn(krylovdim+1), s(krylovdim+1);
 
   //compute rhs norm
-	TPZFMatrix<TVar> r;
-	M.Solve(b,r);
-	const RTVar normb = [&r]{
-		RTVar norm_b = Norm(r);
-		if(IsZero(norm_b)) return (RTVar)1;
-		return norm_b;
-	}();
+  TPZFMatrix<TVar> r;
+  M.Solve(b,r);
+  const RTVar normb = [&r]{
+    RTVar norm_b = Norm(r);
+    if(norm_b < ztol) return (RTVar)1;
+    return norm_b;
+  }();
 	
   if(fromcurrent){//we actually need to compute the residual
-		//r = b-A*x without dynamic allocation
-		A.MultAdd(x,b,r,-1,1);
+    //r = b-A*x without dynamic allocation
+    A.MultAdd(x,b,r,-1,1);
     M.Solve(r,r);
   }else{//residual is equal to rhs for initial sol == 0   
     x.Zero();
   }
 	
   RTVar beta = Norm(r);
+  std::cout<<"initial precond correction "<<beta<<std::endl;
   RTVar resid = beta;
-  if ((resid / normb) <= tol) {
+  if (resid <= tol) {
     tol = resid;
     max_iter = 0;
+    std::cout.copyfmt(cout_state);
     return 0;
   }
 #ifdef PZGMRESDEBUG
   TPZFMatrix<TVar> xcp = x;
   TPZFMatrix<TVar> rcp = r;
 #endif
-	//we avoid allocating w at every step
-	TPZFMatrix<TVar> w(r.Rows(),1,0), w1;
+  //we avoid allocating w at every step
+  TPZFMatrix<TVar> w(r.Rows(),1,0), w1;
   int iter = 1;
   while (iter <= max_iter) {
-    v[0] = r * (1.0 / beta);
+    r.MultiplyByScalar((1.0/beta),v[0]);
     s = 0.0;
     s[0] = beta;
 
     int i = 0;
     for (; i < krylovdim && iter <= max_iter; i++, iter++) {
-			A.Multiply(v[i],w1);
-			M.Solve(w1,w);
+      A.Multiply(v[i],w1);
+      M.Solve(w1,w);
       for (int k = 0; k <= i; k++) {
         const auto dotwv = Dot(w,v[k]);
         H(k, i) = dotwv;
         w -= dotwv * v[k];
       }
       const auto normw = Norm(w);
-      if(IsZero(normw)){
+      if(normw < ztol){
         i++;
         break;
       }
@@ -91,17 +96,19 @@ int GMRES(const TPZMatrix<TVar> &A, TPZFMatrix<TVar> &x, const TPZFMatrix<TVar> 
         ApplyPlaneRotation(H(k,i), H(k+1,i), cs[k], sn[k]);
       }
       
-      GeneratePlaneRotation(H(i,i), H(i+1,i), cs[i], sn[i]);
+      GeneratePlaneRotation(H(i,i), H(i+1,i), cs[i], sn[i], ztol);
       ApplyPlaneRotation(H(i,i), H(i+1,i), cs[i], sn[i]);
       ApplyPlaneRotation(s[i], s[i+1], cs[i], sn[i]);
-      
-      if ((resid = std::abs(s[i+1]) / normb) < tol) {
-				i++;
+
+      resid = std::abs(s[i+1])/normb;
+      if (resid < tol) {
+        i++;
         break;
       }
 #ifdef PZGMRESDEBUG
       xcp = x;
       Update(xcp,i,H,s,v);
+      const auto du = Norm(x-xcp);
       A.MultAdd(xcp,b,rcp,-1,1);
       M.Solve(rcp,rcp);
       auto nres = Norm(rcp);
@@ -109,26 +116,25 @@ int GMRES(const TPZMatrix<TVar> &A, TPZFMatrix<TVar> &x, const TPZFMatrix<TVar> 
                 <<"\n\t|s(i+1)|   :" << std::abs(s[i+1])
                 <<"\n\t|res|      :" << nres
                 <<"\n\t|res|/normb:" << nres/normb
+                <<"\n\t|du|:" << du
                 << std::endl;
 #else      
       std::cout << iter << "\t" << resid << std::endl;
 #endif
     }
     Update(x, i - 1, H, s, v);
-		//r = b-A*x without dynamic allocation
-		A.MultAdd(x,b,r,-1,1);
+    //r = b-A*x without dynamic allocation
+    A.MultAdd(x,b,r,-1,1);
     M.Solve(r,r);
     beta = Norm(r);
+    resid = beta/normb;
     std::cout<<"beta "<<beta<<" resid "<<resid<<" normb "<<normb<<std::endl;
-    if ((resid = beta / normb) < tol) {
-      tol = resid;
-      max_iter = iter;
-      return 0;
+    if (resid < tol) {
+      break;
     }
   }
-  
+  max_iter = iter;
   tol = resid;
-
   std::cout.copyfmt(cout_state);
   return 1;
 }
@@ -138,24 +144,24 @@ int GMRES(const TPZMatrix<TVar> &A, TPZFMatrix<TVar> &x, const TPZFMatrix<TVar> 
     @note These rotations are based on lapack Xlartg routines. (X=s,d,c,z)
     They will result in a plane rotation with real cosine and complex sine*/
 template<class TVar>
-void GeneratePlaneRotation(TVar dx, TVar dy, TVar &cs, TVar &sn)
+void GeneratePlaneRotation(TVar dx, TVar dy, TVar &cs, TVar &sn, RTVar tol)
 {
   
-  if(IsZero(dy)){
+  if(abs(dy) < tol){
     cs = 1.;
     sn = 0;
-  }else if (IsZero(dx)){
+  }else if (abs(dx)<tol){
     cs = 0;
-    if constexpr(is_complex<TVar>::value){
-      sn = std::conj(dy)/abs(dy);
-    }else{
-      sn = dy/std::abs(dy);
-    }
+    sn = dy/std::abs(dy);
   }else{
     //note: std::norm is actually the squared magnitude
-    const TVar norm = (dx / abs(dx) ) * sqrt(std::norm(dx) + std::norm(dy));
-    sn = dy/norm;
-    cs = dx/norm;
+    const TVar sq = sqrt(std::norm(dx) + std::norm(dy));
+    cs = abs(dx)/sq;
+    if constexpr (is_complex<TVar>::value){
+      sn = (dx/abs(dx))*std::conj(dy)/sq;
+    }else{
+      sn = (dx/abs(dx))*dy/sq;
+    }
   }
   
 }
@@ -169,7 +175,7 @@ void ApplyPlaneRotation(TVar &dx, TVar &dy, const TVar cs, const TVar sn)
 {
   const TVar temp = cs * dx + sn * dy;
   if constexpr (is_complex<TVar>::value){
-    dy = -std::conj(sn) * dx + cs * dy;
+    dy = -std::conj(sn) * dx + std::conj(cs) * dy;
   }else{
     dy = -sn * dx + cs * dy;
   }

--- a/Solvers/TPZJacobiPrecond.h
+++ b/Solvers/TPZJacobiPrecond.h
@@ -41,6 +41,11 @@ public:
 	{
 		return new TPZJacobiPrecond(*this);
 	}
+  /** @brief Sets coloring of blocks (for GS-like iteration)*/
+  void SetColoring(const TPZVec<int64_t> &colors, const int numcolors);
+protected:
+  //! Vector storing coloring info
+  TPZVec<TPZVec<int64_t>> fColorVec;
 };
 
 #endif //TPZJACOBIPRECOND_H

--- a/Solvers/pzseqsolver.cpp
+++ b/Solvers/pzseqsolver.cpp
@@ -44,8 +44,8 @@ void TPZSequenceSolver<TVar>::Solve(const TPZFMatrix<TVar> &F, TPZFMatrix<TVar> 
 		cout << "TPZSequenceSolver::Solve called without a matrix pointer\n";
 	}
 	TPZAutoPointer<TPZMatrix<TVar> > mat = this->Matrix();
-	if(result.Rows() != mat->Rows() || result.Cols() != F.Cols()) {
-		result.Redim(mat->Rows(),F.Cols());
+	if(result.Rows() != mat->Cols() || result.Cols() != F.Cols()) {
+		result.Redim(mat->Cols(),F.Cols());
 	}
 	
 	this->fScratch = F;
@@ -54,16 +54,17 @@ void TPZSequenceSolver<TVar>::Solve(const TPZFMatrix<TVar> &F, TPZFMatrix<TVar> 
 	TPZFMatrix<TVar> resloc(F.Rows(),F.Cols(),0.);
 	result.Zero();
 	if(this->fScratch.Rows() != result.Rows() || this->fScratch.Cols() != result.Cols()) {
-		this->fScratch.Redim(result.Rows(),result.Cols());
+    //if scratch holds F then it cannot be resized
+		DebugStop();
 	}
-    int nums = fSolvers.NElements();
-    int s;
-    for(s=0; s<nums; s++) {
-        fSolvers[s]->Solve(this->fScratch,delu,&resloc);
-        result += delu;
-        mat->Residual(result,fcp,this->fScratch);
-    }
-    if(residual) *residual = this->fScratch;
+  int nums = fSolvers.NElements();
+  int s;
+  for(s=0; s<nums; s++) {
+    fSolvers[s]->Solve(this->fScratch,delu,&resloc);
+    result += delu;
+    mat->Residual(result,fcp,this->fScratch);
+  }
+  if(residual) *residual = this->fScratch;
 }
 
 

--- a/Solvers/pzseqsolver.h
+++ b/Solvers/pzseqsolver.h
@@ -50,8 +50,15 @@ public:
         int ClassId() const override;
 	void Write(TPZStream &buf, int withclassid) const override;
 	void Read(TPZStream &buf, void *context) override;
-	
-	
+
+	//! Gets number of solvers
+	int NumSolvers() const {return fSolvers.size();}
+
+	//! Gets a given solver
+	TPZMatrixSolver<TVar>* GetSolver(const int i){
+		if(i >= 0 && i < NumSolvers()){return fSolvers[i];}
+		else{return nullptr;}
+	}
 private:    
 	TPZStack < TPZMatrixSolver<TVar> * > fSolvers;
 };

--- a/Solvers/pzstepsolver.cpp
+++ b/Solvers/pzstepsolver.cpp
@@ -152,11 +152,13 @@ void TPZStepSolver<TVar>::Solve(const TPZFMatrix<TVar> &F, TPZFMatrix<TVar> &res
 			mat->SolveBICGStab(numiterations, *fPrecond, F, result,residual,tol,fFromCurrent);
       name = "BiCGStab";
 			break;
-		case TPZStepSolver::EDirect:
-			result = F;
-			mat->SolveDirect(result,fDecompose);
-			if(residual) residual->Redim(F.Rows(),F.Cols());
+    case TPZStepSolver::EDirect:{
+      result = F;
+      mat->SolveDirect(result,fDecompose);
+      //mat has been decomposed, we cannot compute the residual
+      if(residual) {residual->Redim(F.Rows(),F.Cols());}
 			break;
+    }
 		case TPZStepSolver::EMultiply:
 			mat->Multiply(F,result);
 			if(residual) mat->Residual(result,F,*residual);

--- a/Solvers/pzstepsolver.cpp
+++ b/Solvers/pzstepsolver.cpp
@@ -79,8 +79,8 @@ void TPZStepSolver<TVar>::Solve(const TPZFMatrix<TVar> &F, TPZFMatrix<TVar> &res
         }
     }
     
-	if(result.Rows() != mat->Rows() || result.Cols() != F.Cols()) {
-		result.Redim(mat->Rows(),F.Cols());
+	if(result.Rows() != mat->Cols() || result.Cols() != F.Cols()) {
+		result.Redim(mat->Cols(),F.Cols());
 	}
   //not every solver need to resize fScratch
 	switch(fSolver) {

--- a/Solvers/pzstepsolver.cpp
+++ b/Solvers/pzstepsolver.cpp
@@ -82,10 +82,18 @@ void TPZStepSolver<TVar>::Solve(const TPZFMatrix<TVar> &F, TPZFMatrix<TVar> &res
 	if(result.Rows() != mat->Rows() || result.Cols() != F.Cols()) {
 		result.Redim(mat->Rows(),F.Cols());
 	}
-	
-	if(this->fScratch.Rows() != result.Rows() || this->fScratch.Cols() != result.Cols()) {
-		this->fScratch.Redim(result.Rows(),result.Cols());
-	}
+  //not every solver need to resize fScratch
+	switch(fSolver) {
+		case TPZStepSolver::EJacobi:
+		case TPZStepSolver::ESOR:
+		case TPZStepSolver::ESSOR:
+      if(this->fScratch.Rows() != result.Rows() ||
+         this->fScratch.Cols() != result.Cols()) {
+        this->fScratch.Redim(result.Rows(),result.Cols());
+      }
+  default:
+    break;
+  }
 	
 	REAL tol = fTol;
 	int64_t numiterations = fMaxIterations;

--- a/StrMatrix/pzbdstrmatrix.h
+++ b/StrMatrix/pzbdstrmatrix.h
@@ -42,9 +42,9 @@ public:
     //@}
     
     void AssembleBlockDiagonal(TPZBlockDiagonal<TVar> & block);
-private:
-    
+
     void BlockSizes(TPZVec < int > & blocksizes);
+private:
     
     MBlockStructure fBlockStructure{EVertexBased};
     

--- a/UnitTest_PZ/TestIterative/TestIterative.cpp
+++ b/UnitTest_PZ/TestIterative/TestIterative.cpp
@@ -21,6 +21,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
 
+
+//useful for debugging
+// #define TEST_1D
+
 template<>
 struct Catch::StringMaker<long double> {
     static std::string convert(long double ref);
@@ -39,6 +43,8 @@ std::string Catch::StringMaker<long double>::convert(long double value) {
 namespace testiterative{
   //! Creates computational mesh for 2d poisson problem
   TPZCompMesh *CreateCMesh();
+  //! Creates computational mesh for 1d poisson problem
+  TPZCompMesh *CreateCMesh1D();
   //! Creates vector of active equations by removing all dirichlet bc eqs
   void
   FilterBoundaryEquations(TPZCompMesh * cmesh,
@@ -199,11 +205,72 @@ TEST_CASE("Equation filter and precond","[iterative_testss]") {
   Catch::StringMaker<STATE>::precision = oldPrecision;
 }
 
+
+#ifdef TEST_1D
+/*
+  The following test case is mostly for debugging.
+  No need to run it every time
+ */
+TEST_CASE("1D H1 problem","[iterative_tests]") {
+  auto oldPrecision = Catch::StringMaker<STATE>::precision;
+  Catch::StringMaker<STATE>::precision = std::numeric_limits<STATE>::max_digits10;
+  TPZAutoPointer<TPZCompMesh> cmesh = testiterative::CreateCMesh1D();
+  constexpr bool optimizeBandwidth{false};
+  TPZLinearAnalysis an(cmesh,optimizeBandwidth);
+  {
+    TPZStepSolver<STATE> solv;
+    solv.SetDirect(ECholesky);
+    an.SetSolver(solv);
+  }
+#if defined (PZ_USING_MKL) || (PZ_USING_EIGEN)
+  TPZSSpStructMatrix<STATE> str(cmesh);
+#else
+  TPZSkylineStructMatrix<STATE>str(cmesh);
+#endif
+  TPZVec<int64_t> active_eqs;
+  testiterative::FilterBoundaryEquations(cmesh.operator->(), active_eqs);
+  str.EquationFilter().SetActiveEquations(active_eqs);
+  an.SetStructuralMatrix(str);
+  an.Assemble();
+
+  auto *solver = dynamic_cast<TPZStepSolver<STATE>*>(an.Solver());
+
+  solver->Matrix()->SetSymmetry(SymProp::Herm);
+  solver->Matrix()->SetDefPositive(true);
+
+
+  constexpr int64_t fromCurrent{0};
+
+  auto pre_type = GENERATE(Precond::Jacobi,
+                           Precond::BlockJacobi,
+                           Precond::Element,
+                           Precond::NodeCentered);
+  
+  const bool overlap = GENERATE(true,false);
+  const auto precondname = std::string(Precond::Name(pre_type)) +
+                                       (overlap ? " with overlap" : " without overlap");
+  SECTION(precondname){
+    std::cout<<"1d: testing "<<precondname<<std::endl;
+    TPZAutoPointer<TPZMatrixSolver<STATE>> pre =
+      an.BuildPreconditioner<STATE>(pre_type, overlap);
+    const bool created_precond = pre;
+    REQUIRE(created_precond);
+    solver->SetGMRES(testiterative::niter, testiterative::niter,
+                     *pre, testiterative::tol, fromCurrent);
+    an.Solve();
+    const auto tol_res = solver->GetTolerance();
+    REQUIRE(tol_res <= testiterative::tol);
+  }
+  Catch::StringMaker<STATE>::precision = oldPrecision;
+}
+
+#endif
+
 namespace testiterative{
 
   TPZCompMesh *CreateCMesh()
   {
-    constexpr int rhsPOrder{2};
+    constexpr int rhsPOrder{3};
     const auto rhs = [](const TPZVec<REAL>&loc, TPZVec<STATE> &u){
       const REAL &x = loc[0];
       const REAL &y = loc[1];
@@ -276,6 +343,77 @@ namespace testiterative{
     return cmesh;
   }
 
+  TPZCompMesh *CreateCMesh1D()
+  {
+    /*
+      this rhs corresponds to the solution (x^2-1)^2
+     */
+    constexpr int rhsPOrder{2};
+    const auto rhs = [](const TPZVec<REAL>&loc, TPZVec<STATE> &u){
+      const REAL &x = loc[0];
+      const REAL &y = loc[1];
+      u[0] = 4-12*x*x;
+    };
+    
+    //dimension of the problem
+    constexpr int dim{1};
+    //number of elements
+    constexpr int nEls{5};
+    //all geometric coordinates in NeoPZ are in the 3D space
+
+    //left boundary
+    constexpr REAL minX{-1};
+    //right boundary
+    constexpr REAL maxX{ 1};
+
+    /*vector for storing materials(regions) identifiers
+     * for the TPZGeoMeshTools::CreateGeoMeshOnGrid function.
+     * In this example, we have different materials in each
+     * section of the boundary*/
+    TPZManVector<int,5> matIdVec={1,-1,-1};
+    //whether to create boundary elements
+    constexpr bool genBoundEls{true};
+    //type of elements
+    constexpr MMeshType meshType{MMeshType::ETriangular};
+
+
+    //polynomial order of elements
+    constexpr int pOrder{3};
+    //defining the geometry of the problem
+    //TPZAutoPointer is a smart pointer from the NeoPZ library
+    TPZAutoPointer<TPZGeoMesh> gmesh =
+      TPZGeoMeshTools::CreateGeoMesh1D(minX, maxX, nEls, matIdVec, genBoundEls);
+
+    TPZCompMesh *cmesh = new TPZCompMesh(gmesh);
+
+    auto *mat = new TPZMatPoisson<STATE>(matIdVec[0],dim);
+    //TPZMatLaplacian solves div(k grad(u)) = -f
+    mat->SetForcingFunction(rhs,rhsPOrder);
+    cmesh->InsertMaterialObject(mat);
+
+    //now we insert the boundary conditions
+    {
+      //TPZFMatrix<T> implements a full matrix of type T
+      /* val1 and val2 are used for calculating the boundary
+       * conditions. val1 goes in the matrix and val2 in the rhs.
+       * for dirichlet boundary conditions, only the value of 
+       * val2 is used.*/
+      TPZFMatrix<STATE> val1(1,1,0.);
+      TPZManVector<STATE,1> val2={0};
+      //dirichlet=0,neumann=1,robin=2
+      constexpr int boundType{0};
+      //TPZBndCond is a material type for boundary conditions
+      TPZBndCond * bnd = mat->CreateBC(mat,matIdVec[1],boundType,val1,val2);
+      cmesh->InsertMaterialObject(bnd);
+
+    }
+    
+    cmesh->SetAllCreateFunctionsContinuous();
+    cmesh->SetDefaultOrder(pOrder);
+    cmesh->AutoBuild();
+    return cmesh;
+  }
+  
   void FilterBoundaryEquations(TPZCompMesh *cmesh,
                                TPZVec<int64_t> &activeEquations) {
     TPZManVector<int64_t, 1000> allConnects;

--- a/UnitTest_PZ/TestMatrix/TestMatrix.cpp
+++ b/UnitTest_PZ/TestMatrix/TestMatrix.cpp
@@ -18,6 +18,8 @@
 #include "TPZSYSMPPardiso.h"
 #endif
 #include "tpzsparseblockdiagonal.h"
+#include "pzseqsolver.h"
+#include "pzstepsolver.h"
 #include <random>
 
 #include <catch2/catch_test_macros.hpp>
@@ -855,6 +857,8 @@ template<class TVar>
 
   template<class TVar>
   void SparseBlockDiagInverse();
+  template<class TVar>
+  void SparseBlockColorInverse();
 };
 
 
@@ -1122,6 +1126,7 @@ TEMPLATE_TEST_CASE("Additional Block Diagonal tests","[matrix_tests]",
   }
   SECTION("Sparse Block Inverse"){
     testmatrix::SparseBlockDiagInverse<TestType>();
+    testmatrix::SparseBlockColorInverse<TestType>();
   }
 }
 TEMPLATE_TEST_CASE("Symmetry test","[matrix_tests]",
@@ -2364,5 +2369,92 @@ void SparseBlockDiagInverse(){
       REQUIRE((std::abs(resblck.GetVal(ieq,0)) == Catch::Approx(0).margin(tol)));
     }
   }
-}   
+}
+
+template<class TVar>
+void SparseBlockColorInverse(){
+
+  constexpr int neq = 10;
+  constexpr int nblocks = 4;
+  //expected solution is {1,1,1,1,1,1,1,1,1,1}^T
+  TPZAutoPointer<TPZFMatrix<TVar>> fmat =
+    new TPZFMatrix<TVar>({
+        {1, 2, 0, 1, 0, 0, 0, 0, 0, 0},
+        {3, 1, 0, 2, 0, 0, 0, 0, 0, 0},
+        {0, 0, 1, 0, 4, 1, 0, 0, 0, 0},
+        {3, 2, 0, 3, 0, 0, 0, 0, 0, 0},
+        {0, 0, 2, 0, 1, 1, 0, 0, 0, 0},
+        {0, 0, 3, 0, 5, 4, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 1, 0, 2, 0},
+        {0, 0, 0, 0, 0, 0, 0, 6, 0, 2},
+        {0, 0, 0, 0, 0, 0, 3, 0, 4, 0},
+        {0, 0, 0, 0, 0, 0, 0, 2, 0, 5}
+    });
+
+  // TPZAutoPointer<TPZFYsmpMatrix<TVar>> smat = new TPZFYsmpMatrix<TVar>(neq,neq);
+  // TPZVec<int64_t> ia = {0,3,6,9,12,15,18,20,22,24,26};
+  // TPZVec<int64_t> ja = {0,1,3,0,1,3,2,4,5,0,1,3,2,4,5,2,4,5,6,8,7,9,6,8,7,9};
+  // TPZVec<TVar> aa =    {1,2,1,3,1,2,1,4,1,3,2,3,2,1,1,3,5,4,1,2,6,2,3,4,2,5};
+  // smat->SetData(ia,ja,aa);
+  
+  TPZFMatrix<TVar> rhs = {4,6,6,8,4,12,3,8,7,7};
+  //now we will extract a few blocks from the full matrix
+  //non-null equations
+  TPZVec<int64_t> blockgraph =
+    {
+      0,1,3,//first block
+      2,4,5,//second block
+      6,8,//third block
+      7,9//fourth block
+    };
+
+  //index in blockgraph of first equation of each block
+  TPZVec<int64_t> blockgraphindex =
+    {
+      0,//first block
+      3,//second block
+      6,//third block
+      8,//fourth block
+      10//size of blockgraph
+    };
+  constexpr int numcolors{2};
+  //block colors
+  TPZVec<int> colors =
+    {
+      0,//first block
+      1,//second block
+      0,//third block
+      1//fourth bock
+    };
+
+  TPZSequenceSolver<TVar> seqsolv;
+  for(int c = 0; c < numcolors; c++){
+    
+    TPZAutoPointer<TPZSparseBlockDiagonal<TVar>> blmat
+      = new TPZSparseBlockDiagonal<TVar>(blockgraph,blockgraphindex,neq,c,colors);
+    blmat->BuildFromMatrix(*fmat);
+    
+    TPZStepSolver<TVar> step(blmat);
+    step.SetDirect(ELU);
+    seqsolv.AppendSolver(step);
+  }
+  seqsolv.SetMatrix(fmat);
+  TPZFMatrix<TVar> res = rhs;
+
+
+
+  constexpr RTVar tol =std::numeric_limits<RTVar>::epsilon()*2000;
+  /*
+  //just to ensure that the solution is correct
+  TPZAutoPointer<TPZMatrix<TVar>> fmatcp = fmat->Clone();
+  fmatcp->SolveDirect(res,ELU);
+  for(int i = 0; i < neq; i++){
+    REQUIRE(std::abs(res.GetVal(i,0)-(TVar)1.)==Catch::Approx(0).margin(tol));
+  }
+  */
+  seqsolv.Solve(rhs, res);
+  for(int i = 0; i < neq; i++){
+    REQUIRE(std::abs(res.GetVal(i,0)-(TVar)1.)==Catch::Approx(0).margin(tol));
+  }
+}
 };

--- a/Util/log4cxx.cfg
+++ b/Util/log4cxx.cfg
@@ -264,10 +264,16 @@ log4j.appender.front.Append=false
 log4j.appender.front.layout=org.apache.log4j.PatternLayout
 log4j.appender.front.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n
 
-log4j.logger.pz.analysis=info
+log4j.logger.pz.analysis=info,analysisfile
+log4j.appender.analysisfile=org.apache.log4j.FileAppender
+log4j.appender.analysisfile.File=LOG/analysis.txt
+log4j.appender.analysisfile.Append=false
+log4j.appender.analysisfile.layout=org.apache.log4j.PatternLayout
+log4j.appender.analysisfile.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n
 log4j.logger.pz.analysis.pzsmanalysis=info
 log4j.logger.pz.analysis.elastoplastic=info
 log4j.logger.pz.analysis.postproc=info
+log4j.logger.pz.analysis.precondgraph=info
 
 log4j.logger.material.plasticity.SML2=info
 log4j.logger.material.plasticity.SML=info


### PR DESCRIPTION
This PR agglomerates several changes that arose during exhaustive tests of iterative methods.

**GMRES**
- debug output is more complete, now it shows precond correction at every iteration
- adds missing includes to gmres.h
- minor fixes on tolerances
- indent
- printing initial precond correction
- rotation change for complex matrices, as [they can be quite nasty](https://www.cs.cornell.edu/~bindel/papers/2002-toms.pdf)
- avoids copy of matrix on restart

**TestIterative**
- adds 1D test for ease of debugging
- sensitive parameters

**Sparse matrices**
- Removes non-working GetSub methods of `TPZYsmpMatrix`
- adds `GetRowIndices` method in `TPZMatrix` and `TPZFYsmpMatrix`
- adds `RowTimesVector` method in `TPZMatrix` and `TPZFYsmpMatrix`

**Block matrices**
- adds `GetBlockPtr`, `GetBlockList` and `GetBlockEqs` methods
- adds additional tests (coloring, set block indices, etc)

**Renumbering**
- installing renumbering algorithms (external projects can choose `TPZCutHillMcKee`, for instance)
- Fixes on `TPZNodeSetCompute::ColorGraph` and adds option for even more strict coloring
- Several optimizations involving dynamic memory allocation. Still much to be done, though.

**TPZAnalysis**
- Changes on `BuildPreconditioner` method + documentation