### PR TITLE
Hcurl changes

### DIFF
--- a/Mesh/TPZCompElHCurl.cpp
+++ b/Mesh/TPZCompElHCurl.cpp
@@ -509,8 +509,8 @@ void TPZCompElHCurl<TSHAPE>::SideShapeFunction(int side,TPZVec<REAL> &point,TPZF
         }
     }();
     
-    TPZFMatrix<REAL> phiref(sidedim,nshape);
-    TPZFMatrix<REAL> curlphiref(curldim,nshape);
+    TPZFNMatrix<1000, REAL> phiref(sidedim,nshape);
+    TPZFNMatrix<1000, REAL> curlphiref(curldim,nshape);
     
     switch(sidetype){
     case EOned:
@@ -563,7 +563,7 @@ void TPZCompElHCurl<TSHAPE>::TransformShape(const TPZFMatrix<REAL> &phiref,
 {
 
     //applies covariant piola transform and compute the deformed vectors
-    TPZFMatrix<REAL> axest, jacinvt;
+    TPZFNMatrix<9,REAL> axest, jacinvt;
     jacinv.Transpose(&jacinvt);
     axes.Transpose(&axest);
 

--- a/Mesh/TPZCompElHCurl.cpp
+++ b/Mesh/TPZCompElHCurl.cpp
@@ -567,7 +567,13 @@ void TPZCompElHCurl<TSHAPE>::TransformShape(const TPZFMatrix<REAL> &phiref,
     jacinv.Transpose(&jacinvt);
     axes.Transpose(&axest);
 
-    (axest * (jacinvt * phiref)).Transpose(&phi);
+    //2000 should take care of up to a 6th order tetrahedral el
+    TPZFNMatrix<2000,REAL> tmp1,tmp2;
+    //we want to do (axest * (jacinvt * phiref)).Transpose(&phi);
+    //with no mem alloc
+    jacinvt.Multiply(phiref, tmp1);
+    axest.Multiply(tmp1,tmp2);
+    tmp2.Transpose(&phi);
 }
 
 template<class TSHAPE>
@@ -578,7 +584,7 @@ void TPZCompElHCurl<TSHAPE>::TransformCurl(const TPZFMatrix<REAL> &curlphiref,
                                            TPZFMatrix<REAL> &curlphi)
 {
     if constexpr(TDIM==3){
-        curlphi = jacobian * curlphiref;
+        jacobian.Multiply(curlphiref, curlphi);
         curlphi *= 1./detjac;
     }else {
         curlphi = curlphiref;

--- a/Mesh/TPZCompElHCurl.cpp
+++ b/Mesh/TPZCompElHCurl.cpp
@@ -278,7 +278,7 @@ void TPZCompElHCurl<TSHAPE>::SetSideOrder(int side, int order){
     c.SetNState(nvars);
     const int nshape =this->NConnectShapeF(connect,order);
     c.SetNShape(nshape);
-    this-> Mesh()->Block().Set(seqnum,nshape*nvars);
+    this->Mesh()->Block().Set(seqnum,nshape*nvars);
 }
 
 template<class TSHAPE>
@@ -591,7 +591,7 @@ template<class TSHAPE>
 void TPZCompElHCurl<TSHAPE>::CreateHCurlConnects(TPZCompMesh &mesh){
     constexpr int nNodes = TSHAPE::NCornerNodes;
     constexpr int nConnects = TSHAPE::NSides - nNodes;
-    this->fConnectIndexes.Resize(nConnects);
+    
     for(auto i = 0; i < nConnects; i++){
         const int sideId = nNodes + i;
         this->fConnectIndexes[i] = this->CreateMidSideConnect(sideId);
@@ -607,12 +607,7 @@ void TPZCompElHCurl<TSHAPE>::CreateHCurlConnects(TPZCompMesh &mesh){
         mesh.ConnectVec()[this->fConnectIndexes[i]].IncrementElConnected();
         this->IdentifySideOrder(sideId);
     }
-    int sideorder = 2*EffectiveSideOrder(TSHAPE::NSides-1);
-    if (sideorder > this->fIntRule.GetMaxOrder()){
-        sideorder = this->fIntRule.GetMaxOrder();
-    }
-    TPZManVector<int,3> order(3,sideorder);
-    this->fIntRule.SetOrder(order);
+    this->AdjustIntegrationRule();
 }
 
 template<class TSHAPE>

--- a/Mesh/TPZCompElHCurl.cpp
+++ b/Mesh/TPZCompElHCurl.cpp
@@ -509,8 +509,8 @@ void TPZCompElHCurl<TSHAPE>::SideShapeFunction(int side,TPZVec<REAL> &point,TPZF
         }
     }();
     
-    TPZFNMatrix<1000, REAL> phiref(sidedim,nshape);
-    TPZFNMatrix<1000, REAL> curlphiref(curldim,nshape);
+    TPZFNMatrix<1000, REAL> phiref(sidedim,nshape,0.);
+    TPZFNMatrix<1000, REAL> curlphiref(curldim,nshape,0.);
     
     switch(sidetype){
     case EOned:
@@ -530,7 +530,7 @@ void TPZCompElHCurl<TSHAPE>::SideShapeFunction(int side,TPZVec<REAL> &point,TPZF
 
     //get the jacobian of the side transformation
     TPZGeoElSide gelside = TPZGeoElSide(this->Reference(),side);
-    TPZFNMatrix<9,REAL> jac(sideDim,sideDim),jacinv(sideDim,sideDim),axes(sideDim,3);
+    TPZFNMatrix<9,REAL> jac(sideDim,sideDim,0.),jacinv(sideDim,sideDim,0.),axes(sideDim,3,0.);
     REAL detjac = 0;
     gelside.Jacobian(point, jac, axes, detjac, jacinv);
 

--- a/Mesh/TPZCompElHCurl.cpp
+++ b/Mesh/TPZCompElHCurl.cpp
@@ -366,8 +366,8 @@ void TPZCompElHCurl<TSHAPE>::ComputeShape(TPZVec<REAL> &qsi, TPZMaterialData &da
 //          }();
 
     const int nshape = this->NShapeF();
-    TPZFNMatrix<dim*80,REAL> phiref(dim,nshape);
-    TPZFNMatrix<curldim*80,REAL> curlphiref(curldim,nshape);
+    TPZFNMatrix<dim*80,REAL> phiref(dim,nshape,0.);
+    TPZFNMatrix<curldim*80,REAL> curlphiref(curldim,nshape,0.);
 
     TPZShapeData &shapedata = data;
     switch (fhcurlfam)

--- a/Shape/TPZShapeHCurl.cpp
+++ b/Shape/TPZShapeHCurl.cpp
@@ -836,7 +836,8 @@ void TPZShapeHCurl<TSHAPE>::StaticIndexShapeToVec(TPZShapeData &data) {
 template<class TSHAPE>
 int TPZShapeHCurl<TSHAPE>::MaxOrder(const int ordh1){
 
-    if constexpr (std::is_same_v<TSHAPE,pzshape::TPZShapeCube> ||
+    if constexpr (std::is_same_v<TSHAPE,pzshape::TPZShapePrism> ||
+                  std::is_same_v<TSHAPE,pzshape::TPZShapeCube> ||
                   std::is_same_v<TSHAPE,pzshape::TPZShapeQuad>){
         return ordh1+1;
     }else{

--- a/Shape/TPZShapeHCurl.cpp
+++ b/Shape/TPZShapeHCurl.cpp
@@ -207,55 +207,43 @@ void TPZShapeHCurl<TSHAPE>::Shape(const TPZVec<T> &pt, TPZShapeData &data, TPZFM
     int vs_index = 0;
     int phi_index = 0;
 
-    //tmp phi and curlphi
-    TPZFNMatrix<dim,T> phi_1(dim,1),phi_2(dim,1);
-    TPZFNMatrix<curldim,T> cphi_1(curldim,1),cphi_2(curldim,1);
+    //low order funcs
+    TPZFNMatrix<dim*nedges,T> phi_lo(dim,nedges,0.);
+    TPZFNMatrix<curldim*nedges,T> curlphi_lo(curldim,nedges,0.);
+
+    TSHAPE::ComputeConstantHCurl(pt, phi_lo, curlphi_lo, data.fSideTransformationId);
+
+
+    TPZManVector<int64_t,nedges> firstH1edgeFunc(nedges,0);
+    firstH1edgeFunc[0] = ncorner;
+    for (int icon = 1; icon < nedges; icon++){
+        firstH1edgeFunc[icon] = firstH1edgeFunc[icon-1] + data.fH1NumConnectShape[icon-1];
+    }
+    
     //we iterate through edges...
     for(int icon = 0; icon < nedges; icon++){
         const auto order = connectorders[icon];
-
-        {//gets phi_1
-            const auto &itf = data.fSDVecShapeIndex[vs_index];
-            const int fv = itf.first;
-            const int fs = itf.second;
-            ComputeShape(phi_1,0,fs,fv);
-            ComputeCurl(cphi_1,0,fs,fv);
-        }
-
-        {//gets phi_2
-            const auto &its = data.fSDVecShapeIndex[vs_index+1];
-            const int sv = its.first;
-            const int ss = its.second;
-            ComputeShape(phi_2,0,ss,sv);
-            ComputeCurl(cphi_2,0,ss,sv);
-        }
-
-        //constant trace
+        //constant traces
         for(auto x = 0; x < dim; x++){
-            phi(x,phi_index) =  phi_1.GetVal(x,0) + phi_2.GetVal(x,0);
+            phi(x,phi_index) =  phi_lo.GetVal(x,icon);
         }
         for(auto x = 0; x < curldim; x++){
-            curlphi(x,phi_index) =  cphi_1.GetVal(x,0) + cphi_2.GetVal(x,0);
+            curlphi(x,phi_index) =  curlphi_lo.GetVal(x,icon);
         }
-        phi_index++;
-        if(order>0){
-            //linear traces
+        phi_index++;vs_index++;
+        
+        if(order==0){vs_index++;}
+        vs_index += order;
+        
+        const int firstedgefunc = firstH1edgeFunc[icon];
+        for(int ord = 1; ord < order+1; ord++, phi_index++){
+            const int scalindex = firstedgefunc + ord-1;
             for(auto x = 0; x < dim; x++){
-                phi(x,phi_index) =  phi_1.GetVal(x,0) - phi_2.GetVal(x,0);
+                phi(x,phi_index) =  dphi.GetVal(x,scalindex);
             }
             for(auto x = 0; x < curldim; x++){
-                curlphi(x,phi_index) =  cphi_1.GetVal(x,0) - cphi_2.GetVal(x,0);
+                curlphi(x,phi_index) =  0;
             }
-            phi_index++;
-        }
-        vs_index+=2;
-        //higher order edge functions
-        for(int ord = 2; ord < order+1; ord++, phi_index++, vs_index++){
-            const auto &it = data.fSDVecShapeIndex[vs_index];
-            const int vecindex = it.first;
-            const int scalindex = it.second;
-            ComputeShape(phi,phi_index,scalindex,vecindex);
-            ComputeCurl(curlphi,phi_index,scalindex,vecindex);
         }
     }
 
@@ -269,8 +257,14 @@ void TPZShapeHCurl<TSHAPE>::Shape(const TPZVec<T> &pt, TPZShapeData &data, TPZFM
         ComputeShape(phi,phi_index,scalindex,vecindex);
         ComputeCurl(curlphi,phi_index,scalindex,vecindex);
     }
-
-
+// #ifdef PZDEBUG
+    if(vs_index!=data.fSDVecShapeIndex.size()){
+        DebugStop();
+    }
+    if(phi_index != phi.Cols()){
+        DebugStop();
+    }
+// #endif
 }
 
 
@@ -348,19 +342,23 @@ void TPZShapeHCurl<TSHAPE>::CalcH1ShapeOrders(
     for(auto iCon = 0; iCon < nConnects; iCon++){
         const auto iSide = iCon + TSHAPE::NCornerNodes;
         const auto sideDim = TSHAPE::SideDimension(iSide);
-        const bool quadSide =
+        const bool quadSideOrEdge =
+            TSHAPE::Type(iSide) == EOned ||
             TSHAPE::Type(iSide) == EQuadrilateral ||
             TSHAPE::Type(iSide) == ECube ||
             TSHAPE::Type(iSide) == EPrisma;
-        /*some H1 functions associated with the side iSide of dimension dim
+        /*
+          some H1 functions associated with the side iSide of dimension dim
           might be needed for computing the shape functions of a side with
           dimension dim+1 that contains the side iSide.
+          for instance, p+1 h1 edge functions are needed for p hcurl elements
+          
           It is also worth noting that quadrilateral sides require functions
           of ordH1er k+1*/
         TPZStack<int> highDimSides;
         TSHAPE::HigherDimensionSides(iSide, highDimSides);
         const auto sideOrder = ordHCurl[iCon];
-        auto maxOrder = quadSide ? sideOrder + 1: sideOrder;
+        auto maxOrder = quadSideOrEdge ? sideOrder + 1: sideOrder;
         for(auto &ihSide : highDimSides){
             if(TSHAPE::SideDimension(ihSide) != sideDim+1) break;
             else {

--- a/Shape/TPZShapeHCurl.cpp
+++ b/Shape/TPZShapeHCurl.cpp
@@ -148,8 +148,8 @@ void TPZShapeHCurl<TSHAPE>::Shape(const TPZVec<T> &pt, TPZShapeData &data, TPZFM
     constexpr int nvol = dim == 3 ? 1 : 0;
     constexpr int nedges = nsides - nvol - nfaces - ncorner;
     
-    TPZFNMatrix<100,T> locphi(data.fPhi.Rows(),data.fPhi.Cols());
-    TPZFNMatrix<100*dim,T> dphi(data.fDPhi.Rows(),data.fDPhi.Cols());
+    TPZFNMatrix<100,T> locphi(data.fPhi.Rows(),data.fPhi.Cols(),0.);
+    TPZFNMatrix<100*dim,T> dphi(data.fDPhi.Rows(),data.fDPhi.Cols(),0.);
     
     TPZShapeH1<TSHAPE>::Shape(pt,data, locphi, dphi);
 

--- a/Shape/pzshapelinear.cpp
+++ b/Shape/pzshapelinear.cpp
@@ -90,6 +90,63 @@ namespace pzshape {
 #endif
 		
 	} //end of method
+
+    void TPZShapeLinear::IntegratedLegendre(REAL x,int num,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
+		if (num <= 0) return;
+		phi.Put(0, 0, 1.0);
+		dphi.Put(0, 0, 0.0);
+		
+		if (num == 1) return;
+		
+		phi.Put(1, 0, x);
+		dphi.Put(0, 1, 1.0);
+
+        if(num == 2) return;
+
+        phi.Put(2,0,0.5*(x*x-1));
+        dphi.Put(0,2,x);
+
+		for (auto ord = 3; ord < num; ord++)
+		{
+            const auto coeff1 = 2*(ord-1)-1;
+            const auto coeff2 = ord-3;
+			const auto val = coeff1*x*phi.GetVal(ord-1,0) - coeff2*phi.GetVal(ord-2,0);
+			phi.Put(ord, 0, val/ord);
+			
+			const auto deriv = coeff1*phi.GetVal(ord-1,0) + coeff1*x*dphi.GetVal(0,ord-1)
+                - coeff2*dphi.GetVal(0,ord-2);
+			dphi.Put(0, ord, deriv/ord);
+		}
+	}
+    void TPZShapeLinear::ScaledIntegratedLegendre(const REAL x,const REAL t, int num,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi){
+				if (num <= 0) return;
+		phi.Put(0, 0, 1.0);
+		dphi.Put(0, 0, 0.0);
+		
+		if (num == 1) return;
+		
+		phi.Put(1, 0, x);
+		dphi.Put(0, 1, 1.0);
+
+        if(num == 2) return;
+
+        phi.Put(2,0,0.5*(x*x-t*t));
+        dphi.Put(0,2,x);
+
+        TPZFNMatrix<300,REAL> phi_leg(num,1,0), dphi_leg(1,num,0);
+        TPZShapeLinear::IntegratedLegendre(x, num, phi_leg, dphi_leg);
+		for (auto ord = 3; ord < num; ord++)
+		{
+            const auto coeff1 = 2*(ord-1)-1;
+            const auto coeff2 = (ord-3)*t*t;
+			const auto val = coeff1*x*phi_leg.GetVal(ord-1,0) - coeff2*phi_leg.GetVal(ord-2,0);
+			phi.Put(ord, 0, val/ord);
+			
+			const auto deriv = coeff1*phi_leg.GetVal(ord-1,0) + coeff1*x*dphi_leg.GetVal(0,ord-1)
+                - coeff2*dphi_leg.GetVal(0,ord-2);
+			dphi.Put(0, ord, deriv/ord);
+		}
+	}
 	
 	void TPZShapeLinear::Legendre(REAL x,int num,TPZFMatrix<REAL> &phi,TPZFMatrix<REAL> &dphi, int nderiv){
 		

--- a/Shape/pzshapelinear.h
+++ b/Shape/pzshapelinear.h
@@ -73,6 +73,23 @@ namespace pzshape {
 		 * @param dphi values of the derivatives of the shape functions
 		 */
 		static void Legendre(REAL x,int num,TPZFMatrix<REAL> & phi,TPZFMatrix<REAL> & dphi);
+        /**
+		 * @brief Legendre orthogonal polynomial, computes num orthogonal functions at the point x
+		 * @param x coordinate of the point
+		 * @param num number of shape functions to be computed
+		 * @param phi shapefunction values
+		 * @param dphi values of the derivatives of the shape functions
+		 */
+		static void IntegratedLegendre(REAL x,int num,TPZFMatrix<REAL> & phi,TPZFMatrix<REAL> & dphi);
+        /**
+		 * @brief Legendre orthogonal polynomial, computes num orthogonal functions at the point x
+		 * @param x coordinate of the point
+         * @param t scaling factor
+		 * @param num number of shape functions to be computed
+		 * @param phi shapefunction values
+		 * @param dphi values of the derivatives of the shape functions
+		 */
+		static void ScaledIntegratedLegendre(REAL x, REAL t, int num,TPZFMatrix<REAL> & phi,TPZFMatrix<REAL> & dphi);
 		
 		/**
 		 * @brief Jacobi orthogonal polynomials

--- a/UnitTest_PZ/TestMesh/TestHDivConstant.cpp
+++ b/UnitTest_PZ/TestMesh/TestHDivConstant.cpp
@@ -517,7 +517,9 @@ void IntegralNormal()
         TPZManVector<int> orders(TSHAPE::NFacets+1,1);
         TPZManVector<int> sideorient(TSHAPE::NFacets,1);
         shape.Initialize(ids, orders, sideorient, data);
-        data.fSideTransformationId.Resize(TSHAPE::NFacets, 0);
+        // comment this out because it will break hcurl shape funcs
+        // why was it here?
+        // data.fSideTransformationId.Resize(TSHAPE::NFacets, 0);
         data.fSideOrient.Resize(TSHAPE::NFacets, 1);
         int nshape = shape.NHDivShapeF(data);
         TPZManVector<REAL> pt(3,0.);

--- a/UnitTest_PZ/TestTopology/TestTopology.cpp
+++ b/UnitTest_PZ/TestTopology/TestTopology.cpp
@@ -352,7 +352,7 @@ namespace topologytests{
         TPZShapeHCurl<TSHAPE>::Initialize(ids, conOrders, shapedata);
 
         const int npts = intRule->NPoints();
-        auto nshape = shapedata.fSDVecShapeIndex.size();
+        auto nshape = TPZShapeHCurl<TSHAPE>::NHCurlShapeF(shapedata);
 
         for (auto ipt = 0; ipt < npts; ipt++) {
             REAL w;


### PR DESCRIPTION
This PR concerns changes in the construction of HCurl-conforming approximation spaces.

Apart from some speedup/optimizations regarding dynamic memory allocation,
some relevant changes were made:

The edge functions for hcurl elements now consist of the lowest order edge functions (constant tangential trace) and gradient of H1 edge functions.

While the previous approach did contain the necessary gradients, there were also undesired solenoidal terms  which would strongly affect the performance of some preconditioners.