### PR TITLE
Complex connect

### DIFF
--- a/Mesh/TPZCompElHCurl.cpp
+++ b/Mesh/TPZCompElHCurl.cpp
@@ -786,8 +786,10 @@ void TPZCompElHCurl<TSHAPE>::RestrainSide(int side, TPZInterpolatedElement *larg
             continue;
         }
         int64_t jnodindex = large->SideConnectIndex(jn, neighbourside);
-        TPZConnect::TPZDepend *depend = inod.AddDependency(inodindex, jnodindex, MSL, MBlocksmall.Position(in), MBlocklarge.Position(jn),
-                                                           MBlocksmall.Size(in), MBlocklarge.Size(jn));
+        TPZConnect::TPZDepend<STATE> *depend =
+            inod.AddDependency(inodindex, jnodindex, MSL,
+                               MBlocksmall.Position(in), MBlocklarge.Position(jn),
+                               MBlocksmall.Size(in), MBlocklarge.Size(jn));
         if (blocknorm(in, jn) < 1.e-8) {
             depend->fDepMatrix.Zero();
         }

--- a/Mesh/TPZElementMatrixT.cpp
+++ b/Mesh/TPZElementMatrixT.cpp
@@ -270,8 +270,11 @@ void TPZElementMatrixT<TVar>::ApplyConstraints(){
 			// insize : number of equations processed
 			
 			// loop over the nodes from which dfn depends
-			TPZConnect::TPZDepend *dep = dfn->FirstDepend();
+			TPZConnect::TPZDependBase *dep = dfn->FirstDepend();
+
+      TPZFNMatrix<50,TVar> depmat;
 			while(dep) {
+        dep->FillDepMatrix(depmat);
 				int64_t depnodeindex = dep->fDepConnectIndex;
 				// look for the index where depnode is found
 				int depindex=0;
@@ -289,12 +292,12 @@ void TPZElementMatrixT<TVar>::ApplyConstraints(){
 				int64_t send;
 				int64_t receive;
 				int ieq;
-				STATE coef;
+				TVar coef;
 				int idf;
 				int numstate = dfn->NState();
 				for(send=inpos; send<inpos+insize; send += numstate) {
 					for(receive=deppos; receive<deppos+depsize; receive += numstate) {
-						coef = dep->fDepMatrix((send-inpos)/numstate,(receive-deppos)/numstate);
+						coef = depmat((send-inpos)/numstate,(receive-deppos)/numstate);
 						if (this->fType == TPZElementMatrix::EK){
 							for(ieq=0; ieq<toteq; ieq++) for(idf=0; idf<numstate; idf++)  {
 								(this->fConstrMat)(receive+idf,ieq) += coef*(this->fConstrMat)(send+idf,ieq);
@@ -311,7 +314,7 @@ void TPZElementMatrixT<TVar>::ApplyConstraints(){
 				if (this->fType == TPZElementMatrix::EK){
 					for(send=inpos; send<inpos+insize; send += numstate) {
 						for(receive=deppos; receive<deppos+depsize; receive += numstate) {
-							coef = dep->fDepMatrix((send-inpos)/numstate,(receive-deppos)/numstate);
+							coef = depmat((send-inpos)/numstate,(receive-deppos)/numstate);
 							for(ieq=0; ieq<toteq; ieq++) for(idf=0; idf<numstate; idf++) {
 								(this->fConstrMat)(ieq,receive+idf) += coef*(this->fConstrMat)(ieq,send+idf);
 							}

--- a/Mesh/TPZElementMatrixT.cpp
+++ b/Mesh/TPZElementMatrixT.cpp
@@ -298,6 +298,13 @@ void TPZElementMatrixT<TVar>::ApplyConstraints(){
 				for(send=inpos; send<inpos+insize; send += numstate) {
 					for(receive=deppos; receive<deppos+depsize; receive += numstate) {
 						coef = depmat((send-inpos)/numstate,(receive-deppos)/numstate);
+            if constexpr (std::is_same_v<CTVar,TVar>){
+              /*weak formulations with complex basis functions are usually obtained
+               by multiplying by the complex conjugate test function, being consistent
+               with the complex inner product. therefore, if the dependency is complex,
+               we must conjugate it.*/
+              coef = std::conj(coef);
+            }
 						if (this->fType == TPZElementMatrix::EK){
 							for(ieq=0; ieq<toteq; ieq++) for(idf=0; idf<numstate; idf++)  {
 								(this->fConstrMat)(receive+idf,ieq) += coef*(this->fConstrMat)(send+idf,ieq);

--- a/Mesh/TPZMultiphysicsCompMesh.cpp
+++ b/Mesh/TPZMultiphysicsCompMesh.cpp
@@ -360,7 +360,7 @@ void TPZMultiphysicsCompMesh::AddConnects(){
             TPZConnect &cn = ConnectVec()[FirstConnect[i_as]+ic];
             if (cn.HasDependency())
             {
-                TPZConnect::TPZDepend *dep = cn.FirstDepend();
+                TPZConnect::TPZDependBase *dep = cn.FirstDepend();
                 while (dep) {
                     dep->fDepConnectIndex = dep->fDepConnectIndex+FirstConnect[i_as];
                     dep = dep->fNext;

--- a/Mesh/pzcheckmesh.cpp
+++ b/Mesh/pzcheckmesh.cpp
@@ -21,7 +21,7 @@ void TPZCheckMesh::BuildDependList(int connect, TPZStack<int> &dependlist) {
 	int nconnects = fMesh->ConnectVec().NElements();
 	int ic;
 	for(ic=0; ic<nconnects; ic++) {
-		TPZConnect::TPZDepend *dep = fMesh->ConnectVec()[ic].FirstDepend();
+		TPZConnect::TPZDependBase *dep = fMesh->ConnectVec()[ic].FirstDepend();
 		if(dep && dep->HasDepend(connect)) {
 			dependlist.Push(ic);
 			continue;
@@ -223,10 +223,10 @@ int TPZCheckMesh::CheckConstraintDimension()
         }
 		int iblsize = fMesh->Block().Size(iseqnum);
 		if(con.HasDependency()) {
-			TPZConnect::TPZDepend *dep = con.FirstDepend();
+			TPZConnect::TPZDependBase *dep = con.FirstDepend();
 			while(dep) {
-				int r = dep->fDepMatrix.Rows();
-				int c = dep->fDepMatrix.Cols();
+				int r = dep->DepRows();
+				int c = dep->DepCols();
 				int jcind = dep->fDepConnectIndex;
 				TPZConnect &jcon = fMesh->ConnectVec()[jcind];
 				int jseqnum = jcon.SequenceNumber();
@@ -295,7 +295,7 @@ int TPZCheckMesh::CheckConstraintDimension()
                     largecon.insert(large.Element()->ConnectIndex(icl));
                 }
                 TPZConnect &c = fMesh->ConnectVec()[*it];
-                TPZConnect::TPZDepend *dep = c.FirstDepend();
+                TPZConnect::TPZDependBase *dep = c.FirstDepend();
                 while(dep)
                 {
                     if (largecon.find(dep->fDepConnectIndex) == largecon.end()) {

--- a/Mesh/pzcheckrestraint.cpp
+++ b/Mesh/pzcheckrestraint.cpp
@@ -128,13 +128,13 @@ void TPZCheckRestraint::AddConnect(int connectindex) {
 			fRestraint(il,ic) = 1.;
 		}
 	} else {
-		TPZConnect::TPZDepend *depend = smallc.FirstDepend();
+		auto *depend = dynamic_cast<TPZConnect::TPZDepend<REAL>*>(smallc.FirstDepend());
 		if(!depend) {
 			cout << "TPZCheckRestraint::AddConnect data structure error 1\n";
 		}
 		while(depend) {
 			AddDependency(connectindex,depend->fDepConnectIndex,depend->fDepMatrix);
-			depend = depend->fNext;
+			depend = dynamic_cast<TPZConnect::TPZDepend<REAL>*>(depend->fNext);
 		}
 	}
 }
@@ -183,7 +183,7 @@ void TPZCheckRestraint::AddDependency(int smallconnectindex, int largeconnectind
 		}
 	} else {
 		TPZConnect &largec = fMesh->ConnectVec()[largeconnectindex];
-		TPZConnect::TPZDepend *depend = largec.FirstDepend();
+		auto depend = dynamic_cast<TPZConnect::TPZDepend<REAL> *>(largec.FirstDepend());
 		if(!depend) {
 			// recado de erro
 			cout << "TPZCheckRestraint::Error:\tLarge connect without dependency\n";
@@ -204,7 +204,7 @@ void TPZCheckRestraint::AddDependency(int smallconnectindex, int largeconnectind
 			
 			TPZFMatrix<REAL> depmat = dependmatrix * depend->fDepMatrix;
 			AddDependency(smallconnectindex,depend->fDepConnectIndex,depmat);
-			depend = depend->fNext;
+			depend = dynamic_cast<TPZConnect::TPZDepend<REAL> *>(depend->fNext);
 		}
 	}
 }

--- a/Mesh/pzcondensedcompel.cpp
+++ b/Mesh/pzcondensedcompel.cpp
@@ -259,7 +259,7 @@ void TPZCondensedCompElT<TVar>::Resequence()
     // this will be tracked by depreceive
     for (int ic=0; ic<ncon; ic++) {
         TPZConnect &c = fReferenceCompEl->Connect(ic);
-        TPZConnect::TPZDepend * dep = c.FirstDepend();
+        TPZConnect::TPZDependBase * dep = c.FirstDepend();
         while (dep) {
             depreceive.insert(dep->fDepConnectIndex);
             dep = dep->fNext;

--- a/Mesh/pzelchdiv.cpp
+++ b/Mesh/pzelchdiv.cpp
@@ -1207,9 +1207,22 @@ void TPZCompElHDiv<TSHAPE>::RestrainSide(int side, TPZInterpolatedElement *large
         // If negative, the element sides have opposite orientations and vice-versa.
 
             auto depend = myconnect.FirstDepend();
-            while(depend){
-                depend->fDepMatrix.MultiplyByScalar(-1.,depend->fDepMatrix);
-                depend = depend->fNext;
+            auto Invert = [](auto dep){
+                while(dep){
+                    dep->fDepMatrix.MultiplyByScalar(-1.,dep->fDepMatrix);
+                    dep = dynamic_cast<decltype(dep)>(dep->fNext);
+                }
+            };
+            auto dep_real =
+                dynamic_cast<TPZConnect::TPZDepend<STATE>*>(depend);
+            if(dep_real){
+                Invert(dep_real);
+            }else{
+                auto dep_cplx =
+                    dynamic_cast<TPZConnect::TPZDepend<CSTATE>*>(depend);
+                if(dep_cplx){
+                    Invert(dep_cplx);
+                }
             }
         }
     }

--- a/Mesh/pzelementgroup.cpp
+++ b/Mesh/pzelementgroup.cpp
@@ -116,7 +116,7 @@ void TPZElementGroup::ReorderConnects()
     // this will be tracked by depreceive
     for (int ic=0; ic<nc; ic++) {
         TPZConnect &c = Connect(ic);
-        TPZConnect::TPZDepend * dep = c.FirstDepend();
+        TPZConnect::TPZDependBase * dep = c.FirstDepend();
         while (dep) {
             depreceive.insert(dep->fDepConnectIndex);
             dep = dep->fNext;

--- a/Mesh/pzintel.cpp
+++ b/Mesh/pzintel.cpp
@@ -997,7 +997,7 @@ void TPZInterpolatedElement::RestrainSide(int side, TPZInterpolatedElement *larg
             continue;
         }
         int64_t jnodindex = large->SideConnectIndex(jn, neighbourside);
-        TPZConnect::TPZDepend *depend = inod.AddDependency(inodindex, jnodindex, MSL, MBlocksmall.Position(in), MBlocklarge.Position(jn),
+        TPZConnect::TPZDepend<STATE> *depend = inod.AddDependency(inodindex, jnodindex, MSL, MBlocksmall.Position(in), MBlocklarge.Position(jn),
                 MBlocksmall.Size(in), MBlocklarge.Size(jn));
         if (blocknorm(in, jn) < 1.e-8) {
             depend->fDepMatrix.Zero();
@@ -1221,7 +1221,7 @@ void TPZInterpolatedElement::CheckConstraintConsistency(int side) {
         int n_small_side_connect = NSideConnects(side)-1;
         TPZConnect &thiscon = SideConnect(n_small_side_connect, side);
         int jn;
-        TPZConnect::TPZDepend *dep = thiscon.FirstDepend();
+        TPZConnect::TPZDependBase *dep = thiscon.FirstDepend();
         while (dep) {
             for (jn = 0; jn < nlargesideconnects; jn++) {
                 int largeindex = largel->SideConnectIndex(jn, largeside);
@@ -1885,10 +1885,10 @@ bool TPZInterpolatedElement::VerifyConstraintConsistency(int side, TPZCompElSide
         int64_t clargeindex = largel->SideConnectIndex(ic, large.Side());
         largenshapeconnect[clargeindex] = clarge.NShape();
     }
-    TPZConnect::TPZDepend *depend = c.FirstDepend();
+    TPZConnect::TPZDependBase *depend = c.FirstDepend();
     while (depend) {
-        int nrow = depend->fDepMatrix.Rows();
-        int ncol = depend->fDepMatrix.Cols();
+        int nrow = depend->DepRows();
+        int ncol = depend->DepCols();
         /// the number of rows of the dependency matrix is equal to the number of shape functions of the connect associated with the small side
         if (nrow != c.NShape()) {
             return false;

--- a/Pre/TPZMHMixedMeshControl.cpp
+++ b/Pre/TPZMHMixedMeshControl.cpp
@@ -933,7 +933,7 @@ void TPZMHMixedMeshControl::HybridizeSkeleton(int skeletonmatid, int pressuremat
                 DebugStop();
             }
             TPZConnect &c = smallel->SideConnect(0, smallCompElSide.Side());
-            TPZConnect::TPZDepend *dep = c.FirstDepend();
+            TPZConnect::TPZDependBase *dep = c.FirstDepend();
             if(dep->fDepConnectIndex != origdepindex)
             {
                 DebugStop();

--- a/Pre/pzbuildmultiphysicsmesh.cpp
+++ b/Pre/pzbuildmultiphysicsmesh.cpp
@@ -148,7 +148,7 @@ void TPZBuildMultiphysicsMesh::AddConnects(TPZVec<TPZCompMesh *> &cmeshVec, TPZC
 			TPZConnect &cn = MFMesh->ConnectVec()[FirstConnect[imesh]+ic];
 			if (cn.HasDependency()) 
 			{
-				TPZConnect::TPZDepend *dep = cn.FirstDepend();
+				TPZConnect::TPZDependBase *dep = cn.FirstDepend();
 				while (dep) {
 					dep->fDepConnectIndex = dep->fDepConnectIndex+FirstConnect[imesh];
 					dep = dep->fNext;
@@ -229,7 +229,7 @@ void TPZBuildMultiphysicsMesh::AppendConnects(TPZCompMesh *cmesh, TPZCompMesh *M
         TPZConnect &cn = MFMesh->ConnectVec()[nconnects_old + ic];
         if (cn.HasDependency())
         {
-            TPZConnect::TPZDepend *dep = cn.FirstDepend();
+            TPZConnect::TPZDependBase *dep = cn.FirstDepend();
             while (dep)
             {
                 dep->fDepConnectIndex = dep->fDepConnectIndex + nconnects_old;


### PR DESCRIPTION
This PR allows for complex dependencies. For that, it was necessary to split `TPZDepend` into `TPZDependBase`, an abstract base class, and `TPZDepend<T>`, that contains type-relevant code, for `T=STATE` or `T=CSTATE`.