### PR TITLE
Brings back functionality from TPZCylinderMap

### DIFF
--- a/SpecialMaps/TPZCylinderMap.h
+++ b/SpecialMaps/TPZCylinderMap.h
@@ -88,9 +88,13 @@ namespace pzgeom {
             fOrigin = origin;
         }
 
-        /// axis direction with the vertical axis
-        /// the last line indicates the z-direction
-        void SetCylinderAxis(const TPZFMatrix<REAL> &axis);
+        /** @brief Sets axis of the cylinder and compute rotation matrix*/
+        void SetCylinderAxis(const TPZVec<REAL> &axis);
+        /** @brief Sets the rotation matrix that converts from the reference cylinder
+         to the cylinder in the xyz space.
+        Reference cylinder has axis (0,0,1), therefore last column of rotation matrix
+        should be the axis of the cylinder, and first two columns orthogonal vectors*/
+        void SetRotationMatrix(const TPZFMatrix<REAL> &rotmat);
         
         /// compute the cylindrical coordinates of the corner nodes
         void ComputeCornerCoordinates(TPZGeoMesh &gmesh);

--- a/SpecialMaps/tpzchangeel.h
+++ b/SpecialMaps/tpzchangeel.h
@@ -35,11 +35,15 @@ public:
     /** @brief Turns a regular linear element into a TPZArc3D*/
     static TPZGeoEl * ChangeToArc3D(TPZGeoMesh *mesh, const int64_t ElemIndex,
                                     const TPZVec<REAL> &xcenter, const REAL radius);
-    /** @brief Turns a regular 2D element into a TPZCylinderMap*/
+    /** @brief Turns a regular 2D element into a TPZCylinderMap(using rotation matrix)*/
     static TPZGeoEl * ChangeToCylinder(TPZGeoMesh *mesh, const int64_t ElemIndex,
                                        const TPZVec<REAL> &xcenter,
-                                       const TPZFMatrix<REAL> &axis);
-
+                                       const TPZFMatrix<REAL> &rotmatrix);
+    /** @brief Turns a regular 2D element into a TPZCylinderMap(using cylinder axis)*/
+    static TPZGeoEl * ChangeToCylinder(TPZGeoMesh *mesh, const int64_t ElemIndex,
+                                       const TPZVec<REAL> &xcenter,
+                                       const TPZVec<REAL> &axis);
+    
     /** @brief Slide middle nodes of an quadratic geoelement to the quarterpoint with respect to a given side */
     static TPZGeoEl * ChangeToQuarterPoint(TPZGeoMesh *Mesh, int64_t ElemIndex, int targetSide);
 

--- a/UnitTest_PZ/TestGeometry/GeometryUnitTest.cpp
+++ b/UnitTest_PZ/TestGeometry/GeometryUnitTest.cpp
@@ -174,7 +174,7 @@ TEMPLATE_TEST_CASE("TPZCylinder3D","[special_maps][geometry_tests]",
         auto *gel = new TPZGeoElRefLess<TPZCylinderMap<TGeo>> (nodeind,matid,gmesh);
 
         gel->Geom().SetOrigin(origin);
-        gel->Geom().SetCylinderAxis(axes);
+        gel->Geom().SetRotationMatrix(axes);
         gel->Geom().ComputeCornerCoordinates(gmesh);
         //let us test the corner nodes
         for(int i = 0; i < TGeo::NNodes; i++){


### PR DESCRIPTION
During the refactor that generalised the `TPZCylinderMap` template class, the option to set the cylinder axis was removed. Therefore, the user had to provide the rotation matrix that maps the reference cylinder to the cylinder in the xyz-space.

This PR brings back this functionality and, in order to prevent ambiguity/misusage, renames one of the methods to `SetRotationMatrix` instead of `SetCylinderAxis`.