### PR TITLE
ConjTranspose operations

### DIFF
--- a/Matrix/pzblockdiag.cpp
+++ b/Matrix/pzblockdiag.cpp
@@ -415,13 +415,30 @@ int TPZBlockDiagonal<TVar>::Zero()
 /********************/
 /*** Transpose () ***/
 template<class TVar>
-void TPZBlockDiagonal<TVar>::Transpose (TPZMatrix<TVar> *const T) const
+void TPZBlockDiagonal<TVar>::Transpose (TPZMatrix<TVar> *const T, bool conj) const
 {
 	T->Resize( Dim(), Dim() );
 	
 	int64_t b, eq = 0, pos;
 	int bsize, r, c;
 	int64_t nb = fBlockSize.NElements();
+
+	if constexpr(is_complex<TVar>::value){
+    if(conj){
+			for ( b=0; b<nb; b++) {
+				pos= fBlockPos[b];
+				bsize = fBlockSize[b];
+				for(r=0; r<bsize; r++) {
+					for(c=0; c<bsize; c++) {
+						T->PutVal(eq+r,eq+c,std::conj(fStorage[pos+c+r*bsize]));
+					}
+				}
+				eq += bsize;
+			}
+			return;
+		}
+	}
+	
 	for ( b=0; b<nb; b++) {
 		pos= fBlockPos[b];
 		bsize = fBlockSize[b];

--- a/Matrix/pzblockdiag.h
+++ b/Matrix/pzblockdiag.h
@@ -86,7 +86,7 @@ public:
 	 */
 	int GetSizeofBlock(int64_t blockid) {return fBlockSize[blockid];}
 	
-	void Transpose(TPZMatrix<TVar> *const T) const override;
+	void Transpose(TPZMatrix<TVar> *const T, bool conj=false) const override;
     
     int SolveDirect( TPZFMatrix<TVar> &B , const DecomposeType dt) override {
         

--- a/Matrix/pzbndmat.cpp
+++ b/Matrix/pzbndmat.cpp
@@ -387,14 +387,31 @@ TPZFBMatrix<TVar>::SetBand( int64_t newBand )
 /*** Transpose () ***/
 template<class TVar>
 void
-TPZFBMatrix<TVar>::Transpose (TPZMatrix<TVar> *const T) const
+TPZFBMatrix<TVar>::Transpose (TPZMatrix<TVar> *const T, bool conj) const
 {
 	T->Resize( Dim(), Dim() );
 	
 	int64_t end, begin;
 	//REAL *p = fElem;
+  if constexpr (is_complex<TVar>::value){
+    if(conj){
+      
+      for ( int64_t r = 0; r < Dim(); r++ )
+      {
+        begin = MAX( r - fBandLower, 0 );
+        end   = MIN( r + fBandUpper + 1, Dim() );
+        for ( int64_t c = begin; c < end; c++ )
+        {
+          T->PutVal( c, r, std::conj(GetVal( r, c )) );
+          //			cout<<"(r,c)= "<<r<<"  "<<c<<"\n";
+        }
+      }
+      return;
+    }
+  }
+  
 	for ( int64_t r = 0; r < Dim(); r++ )
-    {
+  {
 		begin = MAX( r - fBandLower, 0 );
 		end   = MIN( r + fBandUpper + 1, Dim() );
 		for ( int64_t c = begin; c < end; c++ )
@@ -402,7 +419,7 @@ TPZFBMatrix<TVar>::Transpose (TPZMatrix<TVar> *const T) const
 			T->PutVal( c, r, GetVal( r, c ) );
 			//			cout<<"(r,c)= "<<r<<"  "<<c<<"\n";
 		}
-    }
+  }
 }
 
 

--- a/Matrix/pzbndmat.h
+++ b/Matrix/pzbndmat.h
@@ -149,7 +149,7 @@ public:
 	// Zeroes the elements of the matrix
 	int Zero() override;
 	
-	void Transpose(TPZMatrix<TVar> *const T) const override;
+	void Transpose(TPZMatrix<TVar> *const T, bool conj=false) const override;
     
     /** @brief decompose the system of equations acording to the decomposition
       * scheme */

--- a/Matrix/pzfmatrix.cpp
+++ b/Matrix/pzfmatrix.cpp
@@ -1179,10 +1179,21 @@ int TPZFMatrix<TVar>::Remodel(const int64_t newRows,const int64_t newCols) {
 /********************/
 /*** Transpose () ***/
 template <class TVar>
-void TPZFMatrix<TVar>::Transpose(TPZMatrix<TVar> *const T) const{
+void TPZFMatrix<TVar>::Transpose(TPZMatrix<TVar> *const T, bool conj) const{
     T->Resize( this->Cols(), this->Rows() );
     //Transposta por filas
     TVar * p = fElem;
+    if constexpr(is_complex<TVar>::value){
+        if(conj){
+            for ( int64_t c = 0; c < this->Cols(); c++ ) {
+                for ( int64_t r = 0; r < this->Rows(); r++ ) {
+                    T->PutVal( c, r, std::conj(*p++) );
+                    //            cout<<"(r,c)= "<<r<<"  "<<c<<"\n";
+                }
+            }
+            return;
+        }
+    }
     for ( int64_t c = 0; c < this->Cols(); c++ ) {
         for ( int64_t r = 0; r < this->Rows(); r++ ) {
             T->PutVal( c, r, *p++ );
@@ -1194,7 +1205,15 @@ void TPZFMatrix<TVar>::Transpose(TPZMatrix<TVar> *const T) const{
 template <class TVar>
 void TPZFMatrix<TVar>::Transpose() {
     TPZFMatrix<TVar> temp;
-    Transpose(&temp);
+    constexpr bool conj{false};
+    Transpose(&temp,conj);
+    *this = temp;
+}
+template <class TVar>
+void TPZFMatrix<TVar>::ConjTranspose() {
+    TPZFMatrix<TVar> temp;
+    constexpr bool conj{true};
+    Transpose(&temp,conj);
     *this = temp;
 }
 

--- a/Matrix/pzfmatrix.cpp
+++ b/Matrix/pzfmatrix.cpp
@@ -702,138 +702,6 @@ void TPZFMatrix<TVar>::MultAdd(const TVar *ptr, int64_t rows, int64_t cols, cons
     
 }
 
-#ifdef USING_LAPACK
-template<>
-void TPZFMatrix<double>::MultAdd(const TPZFMatrix<double> &x,const TPZFMatrix<double> &y, TPZFMatrix<double> &z,
-                                 const double alpha,const double beta,const int opt) const {
-    
-#ifdef PZDEBUG
-    if ((!opt && this->Cols() != x.Rows()) || (opt && this->Rows() != x.Rows())) {
-        Error( "TPZFMatrix::MultAdd matrix x with incompatible dimensions>" );
-        return;
-    }
-    if(beta != (double)0. && ((!opt && this->Rows() != y.Rows()) || (opt && this->Cols() != y.Rows()) || y.Cols() != x.Cols())) {
-        Error( "TPZFMatrix::MultAdd matrix y with incompatible dimensions>" );
-        return;
-    }
-#endif
-    if(!opt) {
-        if(z.Cols() != x.Cols() || z.Rows() != this->Rows()) {
-            z.Redim(this->Rows(),x.Cols());
-        }
-    } else {
-        if(z.Cols() != x.Cols() || z.Rows() != this->Cols()) {
-            z.Redim(this->Cols(),x.Cols());
-        }
-    }
-    if(this->Cols() == 0) {
-        z.Zero();
-        if (beta != 0) {
-            z = y;
-            z *= beta;
-        }
-        return;
-    }
-    if (beta != (double)0.) {
-        z = y;
-    }
-    if (Rows() == 0 || Cols() == 0 || x.Rows() == 0 || x.Cols() == 0) {
-        return;
-    }
-    if (!opt) {
-        cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, this->Rows(), x.Cols(), this->Cols(),
-                    alpha, this->fElem, this->Rows(), x.fElem, x.Rows(), beta, z.fElem, z.Rows());
-    } else {
-        cblas_dgemm(CblasColMajor, CblasTrans, CblasNoTrans, this->Cols(), x.Cols(), this->Rows(),
-                    alpha, this->fElem, this->Rows(), x.fElem, x.Rows(), beta, z.fElem, z.Rows());
-    }
-    
-}
-template<>
-void TPZFMatrix<float>::MultAdd(const TPZFMatrix<float> &x,const TPZFMatrix<float> &y, TPZFMatrix<float> &z,
-                                const float alpha,const float beta,const int opt) const {
-    
-#ifdef PZDEBUG
-    if ((!opt && this->Cols() != x.Rows()) || (opt && this->Rows() != x.Rows())) {
-        Error( "TPZFMatrix::MultAdd matrix x with incompatible dimensions>" );
-        return;
-    }
-    if(beta != (float)0. && ((!opt && this->Rows() != y.Rows()) || (opt && this->Cols() != y.Rows()) || y.Cols() != x.Cols())) {
-        Error( "TPZFMatrix::MultAdd matrix y with incompatible dimensions>" );
-        return;
-    }
-#endif
-    if(!opt) {
-        if(z.Cols() != x.Cols() || z.Rows() != this->Rows()) {
-            z.Redim(this->Rows(),x.Cols());
-        }
-    } else {
-        if(z.Cols() != x.Cols() || z.Rows() != this->Cols()) {
-            z.Redim(this->Cols(),x.Cols());
-        }
-    }
-    if(this->Cols() == 0) {
-        z.Zero();
-    }
-    if (beta != (float)0.) {
-        z = y;
-    }
-    if (Rows() == 0 || Cols() == 0 || x.Rows() == 0 || x.Cols() == 0) {
-        return;
-    }
-    if (!opt) {
-        cblas_sgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, this->Rows(), x.Cols(), this->Cols(),
-                    alpha, this->fElem, this->Rows(), x.fElem, x.Rows(), beta, z.fElem, z.Rows());
-    } else {
-        cblas_sgemm(CblasColMajor, CblasTrans, CblasNoTrans, this->Cols(), x.Cols(), this->Rows(),
-                    alpha, this->fElem, this->Rows(), x.fElem, x.Rows(), beta, z.fElem, z.Rows());
-    }
-    
-}
-
-template<>
-void TPZFMatrix<std::complex<double> >::MultAdd(const TPZFMatrix<std::complex<double> > &x,const TPZFMatrix<std::complex<double> > &y, TPZFMatrix<std::complex<double> > &z,
-                                                const std::complex<double> alpha,const std::complex<double> beta,const int opt) const {
-    
-#ifdef PZDEBUG
-    if ((!opt && this->Cols() != x.Rows()) || (opt && this->Rows() != x.Rows())) {
-        Error( "TPZFMatrix::MultAdd matrix x with incompatible dimensions>" );
-        return;
-    }
-    if(abs(beta) != 0. && ((!opt && this->Rows() != y.Rows()) || (opt && this->Cols() != y.Rows()) || y.Cols() != x.Cols())) {
-        Error( "TPZFMatrix::MultAdd matrix y with incompatible dimensions>" );
-        return;
-    }
-#endif
-    if(!opt) {
-        if(z.Cols() != x.Cols() || z.Rows() != this->Rows()) {
-            z.Redim(this->Rows(),x.Cols());
-        }
-    } else {
-        if(z.Cols() != x.Cols() || z.Rows() != this->Cols()) {
-            z.Redim(this->Cols(),x.Cols());
-        }
-    }
-    if(this->Cols() == 0) {
-        z.Zero();
-    }
-    if (abs(beta) != 0.) {
-        z = y;
-    }
-
-    if (Rows() == 0 || Cols() == 0 || x.Rows() == 0 || x.Cols() == 0) {
-        return;
-    }
-    
-    if (!opt) {
-        cblas_zgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, this->Rows(), x.Cols(), this->Cols(),
-                    &alpha, this->fElem, this->Rows(), x.fElem, x.Rows(), &beta, z.fElem, z.Rows());
-    } else {
-        cblas_zgemm(CblasColMajor, CblasTrans, CblasNoTrans, this->Cols(), x.Cols(), this->Rows(),
-                    &alpha, this->fElem, this->Rows(), x.fElem, x.Rows(), &beta, z.fElem, z.Rows());
-    }
-}
-#endif // USING_LAPACK
 
 /**
  * @brief It computes z = beta * y + alpha * opt(this)*x but z and x can not overlap in memory.
@@ -847,7 +715,7 @@ void TPZFMatrix<std::complex<double> >::MultAdd(const TPZFMatrix<std::complex<do
 template <class TVar>
 void TPZFMatrix<TVar>::MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> &y, TPZFMatrix<TVar> &z,
                                const TVar alpha,const TVar beta,const int opt) const {
-    
+#ifdef PZDEBUG
     if ((!opt && this->Cols() != x.Rows()) || (opt && this->Rows() != x.Rows())) {
         Error( "TPZFMatrix::MultAdd matrix x with incompatible dimensions>" );
         return;
@@ -856,6 +724,7 @@ void TPZFMatrix<TVar>::MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> 
         Error( "TPZFMatrix::MultAdd matrix y with incompatible dimensions>" );
         return;
     }
+#endif
     if(!opt) {
         if(z.Cols() != x.Cols() || z.Rows() != this->Rows()) {
             z.Redim(this->Rows(),x.Cols());
@@ -865,41 +734,52 @@ void TPZFMatrix<TVar>::MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> 
             z.Redim(this->Cols(),x.Cols());
         }
     }
-    if(this->Cols() == 0)
-    {
+
+    if (beta != (TVar)0) {
+        z = y;
+    }else{
         z.Zero();
     }
-    unsigned numeq = opt ? this->Cols() : this->Rows();
-    int64_t rows = this->Rows();
-    int64_t cols = this->Cols();
-    int64_t xcols = x.Cols();
-    int64_t ic, c;
-    if (numeq)
-    {
-        for (ic = 0; ic < xcols; ic++) {
-            TVar *zp = &z(0,ic), *zlast = zp+numeq;
-            if(beta != (TVar)0.) {
-                const TVar *yp = &y.g(0,ic);
-                if(&z != &y) {
-                    for(int64_t i = 0; i<numeq; i++) zp[i]=yp[i];
-//                    memcpy((void *)zp,(void *)yp,numeq*sizeof(TVar));
-                }
-                for(int64_t i=0; i< numeq; i++) z(i,ic) *= beta;
-                
-            } else {
-                while(zp != zlast) {
-                    *zp = 0.;
-                    zp ++;
-                }
-            }
-        }
+
+    const int64_t rows = this->Rows();
+    const int64_t cols = this->Cols();
+    const int64_t xrows = x.Rows();
+    const int64_t xcols = x.Cols();
+    
+    
+    if(rows == 0 || cols == 0 || xrows == 0 || xcols == 0) return;
+
+#ifdef USING_LAPACK
+    
+    //0: no transpose, 1: transpose, 2: conj trans
+    const CBLAS_TRANSPOSE transp =
+        opt == 0 ? CblasNoTrans : (opt == 1 ? CblasTrans : CblasConjTrans);
+    const auto dim1 = opt == 0 ? rows : cols;
+    const auto dim2 = opt == 0 ? cols : rows;
+    if constexpr (std::is_same_v<TVar,double>){
+        cblas_dgemm(CblasColMajor, transp, CblasNoTrans, dim1, xcols, dim2,
+                    alpha, this->fElem, rows, x.fElem, xrows, beta, z.fElem, dim1);
+        return;
+    } else if constexpr (std::is_same_v<TVar,float>){
+        cblas_sgemm(CblasColMajor, transp, CblasNoTrans, dim1, xcols, dim2,
+                    alpha, this->fElem, rows, x.fElem, xrows, beta, z.fElem, dim1);
+        return;
+    } else if constexpr (std::is_same_v<TVar,std::complex<double>>){
+        cblas_zgemm(CblasColMajor, transp, CblasNoTrans, dim1, xcols, dim2,
+                    &alpha, this->fElem, rows, x.fElem, xrows, &beta, z.fElem, dim1);
+        return;
+    } else if constexpr (std::is_same_v<TVar,std::complex<float>>){
+        cblas_cgemm(CblasColMajor, transp, CblasNoTrans, dim1, xcols, dim2,
+                    &alpha, this->fElem, rows, x.fElem, xrows, &beta, z.fElem, dim1);
+        return;
     }
-    
-    if(!(rows*cols)) return;
-    
-    for (ic = 0; ic < xcols; ic++) {
+#endif
+    if (beta != (TVar)0) {
+        z *= beta;
+    }
+    for (auto ic = 0; ic < xcols; ic++) {
         if(!opt) {
-            for ( c = 0; c<cols; c++) {
+            for (auto c = 0; c<cols; c++) {
                 TVar * zp = &z(0,ic), *zlast = zp+rows;
                 TVar * fp = fElem +rows*c;
                 const TVar * xp = &x.g(c,ic);
@@ -910,16 +790,26 @@ void TPZFMatrix<TVar>::MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> 
             }
         } else {
             TVar * fp = fElem,  *zp = &z(0,ic);
-            for (c = 0; c<cols; c++) {
+            for (auto c = 0; c<cols; c++) {
                 TVar val = 0.;
                 // bug correction philippe 5/2/97
                 //					 REAL * xp = &x(0,ic), xlast = xp + numeq;
                 const TVar *xp = &x.g(0,ic);
                 const TVar *xlast = xp + rows;
+                if constexpr (is_complex<TVar>::value){
+                    if(opt==2){
+                        while(xp < xlast) {
+                            val += std::conj(*fp++) * *xp;
+                            xp ++;
+                        }
+                        break;//breaks from the for loop
+                    }
+                }
                 while(xp < xlast) {
                     val += *fp++ * *xp;
                     xp ++;
                 }
+                
                 *zp += alpha *val;
                 zp ++;
             }

--- a/Matrix/pzfmatrix.h
+++ b/Matrix/pzfmatrix.h
@@ -329,11 +329,12 @@ public:
     
     void DeterminantInverse(TVar &determinant, TPZFMatrix<TVar> &inverse);
     
-    void Transpose(TPZMatrix<TVar> *const T) const override;
+    void Transpose(TPZMatrix<TVar> *const T, bool conj=false) const override;
     
     /** @see TPZMatrix<TVar>::Transpose */
     
     void Transpose();
+    void ConjTranspose();
     
     /*** @name Solve linear system of equations ***/
     /** @{ */

--- a/Matrix/pzfmatrix.h
+++ b/Matrix/pzfmatrix.h
@@ -222,13 +222,13 @@ public:
      * @param i Is the row of (this) where the first element of the matrices product should be added 
      * @param j Is the column of (this) where the first element of the matrices product should be added 
      * @param A Is A on the above operation
-     * @param transpA Indicates if A is Transpose or not
+     * @param transpA 0: A not transpose, 1: A tranpose, everything else: A conj transpose
      * @param B Is B on the above operation
-     * @param transpB Indicates if B is Transpose or not
+     * @param transpB 0: B not transpose, 1: B tranpose, everything else: B conj transpose
      * @param alpha Is alpha on the above operation
      */
-    virtual void AddContribution(int64_t i, int64_t j, const TPZFMatrix<TVar> & A, bool transpA, const TPZFMatrix<TVar>& B, 
-						 		 bool transpB, const TVar alpha = 1.0) override;
+    virtual void AddContribution(int64_t i, int64_t j, const TPZFMatrix<TVar> & A, int transpA, const TPZFMatrix<TVar>& B, 
+						 		 int transpB, const TVar alpha = 1.0) override;
 
     /**
      * @name Generic operator with TVar type

--- a/Matrix/pzmatrix.cpp
+++ b/Matrix/pzmatrix.cpp
@@ -616,14 +616,23 @@ int TPZMatrix<TVar>::AddSub(const int64_t sRow, const int64_t sCol, const int64_
 /*****************/
 /*** Transpose ***/
 template<class TVar>
-void TPZMatrix<TVar>::Transpose(TPZMatrix<TVar> *T) const {
+void TPZMatrix<TVar>::Transpose(TPZMatrix<TVar> *T, bool conj) const {
 	T->Resize( Cols(), Rows() );
-	
-	for ( int64_t r = 0; r < Rows(); r++ ) {
+	if constexpr (is_complex<TVar>::value){
+    if(conj){
+      for ( int64_t r = 0; r < Rows(); r++ ) {
         for ( int64_t c = 0; c < Cols(); c++ ) {
-            T->PutVal( c, r, GetVal( r, c ) );
+          T->PutVal( c, r, std::conj(GetVal( r, c )) );
         }
+      }
+      return;
     }
+  }
+	for ( int64_t r = 0; r < Rows(); r++ ) {
+    for ( int64_t c = 0; c < Cols(); c++ ) {
+      T->PutVal( c, r, GetVal( r, c ) );
+    }
+  }
 }
 
 template<class TVar>

--- a/Matrix/pzmatrix.cpp
+++ b/Matrix/pzmatrix.cpp
@@ -158,8 +158,8 @@ void TPZMatrix<TVar>::MultAdd(const TPZFMatrix<TVar> &x,const TPZFMatrix<TVar> &
 }
 
 template <class TVar>
-void TPZMatrix<TVar>::AddContribution(int64_t i, int64_t j, const TPZFMatrix<TVar> & A, bool transpA, const TPZFMatrix<TVar>& B, 
-						 		       bool transpB, const TVar alpha)
+void TPZMatrix<TVar>::AddContribution(int64_t i, int64_t j, const TPZFMatrix<TVar> & A, int transpA, const TPZFMatrix<TVar>& B, 
+						 		       int transpB, const TVar alpha)
 {
     Error( "Not implemented for this type of matrix\n" );
 }

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -217,8 +217,18 @@ public:
 
     virtual TVar RowTimesVector(const int row, const TPZFMatrix<TVar> &v) const;
 
-	virtual void AddContribution(int64_t i, int64_t j, const TPZFMatrix<TVar> & A, bool transpA, const TPZFMatrix<TVar>& B, 
-						 		 bool transpB, const TVar alpha = 1.0);
+  /**
+   * @brief It computes this += alpha*(A * B), where A or B can be transposed.
+   * @param i Is the row of (this) where the first element of the matrices product should be added 
+   * @param j Is the column of (this) where the first element of the matrices product should be added 
+   * @param A Is A on the above operation
+   * @param transpA 0: A not transpose, 1: A tranpose, everything else: A conj transpose
+   * @param B Is B on the above operation
+   * @param transpB 0: B not transpose, 1: B tranpose, everything else: B conj transpose
+   * @param alpha Is alpha on the above operation
+   */
+	virtual void AddContribution(int64_t i, int64_t j, const TPZFMatrix<TVar> & A, int transpA, const TPZFMatrix<TVar>& B, 
+						 		 int transpB, const TVar alpha = 1.0);
 	
 	/** @brief Computes res = rhs - this * x */
 	virtual void Residual(const TPZFMatrix<TVar>& x,const TPZFMatrix<TVar>& rhs, TPZFMatrix<TVar>& res ) ;

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -228,7 +228,7 @@ public:
     /** @brief Converts the matrix in a diagonal matrix*/
     virtual void Diagonal(TVar val);
 	/** @brief It makes *T the transpose of current matrix. */
-	virtual void Transpose(TPZMatrix<TVar>*const T) const;
+	virtual void Transpose(TPZMatrix<TVar>*const T, bool conj = false) const;
 	
 	/**
 	 * @brief It makes Inv =[this].

--- a/Matrix/tpzverysparsematrix.h
+++ b/Matrix/tpzverysparsematrix.h
@@ -112,8 +112,8 @@ public:
 	
 	/** @brief It makes *T the transpose of current matrix. */
 	virtual void Transpose(TPZVerySparseMatrix<TVar>* T) const;
-	virtual void Transpose(TPZMatrix<TVar>*const T) const  override {
-        TPZMatrix<TVar>::Transpose(T);
+	virtual void Transpose(TPZMatrix<TVar>*const T, bool conj=false) const  override {
+    TPZMatrix<TVar>::Transpose(T, conj);
     }
     
     /** @brief decompose the system of equations acording to the decomposition


### PR DESCRIPTION
This PR aims to add possibility of performing not only Transpose operations but also Conjugate Transpose, which is 
important for complex arithmetic.

For now, only the `MultAdd` and `AddContribution` methods were changed, more functionality can be implemented when someone has the time to do so.

Both modifications were made transforming a `bool` parameter to an `int`. `0` stands for no transposition, `1` for transposition and `2` to conjugate transposition. Given that the standard assures that a `true` boolean value is always converted to `1`, no changes in the behaviour of existent code are expected (perhaps a few warnings depending on compiler's settings).

Additionally, the `Transpose` method now has the signature
`virtual void TPZMatrix<TVar>::Transpose(TPZMatrix<TVar>*const T, bool conj = false) const;`

and, in the `TPZFMatrix` template class, the `void ConjTranspose();`

method was added.