### PR TITLE
New tests for HDiv Constant space and fix for the linear dependence of hexahedral shape functions

### DIFF
--- a/Mesh/pzcmesh.cpp
+++ b/Mesh/pzcmesh.cpp
@@ -2008,20 +2008,20 @@ TPZCompMesh* TPZCompMesh::Clone() const {
  }
  */
 
-void TPZCompMesh::CopyMaterials(TPZCompMesh &mesh) const {
+void TPZCompMesh::CopyMaterials(TPZCompMesh &meshto) const {
     // Clone volumetric mats
     for (auto it : fMaterialVec) {
         if (!dynamic_cast<TPZBndCond *> (it.second)) {
-            it.second->Clone(mesh.fMaterialVec);
+            it.second->Clone(meshto.fMaterialVec);
         }
     }
     // Clone BC mats
     for (auto it : fMaterialVec) {
         auto *bc = dynamic_cast<TPZBndCond *> (it.second);
         if (bc) {
-            it.second->Clone(mesh.fMaterialVec);
-            auto *cloned_mat = mesh.FindMaterial(bc->Material()->Id());
-            auto *new_bc = dynamic_cast<TPZBndCond*>(mesh.FindMaterial(bc->Id()));
+            it.second->Clone(meshto.fMaterialVec);
+            auto *cloned_mat = meshto.FindMaterial(bc->Material()->Id());
+            auto *new_bc = dynamic_cast<TPZBndCond*>(meshto.FindMaterial(bc->Id()));
             if (!new_bc) DebugStop();
             new_bc->SetMaterial(cloned_mat);
         }

--- a/Shape/TPZShapeHCurlNoGrads.cpp
+++ b/Shape/TPZShapeHCurlNoGrads.cpp
@@ -85,7 +85,7 @@ void TPZShapeHCurlNoGrads<TSHAPE>::Shape(const TPZVec<REAL> &pt, TPZShapeData &d
     }
     if constexpr (dim < 2) return;
 
-    TPZVec<int> filtVecShape;
+    TPZManVector<int,30> filtVecShape;
     HighOrderFunctionsFilter(first_hcurl_side, connectorders,filtVecShape);
 
     const auto newfuncs = filtVecShape.size();
@@ -101,6 +101,8 @@ void TPZShapeHCurlNoGrads<TSHAPE>::Shape(const TPZVec<REAL> &pt, TPZShapeData &d
       fcount++;
     } 
     
+
+    if(fcount != phi.Cols()) DebugStop();
     
 }
 
@@ -492,8 +494,8 @@ void TPZShapeHCurlNoGrads<TSHAPE>::HighOrderFunctionsFilter(
     */
 
     const auto firstVki = firstSideShape + nvkf;
-    const auto nvkik = 3*(order-1)*(order-1)*(order-1);
-    const auto nvkik1 = (order-1)*(2*order-1);//for each direction
+    const auto nvkik = order >= 1 ? 3*(order-1)*(order-1)*(order-1) : 0;
+    const auto nvkik1 = order >= 1 ? (order-1)*(2*order-1): 0;//for each direction
     
     for(auto ifunc = 0; ifunc < nvkik; ifunc++){
       if(ifunc%3 == 2) continue;//skip z direction

--- a/Shape/TPZShapeHDivConstant.cpp
+++ b/Shape/TPZShapeHDivConstant.cpp
@@ -1,5 +1,5 @@
 #include "TPZShapeHDivConstant.h"
-#include "TPZShapeHCurlNoGrads.h" 
+#include "TPZShapeHCurlNoGrads.h"
 
 #include "TPZShapeH1.h"
 #include "pzshapelinear.h"
@@ -15,283 +15,387 @@
 #include "TPZCompElHCurl.h"
 
 //! Should be called once per element. Initializes the data structure
-template<class TSHAPE>
-void TPZShapeHDivConstant<TSHAPE>::Initialize(TPZVec<int64_t> &ids,
-                TPZVec<int> &connectorders,
-                const TPZVec<int>& sideorient, 
-                TPZShapeData &data)
+template <class TSHAPE>
+void TPZShapeHDivConstant<TSHAPE>::Initialize(const TPZVec<int64_t> &ids,
+                                              const TPZVec<int> &connectorders,
+                                              const TPZVec<int> &sideorient,
+                                              TPZShapeData &data)
 {
     data.fSideOrient = sideorient;
-    data.fHDivConnectOrders.Resize(TSHAPE::NFacets+1);
-    data.fHDivNumConnectShape.Resize(TSHAPE::NFacets+1);
-    if(TSHAPE::Dimension == 2)
+    
+    if (TSHAPE::Dimension == 2)
     {
-        //Compatibilize the polynomial order
-        int conSize = connectorders.size();
-        for (int i = 0; i < conSize; i++){
-            connectorders[i]++;
-        }
-        if (TSHAPE::Type() == ETriangle){
-            connectorders[conSize-1]++;
-        }
-        //Initialize data structures
-        TPZShapeH1<TSHAPE>::Initialize(ids,connectorders,data);
+        //Creating a copy of the connect orders to avoid modifying the original data when calling SHAPEH1::Initialize()
+        TPZManVector<int, 19> locconnectorders(connectorders);
 
-        for(int ic = 0; ic<TSHAPE::NFacets;ic++)
+        // Compatibilize the polynomial order
+        int conSize = connectorders.size();
+        for (int i = 0; i < conSize; i++)
         {
-            data.fHDivConnectOrders[ic] =  connectorders[ic];
-            data.fHDivNumConnectShape[ic] = data.fH1NumConnectShape[ic]+1;
+            locconnectorders[i]++;
+        }
+        // if (TSHAPE::Type() == ETriangle){
+        //     locconnectorders[conSize-1]++;
+        // }
+
+        // Initialize data structures
+        TPZShapeH1<TSHAPE>::Initialize(ids, locconnectorders, data);
+
+        data.fHDivConnectOrders.Resize(TSHAPE::NFacets + 1);
+        data.fHDivNumConnectShape.Resize(TSHAPE::NFacets + 1);
+        for (int ic = 0; ic < TSHAPE::NFacets; ic++)
+        {
+            data.fHDivConnectOrders[ic] = connectorders[ic];
+            data.fHDivNumConnectShape[ic] = data.fH1NumConnectShape[ic] + 1;
         }
         int ic = TSHAPE::NFacets;
-        data.fHDivConnectOrders[ic] =  connectorders[ic];
+        data.fHDivConnectOrders[ic] = connectorders[ic];
         data.fHDivNumConnectShape[ic] = data.fH1NumConnectShape[ic];
     }
     else
     {
-        //Compatibilize the polynomial order
-        if (TSHAPE::Type() == ETetraedro) {
-            int conSize = connectorders.size();
-            for (int i = 0; i < conSize; i++){
-                connectorders[i]++;
+        // Compatibilize the polynomial order
+        TPZManVector<int, 19> adjustorder(connectorders);
+        if (TSHAPE::Type() == ETetraedro)
+        {
+            int conSize = adjustorder.size();
+            for (int i = 0; i < conSize; i++)
+            {
+                adjustorder[i]++;
             }
-            connectorders[conSize-1]++;
+            adjustorder[conSize - 1]++;
         }
 
-        const int nedges = TSHAPE::NSides-TSHAPE::NFacets-TSHAPE::NCornerNodes-1;
-        TPZManVector<int,19> locconorders(TSHAPE::NSides-TSHAPE::NCornerNodes,1);
-        for(int ic = nedges; ic<TSHAPE::NSides-TSHAPE::NCornerNodes; ic++)
+        constexpr int nedges = TSHAPE::NSides - TSHAPE::NFacets - TSHAPE::NCornerNodes - 1;
+        TPZManVector<int, 19> locconnectorders(TSHAPE::NSides - TSHAPE::NCornerNodes, 1);
+        for (int ic = nedges; ic < TSHAPE::NSides - TSHAPE::NCornerNodes; ic++)
         {
-            locconorders[ic] = connectorders[ic-nedges];
+            locconnectorders[ic] = adjustorder[ic - nedges];
         }
-        TPZShapeHCurlNoGrads<TSHAPE>::Initialize(ids, locconorders, data);
-//        TPZManVector<int> HCurlNumConnectShapeF = data.fHDivNumConnectShape;
-//        data.fHDivNumConnectShape.Resize(TSHAPE::NFacets+1);
-//        for(int ic=nedges; ic<TSHAPE::NSides-TSHAPE::NCornerNodes-1; ic++)
-//        {
-//            int numshape = HCurlNumConnectShapeF[ic]+1;
-//            data.fHDivNumConnectShape[ic-nedges] = numshape;
-//        }
-//        int ic = TSHAPE::NSides-TSHAPE::NCornerNodes-1;
-//        int numshape = HCurlNumConnectShapeF[ic];
-//        data.fHDivNumConnectShape[ic-nedges] = numshape;
+
+        // ShapeHCurlNoGrads modifies ShapeData according to the HCurl space data structure.
+        // after its initialization, we need to adjust the data structure to the HDiv space.
+        TPZShapeHCurlNoGrads<TSHAPE>::Initialize(ids, locconnectorders, data);
+
+        TPZManVector<int,60> HCurlConnectOrders = data.fHDivConnectOrders;
+        TPZManVector<int,60> HCurlNumConnectShapeF = data.fHDivNumConnectShape;
+        data.fHDivConnectOrders.Resize(TSHAPE::NFacets + 1);
+        data.fHDivNumConnectShape.Resize(TSHAPE::NFacets + 1);
+        for (int ic = 0; ic < TSHAPE::NFacets+1; ic++)
+        {
+            data.fHDivConnectOrders[ic] = connectorders[ic];
+        }
+        for (int ic = nedges; ic < TSHAPE::NSides - TSHAPE::NCornerNodes - 1; ic++)
+        {
+            int numshape = HCurlNumConnectShapeF[ic] + 1;
+            data.fHDivNumConnectShape[ic - nedges] = numshape;
+        }
+        int ic = TSHAPE::NSides - TSHAPE::NCornerNodes - 1;
+        int numshape = HCurlNumConnectShapeF[ic];
+        data.fHDivNumConnectShape[ic - nedges] = numshape;
     }
 }
 
-
-template<class TSHAPE>
+template <class TSHAPE>
 int TPZShapeHDivConstant<TSHAPE>::NHDivShapeF(TPZShapeData &data)
 {
-    // int nshape = TPZShapeH1<TSHAPE>::NShape(data);
     int nshape = 0;
-    constexpr int firstConnect = TSHAPE::NSides-TSHAPE::NCornerNodes-TSHAPE::NFacets-1;
+    // constexpr int firstConnect = TSHAPE::NSides-TSHAPE::NCornerNodes-TSHAPE::NFacets-1;
     int nc = data.fHDivNumConnectShape.size();
-    for(int ic = firstConnect; ic<nc; ic++) nshape += data.fHDivNumConnectShape[ic];
-    nshape += TSHAPE::NFacets;
+    for (int ic = 0; ic < nc; ic++)
+        nshape += NConnectShapeF(ic, data);
+    // nshape += TSHAPE::NFacets;
     return nshape;
 }
 
-    
-
-template<class TSHAPE>
+template <class TSHAPE>
 void TPZShapeHDivConstant<TSHAPE>::Shape(const TPZVec<REAL> &pt, TPZShapeData &data, TPZFMatrix<REAL> &phi, TPZFMatrix<REAL> &divphi)
 {
 
-    const int ncorner = TSHAPE::NCornerNodes;
-    const int nsides = TSHAPE::NSides;
-    const int dim = TSHAPE::Dimension;
-    const int nfacets = TSHAPE::NFacets;
+    constexpr int ncorner = TSHAPE::NCornerNodes;
+    constexpr int nsides = TSHAPE::NSides;
+    constexpr int dim = TSHAPE::Dimension;
+    constexpr int nfacets = TSHAPE::NFacets;
+    const int nedges = TSHAPE::NumSides(1);
 
     // Compute constant Hdiv functions
-    TPZFNMatrix<12,REAL> vecDiv(dim,nfacets);
-    TPZVec<REAL> div(nfacets);
+    TPZFNMatrix<dim*nfacets, REAL> vecDiv(dim, nfacets);
+    TPZManVector<REAL,nfacets> div(nfacets);
     vecDiv.Zero();
     div.Fill(0.);
     // std::cout << "FSide trans ID = " << data.fSideTransformationId << std::endl;
     TSHAPE::ComputeConstantHDiv(pt, vecDiv, div);
 
     int nshape = data.fPhi.Rows();
-    
-    if (dim == 2){
-        TPZShapeH1<TSHAPE>::Shape(pt,data,data.fPhi,data.fDPhi);    
+
+    if constexpr(dim == 2)
+    {
+        TPZShapeH1<TSHAPE>::Shape(pt, data, data.fPhi, data.fDPhi);
         divphi.Zero();
-        const auto nEdges = TSHAPE::NumSides(1);
 
         int count = 0;
-        int countKernel=ncorner;
-        //Edge functions
-        for (int i = 0; i < nEdges; i++)
+        int countKernel = ncorner;
+        // Edge functions
+        for (int i = 0; i < nedges; i++)
         {
-            //RT0 Function
-            phi(0,count) = vecDiv(0,i) * data.fSideOrient[i];
-            phi(1,count) = vecDiv(1,i) * data.fSideOrient[i];
-            divphi(count,0) = div[i] * data.fSideOrient[i];
+            // RT0 Function
+            phi(0, count) = vecDiv(0, i) * data.fSideOrient[i];
+            phi(1, count) = vecDiv(1, i) * data.fSideOrient[i];
+            divphi(count, 0) = div[i] * data.fSideOrient[i];
             count++;
 
-            //Kernel Hdiv
-            for (int j = 1; j < data.fHDivConnectOrders[i]; j++)
+            // Kernel Hdiv
+            for (int j = 1; j < data.fHDivNumConnectShape[i]; j++)
             {
-                phi(0,count) = -data.fDPhi(1,countKernel);
-                phi(1,count) =  data.fDPhi(0,countKernel);
+                phi(0, count) = -data.fDPhi(1, countKernel);
+                phi(1, count) = data.fDPhi(0, countKernel);
                 count++;
                 countKernel++;
             }
         }
-        
-        //Internal functions
-        for (int i = countKernel; i < nshape; i++){
-            phi(0,count) = -data.fDPhi(1,countKernel);
-            phi(1,count) =  data.fDPhi(0,countKernel);
+
+        // Internal functions
+        for (int i = countKernel; i < nshape; i++)
+        {
+            phi(0, count) = -data.fDPhi(1, countKernel);
+            phi(1, count) = data.fDPhi(0, countKernel);
             count++;
             countKernel++;
         }
-    } else if (dim == 3){
-        
+    }
+    else if constexpr(dim == 3)
+    {
+        //Adjusting the data structure to HCurl pattern
+        TPZShapeData dataHCurl = data;
+        constexpr int nHCurlCon = nsides - ncorner;
+        dataHCurl.fHDivConnectOrders.resize(nHCurlCon);
+        dataHCurl.fHDivConnectOrders.Fill(1);
+        for (int ic = nedges; ic < nHCurlCon; ic++)
+        {
+            dataHCurl.fHDivConnectOrders[ic] = data.fHDivConnectOrders[ic - nedges];
+        }
+        if constexpr(TSHAPE::Type() == ETetraedro)
+        {
+            for (int ic = nedges; ic < nHCurlCon; ic++)
+            {
+                dataHCurl.fHDivConnectOrders[ic]++;
+            }
+            int ic = nHCurlCon - 1;
+            dataHCurl.fHDivConnectOrders[ic]++;
+        }
+
+        dataHCurl.fHDivNumConnectShape.resize(nHCurlCon);
+        dataHCurl.fHDivNumConnectShape.Fill(1);
+        //For the facets, we subtract the constant function
+        for (int ic = 0; ic < nfacets; ic++)
+        {
+            int numshape = data.fHDivNumConnectShape[ic] - 1;
+            dataHCurl.fHDivNumConnectShape[nedges + ic] = numshape;
+        }
+        int ic = nHCurlCon - 1;
+        int numshape = data.fHDivNumConnectShape[nfacets];
+        dataHCurl.fHDivNumConnectShape[ic] = numshape;
+
         divphi.Zero();
-        const auto nEdges = TSHAPE::NumSides(1);
-        int nshapehcurl = TPZShapeHCurlNoGrads<TSHAPE>::NHCurlShapeF(data);
+        int nshapehcurl = TPZShapeHCurlNoGrads<TSHAPE>::NHCurlShapeF(dataHCurl);
         int nshape = NHDivShapeF(data);
-        
-        TPZFMatrix<REAL> phiAux(dim,nshapehcurl),curlPhiAux(3,nshapehcurl);
-        phiAux.Zero(); curlPhiAux.Zero();
 
-        TPZShapeHCurlNoGrads<TSHAPE>::Shape(pt,data,phiAux,curlPhiAux);
-        
+        TPZFNMatrix<200,REAL> phiAux(dim, nshapehcurl), curlPhiAux(3, nshapehcurl);
+        phiAux.Zero();
+        curlPhiAux.Zero();
+
+        TPZShapeHCurlNoGrads<TSHAPE>::Shape(pt, dataHCurl, phiAux, curlPhiAux);
+
         int count = 0;
-        int countKernel=nEdges;
+        int countKernel = nedges;
 
-        //Face functions
+        // Face functions
         for (int i = 0; i < nfacets; i++)
         {
             // std::cout << "Side orient - " << i << " " << data.fSideOrient[i] << std::endl;
-            //RT0 Function
-            for(auto d = 0; d < dim; d++) {
-                phi(d,count) = vecDiv(d,i) * data.fSideOrient[i];
+            // RT0 Function
+            for (auto d = 0; d < dim; d++)
+            {
+                phi(d, count) = vecDiv(d, i) * data.fSideOrient[i];
             }
-            divphi(count,0) = div[i] * data.fSideOrient[i];
+            divphi(count, 0) = div[i] * data.fSideOrient[i];
             count++;
-        
-            //Kernel HDiv functions
-            for (int k = 0; k < data.fHDivNumConnectShape[nEdges+i]; k++){
-                for(auto d = 0; d < dim; d++) {
-                    phi(d,count) = curlPhiAux(d,countKernel);               
+
+            // Kernel HDiv functions
+            for (int k = 0; k < dataHCurl.fHDivNumConnectShape[nedges + i]; k++)
+            {
+                for (auto d = 0; d < dim; d++)
+                {
+                    phi(d, count) = curlPhiAux(d, countKernel);
                 }
                 countKernel++;
                 count++;
             }
+            // if(i==0) {
+            //     for(int k=0; k<count; k++) {
+            //         std::cout << "phi ";
+            //         for(int d=0; d<dim; d++) {
+            //             std::cout << phi(d,k) << " ";
+            //         }
+            //         std::cout << std::endl;
+            //     }
+            // }
         }
-        //Internal Functions - HDivKernel
-        for (int i = 0; i < data.fHDivNumConnectShape[TSHAPE::NSides-TSHAPE::NCornerNodes-1]; i++)
+        // Internal Functions - HDivKernel
+        for (int i = 0; i < dataHCurl.fHDivNumConnectShape[TSHAPE::NSides - TSHAPE::NCornerNodes - 1]; i++)
         {
             for (auto d = 0; d < dim; d++)
             {
-                phi(d,count) = curlPhiAux(d,countKernel);  
+                phi(d, count) = curlPhiAux(d, countKernel);
             }
             countKernel++;
             count++;
         }
+        if (count != nshape)
+            DebugStop();
+        if (countKernel != nshapehcurl)
+            DebugStop();
         // std::cout << "VecDiv = " << vecDiv << std::endl;
         // std::cout << "divphi = " << divphi << std::endl;
         // std::cout << "phi = " << phi << std::endl;
-    } else {
+    }
+    else
+    {
         DebugStop();
     }
 }
 
-
-template<class TSHAPE>
+template <class TSHAPE>
 void TPZShapeHDivConstant<TSHAPE>::Shape(const TPZVec<Fad<REAL>> &pt, TPZShapeData &data, TPZFMatrix<Fad<REAL>> &phi, TPZFMatrix<Fad<REAL>> &divphi)
 {
 
-    const int ncorner = TSHAPE::NCornerNodes;
-    const int nsides = TSHAPE::NSides;
-    const int dim = TSHAPE::Dimension;
-    const int nfacets = TSHAPE::NFacets;
+    constexpr int ncorner = TSHAPE::NCornerNodes;
+    constexpr int nsides = TSHAPE::NSides;
+    constexpr int dim = TSHAPE::Dimension;
+    constexpr int nfacets = TSHAPE::NFacets;
+    const int nedges = TSHAPE::NumSides(1);
 
     // Compute constant Hdiv functions
-    TPZFNMatrix<9,Fad<REAL>> vecDiv(dim,nfacets);
-    TPZVec<Fad<REAL>> div(nfacets);
+    TPZFNMatrix<dim*nfacets, Fad<REAL>> vecDiv(dim, nfacets);
+    TPZManVector<Fad<REAL>,nfacets> div(nfacets);
     vecDiv.Zero();
     div.Fill(0.);
     // std::cout << "FSide trans ID = " << data.fSideTransformationId << std::endl;
     TSHAPE::ComputeConstantHDiv(pt, vecDiv, div);
 
     int nshape = data.fPhi.Rows();
-    
-    if (dim == 2){
-        TPZFNMatrix<9,Fad<REAL>> locphi(data.fPhi.Rows(),data.fPhi.Cols()),dphi(data.fDPhi.Rows(),data.fDPhi.Cols());
-        TPZShapeH1<TSHAPE>::Shape(pt,data,locphi,dphi);    
+
+    if constexpr(dim == 2)
+    {
+        TPZFNMatrix<9, Fad<REAL>> locphi(data.fPhi.Rows(), data.fPhi.Cols()), dphi(data.fDPhi.Rows(), data.fDPhi.Cols());
+        TPZShapeH1<TSHAPE>::Shape(pt, data, locphi, dphi);
         divphi.Zero();
-        const auto nEdges = TSHAPE::NumSides(1);
 
         int count = 0;
-        int countKernel=ncorner;
-        //Edge functions
-        for (int i = 0; i < nEdges; i++)
+        int countKernel = ncorner;
+        // Edge functions
+        for (int i = 0; i < nedges; i++)
         {
-            //RT0 Function
-            phi(0,count) = vecDiv(0,i) * data.fSideOrient[i];
-            phi(1,count) = vecDiv(1,i) * data.fSideOrient[i];
-            divphi(count,0) = div[i] * data.fSideOrient[i];
+            // RT0 Function
+            phi(0, count) = vecDiv(0, i) * data.fSideOrient[i];
+            phi(1, count) = vecDiv(1, i) * data.fSideOrient[i];
+            divphi(count, 0) = div[i] * data.fSideOrient[i];
             count++;
 
-            //Kernel Hdiv
-            for (int j = 1; j < data.fHDivConnectOrders[i]; j++)
+            // Kernel Hdiv
+            for (int j = 1; j < data.fHDivNumConnectShape[i]; j++)
             {
-                phi(0,count) = -dphi(1,countKernel);
-                phi(1,count) =  dphi(0,countKernel);
+                phi(0, count) = -dphi(1, countKernel);
+                phi(1, count) = dphi(0, countKernel);
                 count++;
                 countKernel++;
             }
         }
-        
-        //Internal functions
-        for (int i = countKernel; i < nshape; i++){
-            phi(0,count) = -dphi(1,countKernel);
-            phi(1,count) =  dphi(0,countKernel);
+
+        // Internal functions
+        for (int i = countKernel; i < nshape; i++)
+        {
+            phi(0, count) = -dphi(1, countKernel);
+            phi(1, count) = dphi(0, countKernel);
             count++;
             countKernel++;
         }
-    } else if (dim == 3){
-        
+    }
+    else if constexpr(dim == 3)
+    {
+        //Adjusting the data structure to HCurl pattern
+        TPZShapeData dataHCurl = data;
+        constexpr int nHCurlCon = nsides - ncorner;
+        dataHCurl.fHDivConnectOrders.resize(nHCurlCon);
+        dataHCurl.fHDivConnectOrders.Fill(1);
+        for (int ic = nedges; ic < nHCurlCon; ic++)
+        {
+            dataHCurl.fHDivConnectOrders[ic] = data.fHDivConnectOrders[ic - nedges];
+        }
+        if constexpr(TSHAPE::Type() == ETetraedro)
+        {
+            for (int ic = nedges; ic < nHCurlCon; ic++)
+            {
+                dataHCurl.fHDivConnectOrders[ic]++;
+            }
+            int ic = nHCurlCon - 1;
+            dataHCurl.fHDivConnectOrders[ic]++;
+        }
+
+        dataHCurl.fHDivNumConnectShape.resize(nHCurlCon);
+        dataHCurl.fHDivNumConnectShape.Fill(1);
+        //For the facets, we subtract the constant function
+        for (int ic = 0; ic < nfacets; ic++)
+        {
+            int numshape = data.fHDivNumConnectShape[ic] - 1;
+            dataHCurl.fHDivNumConnectShape[nedges + ic] = numshape;
+        }
+        int ic = nHCurlCon - 1;
+        int numshape = data.fHDivNumConnectShape[nfacets];
+        dataHCurl.fHDivNumConnectShape[ic] = numshape;
+
         divphi.Zero();
-        const auto nEdges = TSHAPE::NumSides(1);
-        int nshapehcurl = TPZShapeHCurlNoGrads<TSHAPE>::NHCurlShapeF(data);
+        int nshapehcurl = TPZShapeHCurlNoGrads<TSHAPE>::NHCurlShapeF(dataHCurl);
         int nshape = NHDivShapeF(data);
-        
-        TPZFNMatrix<9,Fad<REAL>> phiAux(dim,nshapehcurl),curlPhiAux(3,nshapehcurl);
-        phiAux.Zero(); curlPhiAux.Zero();
 
-        TPZShapeHCurlNoGrads<TSHAPE>::Shape(pt,data,phiAux,curlPhiAux);
-        
+        TPZFNMatrix<200, Fad<REAL>> phiAux(dim, nshapehcurl), curlPhiAux(3, nshapehcurl);
+        phiAux.Zero();
+        curlPhiAux.Zero();
+
+        TPZShapeHCurlNoGrads<TSHAPE>::Shape(pt, dataHCurl, phiAux, curlPhiAux);
+
         int count = 0;
-        int countKernel=nEdges;
+        int countKernel = nedges;
 
-        //Face functions
+        // Face functions
         for (int i = 0; i < nfacets; i++)
         {
             // std::cout << "Side orient - " << i << " " << data.fSideOrient[i] << std::endl;
-            //RT0 Function
-            for(auto d = 0; d < dim; d++) {
-                phi(d,count) = vecDiv(d,i) * data.fSideOrient[i];
+            // RT0 Function
+            for (auto d = 0; d < dim; d++)
+            {
+                phi(d, count) = vecDiv(d, i) * data.fSideOrient[i];
             }
-            divphi(count,0) = div[i] * data.fSideOrient[i];
+            divphi(count, 0) = div[i] * data.fSideOrient[i];
             count++;
-        
-            //Kernel HDiv functions
-            for (int k = 0; k < data.fHDivNumConnectShape[nEdges]; k++){
-                for(auto d = 0; d < dim; d++) {
-                    phi(d,count) = curlPhiAux(d,countKernel);               
+
+            // Kernel HDiv functions
+            for (int k = 0; k < dataHCurl.fHDivNumConnectShape[nedges]; k++)
+            {
+                for (auto d = 0; d < dim; d++)
+                {
+                    phi(d, count) = curlPhiAux(d, countKernel);
                 }
                 countKernel++;
                 count++;
             }
         }
-        //Internal Functions - HDivKernel
-        for (int i = 0; i < data.fHDivNumConnectShape[TSHAPE::NSides-TSHAPE::NCornerNodes-1]; i++)
+        // Internal Functions - HDivKernel
+        for (int i = 0; i < dataHCurl.fHDivNumConnectShape[TSHAPE::NSides - TSHAPE::NCornerNodes - 1]; i++)
         {
             for (auto d = 0; d < dim; d++)
             {
-                phi(d,count) = curlPhiAux(d,countKernel);  
+                phi(d, count) = curlPhiAux(d, countKernel);
             }
             countKernel++;
             count++;
@@ -299,94 +403,102 @@ void TPZShapeHDivConstant<TSHAPE>::Shape(const TPZVec<Fad<REAL>> &pt, TPZShapeDa
         // std::cout << "VecDiv = " << vecDiv << std::endl;
         // std::cout << "divphi = " << divphi << std::endl;
         // std::cout << "phi = " << phi << std::endl;
-    } else {
+    }
+    else
+    {
         DebugStop();
     }
 }
 
 // icon is the connect index of the hdiv element
-template<class TSHAPE>
+template <class TSHAPE>
 int TPZShapeHDivConstant<TSHAPE>::NConnectShapeF(int icon, TPZShapeData &data)
 {
-    const int firstcon = TSHAPE::NSides-TSHAPE::NFacets-TSHAPE::NCornerNodes-1;
-    int faceconnect = icon+firstcon;
-    int nshape = data.fHDivNumConnectShape[faceconnect] + 1;
+    // const int firstcon = TSHAPE::NSides-TSHAPE::NFacets-TSHAPE::NCornerNodes-1;
+    // int faceconnect = icon+firstcon;
+    int nshape = data.fHDivNumConnectShape[icon];
+    // if(icon < TSHAPE::NFacets) nshape++;
     return nshape;
 }
 
-template<class TSHAPE>
+template <class TSHAPE>
 int TPZShapeHDivConstant<TSHAPE>::ComputeNConnectShapeF(int connect, int order)
 {
 
 #ifdef DEBUG
-    if (connect < 0 || connect > TSHAPE::NFacets) {
+    if (connect < 0 || connect > TSHAPE::NFacets)
+    {
         DebugStop();
     }
 #endif
     // int order = data.fHDivConnectOrders[connect];
     MElementType thistype = TSHAPE::Type();
 
-    if(thistype == EOned)
-    {   
+    if (thistype == EOned)
+    {
         order++;
-        if(connect < 2) return 0;
-        else return order;
+        if (connect < 2)
+            return 0;
+        else
+            return order;
         // DebugStop();
     }
-    else if(thistype == ETriangle)
-    {   
-        order++;
-        if(connect < TSHAPE::NFacets) return (order);
-        else {
-            order++;
-            return (order-1)*(order-2)/2;
-        }
-    }
-    else if(thistype == EQuadrilateral)
+    else if (thistype == ETriangle)
     {
         order++;
-        if(connect < TSHAPE::NFacets) return (order);
-        else return (order-1)*(order-1);
-    }
-    else if(thistype == ETetraedro)
-    {
-        order++;
-        if(connect < TSHAPE::NFacets) return 1 + (order-1)*(2*order+4)/4;
-        else {
-            order++;
-            return (order-1)*(order-2)*(2*order+3)/6;
+        if (connect < TSHAPE::NFacets)
+            return (order);
+        else
+        {
+            // order++;
+            return (order - 1) * (order - 2) / 2;
         }
     }
-    else if(thistype == EPrisma)
+    else if (thistype == EQuadrilateral)
+    {
+        order++;
+        if (connect < TSHAPE::NFacets)
+            return (order);
+        else
+            return (order - 1) * (order - 1);
+    }
+    else if (thistype == ETetraedro)
+    {
+        order++;
+        if (connect < TSHAPE::NFacets)
+            return 1 + (order - 1) * (2 * order + 4) / 4;
+        else
+        {
+            order++;
+            return (order - 1) * (order - 2) * (2 * order + 3) / 6;
+        }
+    }
+    else if (thistype == EPrisma)
     {
         DebugStop();
         // if(connect == 0 || connect == 4) return (order+1)*(order+2)/2;
         // else if(connect < TSHAPE::NFacets) return (order+1)*(order+1);
         // else return order*order*(3*order+5)/2+7*order-2;
     }
-    else if(thistype == ECube)
+    else if (thistype == ECube)
     {
-        if(connect < TSHAPE::NFacets) return 1 + order*(order+2);
-        else return order*order*(3+2*order);
+        if (connect < TSHAPE::NFacets)
+            return 1 + order * (order + 2);
+        else
+            return order * order * (3 + 2 * order);
     }
     DebugStop();
     unreachable();
- }
+}
 
-template
-struct TPZShapeHDivConstant<pzshape::TPZShapeLinear>;
+template struct TPZShapeHDivConstant<pzshape::TPZShapeLinear>;
 
-template
-struct TPZShapeHDivConstant<pzshape::TPZShapeTriang>;
+template struct TPZShapeHDivConstant<pzshape::TPZShapeTriang>;
 
-template
-struct TPZShapeHDivConstant<pzshape::TPZShapeQuad>;
+template struct TPZShapeHDivConstant<pzshape::TPZShapeQuad>;
 
-template
-struct TPZShapeHDivConstant<pzshape::TPZShapeTetra>;
+template struct TPZShapeHDivConstant<pzshape::TPZShapeTetra>;
 
-template
-struct TPZShapeHDivConstant<pzshape::TPZShapeCube>;
+template struct TPZShapeHDivConstant<pzshape::TPZShapeCube>;
 
-template
-struct TPZShapeHDivConstant<pzshape::TPZShapePrism>;
+template struct TPZShapeHDivConstant<pzshape::TPZShapePrism>;

--- a/Shape/TPZShapeHDivConstant.h
+++ b/Shape/TPZShapeHDivConstant.h
@@ -16,8 +16,8 @@ struct TPZShapeHDivConstant : public TPZShapeHCurlNoGrads<TSHAPE>
 {
     
     //! Should be called once per element. Initializes the data structure
-    static void Initialize(TPZVec<int64_t> &ids,
-                    TPZVec<int> &connectorders,
+    static void Initialize(const TPZVec<int64_t> &ids,
+                    const TPZVec<int> &connectorders,
                     const TPZVec<int>& sideorient, 
                     TPZShapeData &data);
 

--- a/UnitTest_PZ/TestDeRham/TPZMatDeRhamHDivL2.cpp
+++ b/UnitTest_PZ/TestDeRham/TPZMatDeRhamHDivL2.cpp
@@ -16,7 +16,7 @@ void TPZMatDeRhamHDivL2::Contribute(
 
   const TPZFMatrix<REAL> &phiHDiv = datavec[fHDivMeshIndex].divphi;
   
-  const auto &phiL2  = datavec[fL2MeshIndex].fPhi;
+  const auto &phiL2  = datavec[fL2MeshIndex].phi;
 
   const int64_t nHDiv  = phiHDiv.Rows();
   const int64_t nL2  = phiL2.Rows();

--- a/UnitTest_PZ/TestDeRham/TestDeRham.cpp
+++ b/UnitTest_PZ/TestDeRham/TestDeRham.cpp
@@ -21,20 +21,30 @@
 #include "TPZElementMatrixT.h"
 #include "MMeshType.h"
 #include "pzintel.h"
-
+#include "TPZMultiphysicsCompMesh.h"
+#include "pzshapetetra.h"
+#include "pzshapecube.h"
+#include "TPZShapeHDivConstant.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
+#include <catch2/catch_approx.hpp>
 
-enum class ESpace{H1,HCurl,HDiv,HDivConst,L2};
+enum class ESpace
+{
+  H1,
+  HCurl,
+  HDiv,
+  HDivConst,
+  L2
+};
 
 static const std::map<ESpace, const char *> names({{ESpace::H1, "H1"},
                                                    {ESpace::HCurl, "HCurl"},
                                                    {ESpace::HDiv, "HDiv"},
                                                    {ESpace::HDivConst, "HDivConst"},
                                                    {ESpace::L2, "L2"}});
-
 
 /** @brief Compares the dimensions of the span of the differential operator associated
     with the left space against the kernel of the right space.
@@ -43,9 +53,10 @@ static const std::map<ESpace, const char *> names({{ESpace::H1, "H1"},
     rank(M_left) = ker(M_right).
     @note For L2, the comparison is rank(M_left) = rank(M_right), and the operator
     associated with the L2 approximation space is the identity (op(phi_i) = phi_i).
-    @param [in] kRight polynomial order of the rightmost approximation space*/
+    @param [in] kRight polynomial order of the rightmost approximation space (except for HDiv and HDivConst)*/
 template <ESpace leftSpace, ESpace rightSpace, int dim>
 void CheckRankKerDim(int kRight);
+
 /** @brief Checks if the range of the differential operator of the left approximation space is contained in the functions of the approximation space on the right.
     Let us call the operator op (h1-> grad, hcurl -> curl, hdiv -> div, l2 -> id).
     Denoting by
@@ -62,10 +73,10 @@ template <ESpace leftSpace, ESpace rightSpace, int dim>
 void CheckInclusion(int kRight);
 
 TEMPLATE_TEST_CASE("Dimension Compatibility", "[derham_tests]",
-                   (typename std::integral_constant<int,2>),
-                   (typename std::integral_constant<int,3>))
+                   (typename std::integral_constant<int, 2>),
+                   (typename std::integral_constant<int, 3>))
 {
-  //SVD requires LAPACK
+  // SVD requires LAPACK
 #ifndef PZ_USING_LAPACK
   return;
 #endif
@@ -75,45 +86,53 @@ TEMPLATE_TEST_CASE("Dimension Compatibility", "[derham_tests]",
                               ESpace::HCurl,
                               ESpace::HDiv,
                               ESpace::HDivConst);
-  int k = GENERATE(1,2,3);
-  SECTION(names.at(leftSpace)) {
-    switch (leftSpace) {
-    case ESpace::H1:
-      CheckRankKerDim<ESpace::H1,ESpace::HCurl,dim>(k);
-      //TODOFIX
-      // if constexpr (dim == 2){
-      //   CheckRankKerDim<ESpace::H1, ESpace::HDiv, dim>(k);
-      // }
-      break;
-    case ESpace::HCurl:
-      if constexpr (dim == 2){
-        CheckRankKerDim<ESpace::HCurl, ESpace::L2, dim>(k);
+
+  SECTION(names.at(leftSpace))
+  {
+    int k = GENERATE(1, 2, 3);
+    SECTION(std::to_string(k))
+    {
+      switch (leftSpace)
+      {
+      case ESpace::H1:
+      {
+        CheckRankKerDim<ESpace::H1, ESpace::HCurl, dim>(k);
+        break;
       }
-      else{
-        CheckRankKerDim<ESpace::HCurl, ESpace::HDiv, dim>(k);
+      case ESpace::HCurl:
+      {
+        if constexpr (dim == 2)
+        {
+          CheckRankKerDim<ESpace::HCurl, ESpace::L2, dim>(k);
+        }
+        else
+        {
+          CheckRankKerDim<ESpace::HCurl, ESpace::HDiv, dim>(k);
+        }
+        break;
       }
-      break;
-    case ESpace::HDiv:
-      CheckRankKerDim<ESpace::HDiv,ESpace::L2,dim>(k);
-      break;
-    case ESpace::HDivConst:
-      //HdivConstant should only be called with k = 0. The if statement is only to ensure it is called once. If we generate k=0 it fails for other approximation spaces
-      //Any better solutions?
-      if (k == 1) {
-        CheckRankKerDim<ESpace::HDivConst,ESpace::L2,dim>(0);
+      case ESpace::HDiv:
+      {
+        CheckRankKerDim<ESpace::HDiv, ESpace::L2, dim>(k);
+        break;
       }
-      break;
-    case ESpace::L2:
-      break;
+      case ESpace::HDivConst:
+      {
+        CheckRankKerDim<ESpace::HDivConst, ESpace::L2, dim>(k);
+        break;
+      }
+      case ESpace::L2:
+        break;
+      }
     }
   }
 }
 
 TEMPLATE_TEST_CASE("Inclusion", "[derham_tests]",
-                   (typename std::integral_constant<int,2>),
-                   (typename std::integral_constant<int,3>))
+                   (typename std::integral_constant<int, 2>),
+                   (typename std::integral_constant<int, 3>))
 {
-  //SVD requires LAPACK
+  // SVD requires LAPACK
 #ifndef PZ_USING_LAPACK
   return;
 #endif
@@ -123,34 +142,43 @@ TEMPLATE_TEST_CASE("Inclusion", "[derham_tests]",
                               ESpace::HCurl,
                               ESpace::HDiv,
                               ESpace::HDivConst);
-  int k = GENERATE(1,2,3);
-  SECTION(names.at(leftSpace)) {
-    switch (leftSpace) {
-    case ESpace::H1:
-      CheckInclusion<ESpace::H1,ESpace::HCurl,dim>(k);
-      //TODOFIX
-      // if constexpr (dim == 2){
-      //   CheckInclusion<ESpace::H1, ESpace::HDiv, dim>(k);
-      // }
-      break;
-    case ESpace::HCurl:
-      CheckInclusion<ESpace::HCurl, ESpace::HDiv,dim>(k);
-      break;
-    case ESpace::HDiv:
-      CheckInclusion<ESpace::HDiv,ESpace::L2,dim>(k);
-      break;
-    case ESpace::HDivConst:
-      CheckInclusion<ESpace::HDivConst,ESpace::L2,dim>(k);
-      break;
-    default:
-      break;
+  SECTION(names.at(leftSpace))
+  {
+    int k = GENERATE(1, 2, 3);
+    SECTION(std::to_string(k))
+    {
+      switch (leftSpace)
+      {
+      case ESpace::H1:
+      {
+        CheckInclusion<ESpace::H1, ESpace::HCurl, dim>(k);
+        break;
+      }
+      case ESpace::HCurl:
+      {
+        CheckInclusion<ESpace::HCurl, ESpace::HDiv, dim>(k);
+        break;
+      }
+      case ESpace::HDiv:
+      {
+        CheckInclusion<ESpace::HDiv, ESpace::L2, dim>(k);
+        break;
+      }
+      case ESpace::HDivConst:
+      {
+        CheckInclusion<ESpace::HDivConst, ESpace::L2, dim>(k);
+        break;
+      }
+      default:
+        break;
+      }
     }
   }
 }
 
 /*******************************************************************************
  ***********************************AUX FUNCS***********************************
-*******************************************************************************/
+ *******************************************************************************/
 
 /** @brief Creates appropriate computational meshes to study De Rham compatibility of FEM approximation spaces.
     The mesh will consist of elements of type elType (inside the function,
@@ -163,7 +191,7 @@ TEMPLATE_TEST_CASE("Inclusion", "[derham_tests]",
     @param [out] cmeshL computational mesh of leftmost approximaton space
     @param [out] cmeshR computational mesh of rightmost approximaton space*/
 template <ESpace leftSpace, ESpace rightSpace, int dim>
-void CreateMeshes(int kRight, MMeshType elType,
+void CreateMeshes(int &kRight, MMeshType elType,
                   int &kLeft, TPZAutoPointer<TPZGeoMesh> &gmesh,
                   TPZAutoPointer<TPZCompMesh> &cmeshL,
                   TPZAutoPointer<TPZCompMesh> &cmeshR);
@@ -191,327 +219,421 @@ TPZAutoPointer<TPZCompMesh> CreateCMesh(TPZAutoPointer<TPZGeoMesh> gMesh,
   @param [in] S matrix
   @param[in] tol arithmetic tolerance
 */
-int CalcRank(const TPZFMatrix<STATE> & S, const STATE tol);
+int CalcRank(const TPZFMatrix<STATE> &S, const STATE tol);
 
 /*******************************************************************************
 ***********************************TEST FUNCS***********************************
 *******************************************************************************/
 
-
 template <ESpace leftSpace, ESpace rightSpace, int dim>
-void CheckRankKerDim(int kRight) {
+void CheckRankKerDim(int kRight)
+{
 
   /******************************************
   CHECK FUNCTION DECLARATION FOR MORE DETAILS
   *******************************************/
-  //select element type
+  // select element type
   auto elType = GENERATE(MMeshType::ETriangular,
                          MMeshType::EQuadrilateral,
                          MMeshType::ETetrahedral,
                          MMeshType::EHexahedral,
                          MMeshType::EPrismatic);
-  
-  const auto elDim = MMeshType_Dimension(elType);
-  if(elType == MMeshType::EPrismatic && leftSpace == ESpace::HCurl){
-    return;//TODOFIX
-  }
-  //if dimension does not correspond, skip
-  if(elDim != dim) return;
 
-  
-  int kLeft;
-  TPZAutoPointer<TPZGeoMesh> gmesh{nullptr};
-  TPZAutoPointer<TPZCompMesh> cmeshL{nullptr}, cmeshR{nullptr};
-  //creates computational meshes
-  CreateMeshes<leftSpace, rightSpace, dim>(kRight, elType,
-                                           kLeft, gmesh, cmeshL, cmeshR);
-
-  //for debuggin
-  const auto nameLeft = names.at(leftSpace);
-  const auto nameRight = names.at(rightSpace);
-  const auto elName = MMeshType_Name(elType);
-  CAPTURE(nameLeft,nameRight,elName);
-
-  //stores the matrices
-  TPZAutoPointer<TPZMatrix<STATE>> matPtrL = nullptr;
-  TPZAutoPointer<TPZMatrix<STATE>> matPtrR = nullptr;
-
+  SECTION(MMeshType_Name(elType))
   {
-    
-    constexpr int nThreads{0};
-    TPZLinearAnalysis anL(cmeshL,RenumType::ENone);
-    TPZLinearAnalysis anR(cmeshR, RenumType::ENone);
-      
-    TPZFStructMatrix<STATE> strmtrxL(cmeshL);
-    strmtrxL.SetNumThreads(nThreads);
-    anL.SetStructuralMatrix(strmtrxL);
+    if (elType == MMeshType::EPrismatic && leftSpace == ESpace::HDivConst)
+    {
+      return; // TODOFIX
+    }
+    const auto elDim = MMeshType_Dimension(elType);
+    if (elType == MMeshType::EPrismatic && leftSpace == ESpace::HCurl)
+    {
+      return; // TODOFIX
+    }
 
-    TPZFStructMatrix<STATE> strmtrxR(cmeshR);
-    strmtrxR.SetNumThreads(nThreads);
-    anR.SetStructuralMatrix(strmtrxR);
-      
-    TPZStepSolver<STATE> step;
-    step.SetDirect(ELU);
+    // if dimension does not correspond, skip
+    if (elDim != dim)
+      return;
 
-    anL.SetSolver(step);
-    anR.SetSolver(step);
-      
-    anL.Assemble();
-    anR.Assemble();
+    int kLeft;
+    TPZAutoPointer<TPZGeoMesh> gmesh{nullptr};
+    TPZAutoPointer<TPZCompMesh> cmeshL{nullptr}, cmeshR{nullptr};
+    // creates computational meshes
+    CreateMeshes<leftSpace, rightSpace, dim>(kRight, elType,
+                                             kLeft, gmesh, cmeshL, cmeshR);
 
-    matPtrL = anL.MatrixSolver<STATE>().Matrix();
-    matPtrR = anR.MatrixSolver<STATE>().Matrix();
+    // for debuggin
+    const auto nameLeft = names.at(leftSpace);
+    const auto nameRight = names.at(rightSpace);
+    const auto elName = MMeshType_Name(elType);
+    CAPTURE(nameLeft, nameRight, elName);
 
-  }
-    
-  TPZFMatrix<STATE> matL(*matPtrL);
-  TPZFMatrix<STATE> matR(*matPtrR);
+    // stores the matrices
+    TPZAutoPointer<TPZMatrix<STATE>> matPtrL = nullptr;
+    TPZAutoPointer<TPZMatrix<STATE>> matPtrR = nullptr;
 
-  const int dimL = matL.Rows();
-  const int dimR = matR.Rows();
-    
-  TPZFMatrix<STATE> SL, SR;
-    
-  {
-    TPZFMatrix<STATE> Udummy, VTdummy;
-    matL.SVD(Udummy, SL, VTdummy, 'N', 'N');
-    matR.SVD(Udummy, SR, VTdummy, 'N', 'N');
-  }
-  static constexpr auto tol = std::numeric_limits<STATE>::epsilon()*100000;
+    {
+      constexpr int nThreads{4};
+      TPZLinearAnalysis anL(cmeshL, RenumType::ENone);
+      TPZLinearAnalysis anR(cmeshR, RenumType::ENone);
 
-  //rank of op(phi_i,phi_j) of left space
-  const int rankL = CalcRank(SL,tol);
-  const int rankR = CalcRank(SR,tol);
-  //dimension of the nullspace of op(phi_i,phi_j) of right space
-  const int kerR = dimR-rankR;
-      
-  CAPTURE(kLeft,kRight,dimL,rankL,dimR,kerR,rankR);
-  CAPTURE(SL,SR);
-  if constexpr (rightSpace==ESpace::L2){//for L2 the operator is -> 0
-    REQUIRE(rankL == rankR);
-  }
-  else{
-    REQUIRE(rankL == kerR);
+      TPZFStructMatrix<STATE> strmtrxL(cmeshL);
+      strmtrxL.SetNumThreads(nThreads);
+      anL.SetStructuralMatrix(strmtrxL);
+
+      TPZFStructMatrix<STATE> strmtrxR(cmeshR);
+      strmtrxR.SetNumThreads(nThreads);
+      anR.SetStructuralMatrix(strmtrxR);
+
+      TPZStepSolver<STATE> step;
+      step.SetDirect(ELU);
+
+      anL.SetSolver(step);
+      anR.SetSolver(step);
+
+      anL.Assemble();
+      anR.Assemble();
+
+      matPtrL = anL.MatrixSolver<STATE>().Matrix();
+      matPtrR = anR.MatrixSolver<STATE>().Matrix();
+    }
+
+    TPZFMatrix<STATE> matL(*matPtrL);
+    TPZFMatrix<STATE> matR(*matPtrR);
+
+    const int dimL = matL.Rows();
+    const int dimR = matR.Rows();
+
+    TPZFMatrix<STATE> SL, SR;
+
+    {
+      TPZFMatrix<STATE> Udummy, VTdummy;
+      matL.SVD(Udummy, SL, VTdummy, 'N', 'N');
+      matR.SVD(Udummy, SR, VTdummy, 'N', 'N');
+    }
+    static constexpr auto tol = std::numeric_limits<STATE>::epsilon() * 100000;
+
+    TPZManVector<int, 27> connectorderL(cmeshL->NConnects(), 0), connectorderR(cmeshR->NConnects(), 0);
+    for (int i = 0; i < cmeshL->NConnects(); i++)
+    {
+      connectorderL[i] = cmeshL->ConnectVec()[i].Order();
+    }
+    for (int i = 0; i < cmeshR->NConnects(); i++)
+    {
+      connectorderR[i] = cmeshR->ConnectVec()[i].Order();
+    }
+    TPZManVector<int, 27> nshapeL(cmeshL->NConnects(), 0), nshapeR(cmeshR->NConnects(), 0);
+    for (int i = 0; i < cmeshL->NConnects(); i++)
+    {
+      nshapeL[i] = cmeshL->ConnectVec()[i].NShape();
+    }
+    for (int i = 0; i < cmeshR->NConnects(); i++)
+    {
+      nshapeR[i] = cmeshR->ConnectVec()[i].NShape();
+    }
+
+    // rank of op(phi_i,phi_j) of left space
+    const int rankL = CalcRank(SL, tol);
+    const int rankR = CalcRank(SR, tol);
+    // dimension of the nullspace of op(phi_i,phi_j) of right space
+    const int kerR = dimR - rankR;
+
+    CAPTURE(kLeft, kRight, dimL, rankL, dimR, kerR, rankR);
+    CAPTURE(connectorderL, connectorderR);
+    CAPTURE(nshapeL, nshapeR);
+    // CAPTURE(SL, SR);
+    if constexpr (rightSpace == ESpace::L2)
+    { // for L2 the operator is -> 0
+      REQUIRE(rankL == rankR);
+    }
+    else
+    {
+      REQUIRE(rankL == kerR);
+    }
   }
 }
 
 template <ESpace leftSpace, ESpace rightSpace, int dim>
-void CheckInclusion(int kRight) {
+void CheckInclusion(int kRight)
+{
   /******************************************
   CHECK FUNCTION DECLARATION FOR MORE DETAILS
   *******************************************/
-  
+
   constexpr int matId = 1;
-  //select element type
+  // select element type
   auto elType = GENERATE(MMeshType::ETriangular, MMeshType::EQuadrilateral,
                          MMeshType::ETetrahedral, MMeshType::EHexahedral,
                          MMeshType::EPrismatic);
-  const auto elDim = MMeshType_Dimension(elType);
 
-
-  if(elType == MMeshType::EPrismatic && leftSpace == ESpace::HCurl){
-    return;//TODOFIX
-  }
-  //skips if dimension is not compatible
-  if (elDim != dim) return;
-  
-  int kLeft;
-  TPZAutoPointer<TPZGeoMesh> gmesh{nullptr};
-  TPZAutoPointer<TPZCompMesh> cmeshL{nullptr}, cmeshR{nullptr};
-  //for debugging
-  const auto nameLeft = names.at(leftSpace);
-  const auto nameRight = names.at(rightSpace);
-  const auto elName = MMeshType_Name(elType);
-  CAPTURE(nameLeft,nameRight,elName);
-
-  //creates computational meshes
-  CreateMeshes<leftSpace, rightSpace, dim>(kRight, elType, kLeft,
-                                           gmesh, cmeshL, cmeshR);
-  
-  //creates multiphysics mesh
-  TPZAutoPointer<TPZCompMesh> cmeshMF = new TPZCompMesh(gmesh);
-
-
-  /*
-    Now, the appropriate material will be selected given their
-    combination of left and right approximation spaces.
-    This material will be responsible for creating the matrix M
-   */
-  auto *matMF = []() -> TPZMaterial * {
-    if constexpr (rightSpace == ESpace::H1) {
-      return nullptr;
-    } else if constexpr (rightSpace == ESpace::HCurl) {
-      return new TPZMatDeRhamH1HCurl(matId, dim);
-    } else if constexpr (rightSpace == ESpace::HDiv) {
-      if constexpr (dim == 3){
-        return new TPZMatDeRhamHCurlHDiv(matId,dim);
-      }
-      return nullptr;
-    } else if constexpr (rightSpace == ESpace::L2) {
-      return new TPZMatDeRhamHDivL2(matId, dim);
-    }
-  }();
-  if (!matMF)
-    return;
-
-  cmeshMF->InsertMaterialObject(matMF);
-  cmeshMF->SetDimModel(dim);
-
-  cmeshMF->SetAllCreateFunctionsMultiphysicElem();
-
-  cmeshMF->AutoBuild();
-  cmeshMF->CleanUpUnconnectedNodes();
-
-  TPZManVector<TPZCompMesh *, 2> meshVecIn = {cmeshL.operator->(),
-    cmeshR.operator->()};
-
-  TPZBuildMultiphysicsMesh::AddElements(meshVecIn, cmeshMF.operator->());
-  TPZBuildMultiphysicsMesh::AddConnects(meshVecIn, cmeshMF.operator->());
-  TPZBuildMultiphysicsMesh::TransferFromMeshes(meshVecIn,
-                                               cmeshMF.operator->());
-
-  cmeshMF->ExpandSolution();
-  cmeshMF->ComputeNodElCon();
-  cmeshMF->CleanUpUnconnectedNodes();
-  TPZLinearAnalysis analysis(cmeshMF, RenumType::ENone);
-  TPZFStructMatrix<STATE> strmtrx(cmeshMF);
-  analysis.SetStructuralMatrix(strmtrx);
-  TPZStepSolver<STATE> step;
-  step.SetDirect(ELU);
-  analysis.SetSolver(step);
-    
-  analysis.Assemble();
-  //it is a full matrix
-  auto mfMatrix =
-    dynamic_cast<TPZFMatrix<STATE>&> (
-      analysis.MatrixSolver<STATE>().Matrix().operator*());
-
-  const int rLeftEqs = cmeshR->NEquations();
-  const int lLeftEqs = cmeshL->NEquations();
-  TPZFMatrix<STATE> rightMatrix(rLeftEqs,rLeftEqs);
-
-  //rightMatrix is the matrix phi_i phi_j for the approx. space on the right
-  mfMatrix.GetSub(lLeftEqs, lLeftEqs, rLeftEqs, rLeftEqs, rightMatrix);
-
-
-  TPZFMatrix<STATE> Sfull, Sright;
-    
+  SECTION(MMeshType_Name(elType))
   {
-    TPZFMatrix<STATE> Udummy, VTdummy;
-    mfMatrix.SVD(Udummy, Sfull, VTdummy, 'N', 'N');
-    rightMatrix.SVD(Udummy, Sright, VTdummy, 'N', 'N');
+    const auto elDim = MMeshType_Dimension(elType);
+
+    if (elType == MMeshType::EPrismatic && leftSpace == ESpace::HDivConst)
+    {
+      return; // TODOFIX
+    }
+
+    if (elType == MMeshType::EPrismatic && leftSpace == ESpace::HCurl)
+    {
+      return; // TODOFIX
+    }
+    // skips if dimension is not compatible
+    if (elDim != dim)
+      return;
+
+    int kLeft;
+    TPZAutoPointer<TPZGeoMesh> gmesh{nullptr};
+    TPZAutoPointer<TPZCompMesh> cmeshL{nullptr}, cmeshR{nullptr};
+    // for debugging
+    const auto nameLeft = names.at(leftSpace);
+    const auto nameRight = names.at(rightSpace);
+    const auto elName = MMeshType_Name(elType);
+    CAPTURE(nameLeft, nameRight, elName);
+
+    // creates computational meshes
+    CreateMeshes<leftSpace, rightSpace, dim>(kRight, elType, kLeft,
+                                             gmesh, cmeshL, cmeshR);
+
+    // creates multiphysics mesh
+    TPZMultiphysicsCompMesh *cmeshMF = new TPZMultiphysicsCompMesh(gmesh);
+
+    /*
+      Now, the appropriate material will be selected given their
+      combination of left and right approximation spaces.
+      This material will be responsible for creating the matrix M
+     */
+    auto *matMF = []() -> TPZMaterial *
+    {
+      if constexpr (rightSpace == ESpace::H1)
+      {
+        return nullptr;
+      }
+      else if constexpr (rightSpace == ESpace::HCurl)
+      {
+        return new TPZMatDeRhamH1HCurl(matId, dim);
+      }
+      else if constexpr (rightSpace == ESpace::HDiv)
+      {
+        if constexpr (dim == 3)
+        {
+          return new TPZMatDeRhamHCurlHDiv(matId, dim);
+        }
+        return nullptr;
+      }
+      else if constexpr (rightSpace == ESpace::L2)
+      {
+        return new TPZMatDeRhamHDivL2(matId, dim);
+      }
+    }();
+
+    if (!matMF)
+      return;
+
+    cmeshMF->InsertMaterialObject(matMF);
+    cmeshMF->SetDimModel(dim);
+    cmeshMF->SetAllCreateFunctionsMultiphysicElem();
+
+    TPZManVector<int, 2> active_approx_spaces(2, 1);
+    TPZManVector<TPZCompMesh *, 2> meshVec(2);
+    meshVec[0] = cmeshL.operator->();
+    meshVec[1] = cmeshR.operator->();
+
+    cmeshMF->BuildMultiphysicsSpace(active_approx_spaces, meshVec);
+    cmeshMF->CleanUpUnconnectedNodes();
+    cmeshMF->LoadReferences();
+
+    TPZLinearAnalysis analysis(cmeshMF, RenumType::ENone);
+    TPZFStructMatrix<STATE> strmtrx(cmeshMF);
+    analysis.SetStructuralMatrix(strmtrx);
+    TPZStepSolver<STATE> step;
+    step.SetDirect(ELU);
+    analysis.SetSolver(step);
+
+    analysis.Assemble();
+    // it is a full matrix
+    auto mfMatrix =
+        dynamic_cast<TPZFMatrix<STATE> &>(
+            analysis.MatrixSolver<STATE>().Matrix().operator*());
+
+    const int rLeftEqs = cmeshR->NEquations();
+    const int lLeftEqs = cmeshL->NEquations();
+    TPZFMatrix<STATE> rightMatrix(rLeftEqs, rLeftEqs);
+
+    // rightMatrix is the matrix phi_i phi_j for the approx. space on the right
+    mfMatrix.GetSub(lLeftEqs, lLeftEqs, rLeftEqs, rLeftEqs, rightMatrix);
+
+    TPZFMatrix<STATE> Sfull, Sright;
+
+    {
+      TPZFMatrix<STATE> Udummy, VTdummy;
+      mfMatrix.SVD(Udummy, Sfull, VTdummy, 'N', 'N');
+      rightMatrix.SVD(Udummy, Sright, VTdummy, 'N', 'N');
+    }
+
+    /**
+       We want to compare if rank(rightMatrix) == rank(mfMatrix).
+       This will ensure us that op(phi_i).op(phi_j) of the left space
+       are contained in the functions of the approximation space on the right.
+     */
+    static constexpr auto tol = std::numeric_limits<STATE>::epsilon() * 10000;
+    auto fullDim = Sfull.Rows();
+    auto fullRank = CalcRank(Sfull, tol);
+    auto rightDim = Sright.Rows();
+    auto rightRank = CalcRank(Sright, tol);
+
+    CAPTURE(kLeft, kRight, fullDim, fullRank, rightDim, rightRank);
+    REQUIRE(fullRank == rightRank);
   }
-
-
-  /**
-     We want to compare if rank(rightMatrix) == rank(mfMatrix).
-     This will ensure us that op(phi_i).op(phi_j) of the left space
-     are contained in the functions of the approximation space on the right.
-   */
-  static constexpr auto tol = std::numeric_limits<STATE>::epsilon()*10000;
-  auto fullDim = Sfull.Rows();
-  auto fullRank = CalcRank(Sfull,tol);
-  auto rightDim = Sright.Rows();
-  auto rightRank = CalcRank(Sright,tol);
-
-  CAPTURE(kLeft,kRight,fullDim, fullRank,rightDim, rightRank);
-  REQUIRE(fullRank == rightRank);
 }
-
 
 /*******************************************************************************
  ***********************************AUX FUNCS***********************************
-*******************************************************************************/
+ *******************************************************************************/
 template <ESpace leftSpace, ESpace rightSpace, int dim>
-void CreateMeshes(int kRight, MMeshType elType,
+void CreateMeshes(int &kRight, MMeshType elType,
                   int &kLeft, TPZAutoPointer<TPZGeoMesh> &gmesh,
                   TPZAutoPointer<TPZCompMesh> &cmeshL,
-                  TPZAutoPointer<TPZCompMesh> &cmeshR){
+                  TPZAutoPointer<TPZCompMesh> &cmeshR)
+{
+
   constexpr int matId = 1;
-  
-  
+
   const auto elDim = MMeshType_Dimension(elType);
 
   // for CheckInclusion test, the following materials will be ignored
-  auto *matLeft = [&kLeft,kRight,elType]()
-    -> TPZMaterial* {
-    if constexpr (leftSpace == ESpace::H1) {
+  auto *matLeft = [&kLeft, &kRight, elType]()
+      -> TPZMaterial *
+  {
+    if constexpr (leftSpace == ESpace::H1)
+    {
       kLeft = kRight + 1;
       return new TPZMatDeRhamH1(matId, dim);
-    } else if constexpr (leftSpace == ESpace::HCurl) {
-      if(elType == MMeshType::EQuadrilateral || elType == MMeshType::EHexahedral){
+    }
+    else if constexpr (leftSpace == ESpace::HCurl)
+    {
+      if (elType == MMeshType::EQuadrilateral || elType == MMeshType::EHexahedral)
+      {
         kLeft = kRight;
-      }else{
+      }
+      else
+      {
         kLeft = kRight + 1;
       }
-      return new TPZMatDeRhamHCurl(matId,dim);
-    } else if constexpr (leftSpace == ESpace::HDiv) {
+      return new TPZMatDeRhamHCurl(matId, dim);
+    }
+    else if constexpr (leftSpace == ESpace::HDiv)
+    {
       kLeft = kRight;
-      return new TPZMatDeRhamHDiv(matId,dim);
-    } else if constexpr (leftSpace == ESpace::HDivConst) {
+      return new TPZMatDeRhamHDiv(matId, dim);
+    }
+    else if constexpr (leftSpace == ESpace::HDivConst)
+    {
       kLeft = kRight;
-      return new TPZMatDeRhamHDiv(matId,dim);
-    } else if constexpr (leftSpace == ESpace::L2) {
+      kRight = 0;
+      return new TPZMatDeRhamHDiv(matId, dim);
+    }
+    else if constexpr (leftSpace == ESpace::L2)
+    {
       return nullptr;
     }
   }();
-    
+
   auto *matRight = []()
-    -> TPZMaterial * {
-    if constexpr (rightSpace == ESpace::H1) {
+      -> TPZMaterial *
+  {
+    if constexpr (rightSpace == ESpace::H1)
+    {
       return nullptr;
-    } else if constexpr (rightSpace == ESpace::HCurl) {
-      return new TPZMatDeRhamHCurl(matId,dim);
-    } else if constexpr (rightSpace == ESpace::HDiv) {
-      return new TPZMatDeRhamHDiv(matId,dim);
-    } else if constexpr (rightSpace == ESpace::HDivConst) {
-      return new TPZMatDeRhamHDiv(matId,dim);
-    } else if constexpr (rightSpace == ESpace::L2) {
-      return new TPZMatDeRhamL2(matId,dim);
+    }
+    else if constexpr (rightSpace == ESpace::HCurl)
+    {
+      return new TPZMatDeRhamHCurl(matId, dim);
+    }
+    else if constexpr (rightSpace == ESpace::HDiv)
+    {
+      return new TPZMatDeRhamHDiv(matId, dim);
+    }
+    else if constexpr (rightSpace == ESpace::HDivConst)
+    {
+      return new TPZMatDeRhamHDiv(matId, dim);
+    }
+    else if constexpr (rightSpace == ESpace::L2)
+    {
+      return new TPZMatDeRhamL2(matId, dim);
     }
   }();
 
   REQUIRE((matLeft != nullptr && matRight != nullptr));
-  //generates mesh with a single element
+  // generates mesh with a single element
   constexpr bool singleElement{true};
 
-  if constexpr(singleElement){
+  if constexpr (singleElement)
+  {
     constexpr bool createBoundEls{false};
     gmesh = TPZGeoMeshTools::CreateGeoMeshSingleEl(elType, matId, createBoundEls);
-  }else{
-    gmesh = CreateGMesh(dim,elType,matId);
   }
-  cmeshL = CreateCMesh(gmesh, matLeft, matId, kLeft, leftSpace);
-  cmeshR = CreateCMesh(gmesh, matRight, matId, kRight, rightSpace);
+  else
+  {
+    gmesh = CreateGMesh(dim, elType, matId);
+  }
 
-
-  auto EnrichMesh = [](TPZAutoPointer<TPZCompMesh> cmesh, const int k){
-
-    for (auto cel : cmesh->ElementVec()){
-      if(cel->Dimension() != dim) continue;
+  auto EnrichMesh = [](TPZAutoPointer<TPZCompMesh> cmesh, const int k)
+  {
+    for (auto cel : cmesh->ElementVec())
+    {
+      if (cel->Dimension() != dim)
+        continue;
       auto intel =
-        dynamic_cast<TPZInterpolatedElement*>(cel);
+          dynamic_cast<TPZInterpolatedElement *>(cel);
       const auto nsides = intel->Reference()->NSides();
-      intel->SetSideOrder(nsides-1, k+1);
+      intel->SetSideOrder(nsides - 1, k + 1);
+      intel->AdjustIntegrationRule();
     }
     cmesh->ExpandSolution();
   };
 
-  if(elType == MMeshType::ETetrahedral){
-    if constexpr (leftSpace == ESpace::HCurl){
+  cmeshL = CreateCMesh(gmesh, matLeft, matId, kLeft, leftSpace);
+
+  // Enriching the internal functions for Hdiv or HdivConst
+  if constexpr (leftSpace == ESpace::HDiv || leftSpace == ESpace::HDivConst)
+  {
+    int enrichLvl = GENERATE(-1, 0, 1);
+    // SECTION("Enrichment Level: " + std::to_string(enrichLvl+1));
+    EnrichMesh(cmeshL, kLeft + enrichLvl);
+    if constexpr (leftSpace == ESpace::HDiv)
+    { // In this case, the L2 space order has to be equal to the Hdiv enriched space
+      kRight = kLeft + enrichLvl + 1;
+      cmeshR = CreateCMesh(gmesh, matRight, matId, kRight, rightSpace);
+    }
+    else
+    {
+      cmeshR = CreateCMesh(gmesh, matRight, matId, kRight, rightSpace);
+    }
+  }
+  else
+  {
+    cmeshR = CreateCMesh(gmesh, matRight, matId, kRight, rightSpace);
+  }
+
+  if (elType == MMeshType::ETetrahedral)
+  {
+    if constexpr (leftSpace == ESpace::HCurl)
+    {
       EnrichMesh(cmeshL, kLeft);
     }
-    else if constexpr (rightSpace == ESpace::HCurl){
+    else if constexpr (rightSpace == ESpace::HCurl)
+    {
       EnrichMesh(cmeshR, kRight);
     }
-      
-    if constexpr (leftSpace == ESpace::H1){
+
+    if constexpr (leftSpace == ESpace::H1)
+    {
       EnrichMesh(cmeshL, kLeft);
     }
   }
-  
 }
-
 
 TPZAutoPointer<TPZGeoMesh> CreateGMesh(const int dim, const MMeshType elType,
                                        const int matId)
@@ -538,7 +660,8 @@ TPZAutoPointer<TPZCompMesh> CreateCMesh(TPZAutoPointer<TPZGeoMesh> gmesh,
   cmesh->SetDefaultOrder(k);
   cmesh->SetDimModel(gmesh->Dimension());
   cmesh->InsertMaterialObject(mat);
-  switch (space) {
+  switch (space)
+  {
   case ESpace::H1:
     cmesh->SetAllCreateFunctionsContinuous();
     break;
@@ -565,12 +688,12 @@ TPZAutoPointer<TPZCompMesh> CreateCMesh(TPZAutoPointer<TPZGeoMesh> gmesh,
   return cmesh;
 }
 
-
-
-int CalcRank(const TPZFMatrix<STATE> & S, const STATE tol){
+int CalcRank(const TPZFMatrix<STATE> &S, const STATE tol)
+{
   int rank = 0;
   const int dimMat = S.Rows();
-  for (int i = 0; i < dimMat; i++) {
+  for (int i = 0; i < dimMat; i++)
+  {
     rank += S.GetVal(i, 0) > tol ? 1 : 0;
   }
   return rank;

--- a/UnitTest_PZ/TestMesh/CMakeLists.txt
+++ b/UnitTest_PZ/TestMesh/CMakeLists.txt
@@ -1,6 +1,6 @@
 # @file neopz/UnitTest_PZ/TestMesh/CMakeLists.txt  -- CMake file for unit test of the mesh module
 
-add_unit_test(TestHDivConstant TestHDivConstant.cpp)
+add_unit_test(TestHDivConstant TestHDivConstant.cpp TPZMatL2Product.cpp)
 add_unit_test(TestHDiv TestHDiv.cpp)
 # add_unit_test(TestCondensedEl TestCondensedElement.cpp) NEEDS FIX
 add_unit_test(TestErrorAnalysis TestError.cpp)

--- a/UnitTest_PZ/TestMesh/TPZMatL2Product.cpp
+++ b/UnitTest_PZ/TestMesh/TPZMatL2Product.cpp
@@ -1,0 +1,57 @@
+#include "TPZMatL2Product.h"
+#include "TPZMaterialDataT.h"
+#include "pzaxestools.h"
+
+void TPZMatL2Product::Contribute(const TPZMaterialDataT<STATE> &data,
+                                REAL weight, TPZFMatrix<STATE> &ek,
+                                TPZFMatrix<STATE> &ef){
+
+  if (data.fShapeType == TPZMaterialData::EVecShape){
+    ContributeVecShape(data, weight, ek, ef);
+  }
+  else if (data.fShapeType == TPZMaterialData::EScalarShape){
+    ContributeScalarShape(data, weight, ek, ef);
+  }
+}
+
+void TPZMatL2Product::ContributeVecShape(const TPZMaterialDataT<STATE> &data,
+                                        REAL weight, TPZFMatrix<STATE> &ek,
+                                        TPZFMatrix<STATE> &ef)
+{
+  int64_t nShapeHDiv = data.fVecShapeIndex.NElements(); // number of Hdiv shape functions
+  TPZFNMatrix<150, REAL> phiHDiv(fDim, nShapeHDiv, 0.0);
+
+  for (int i = 0; i < nShapeHDiv; i++){
+    int ivecind = data.fVecShapeIndex[i].first;
+    for (int j = 0; j < fDim; j++){
+      phiHDiv(j, i) = data.fDeformedDirections(j, ivecind);
+    }
+  }
+
+#ifdef PZ_USING_LAPACK
+  ek.AddContribution(0, 0, phiHDiv, true, phiHDiv, false, weight);
+#else
+  for (int i = 0; i < nShapeHDiv; i++){
+    for (int j = 0; j < nShapeHDiv; j++){
+      STATE phiiphij = 0.0;
+      for (int d = 0; d < fDim; d++){
+        phiiphij += phiHDiv(d, i) * phiHDiv(d, j);
+      }
+      ek(i, j) += phiiphij * weight;
+    }
+  }
+#endif
+}
+
+void TPZMatL2Product::ContributeScalarShape(const TPZMaterialDataT<STATE> &data,
+                                           REAL weight, TPZFMatrix<STATE> &ek,
+                                           TPZFMatrix<STATE> &ef){
+
+  const TPZFMatrix<REAL> &phi = data.phi;
+  const int nFuncs = phi.Rows();
+  for (int i = 0; i < nFuncs; i++){
+    for (int j = 0; j < nFuncs; j++){
+      ek(i, j) += phi(i, 0) * phi(j, 0) * weight;
+    }
+  }
+}

--- a/UnitTest_PZ/TestMesh/TPZMatL2Product.h
+++ b/UnitTest_PZ/TestMesh/TPZMatL2Product.h
@@ -1,0 +1,39 @@
+#ifndef TPZMATL2PRODUCT_H
+#define TPZMATL2PRODUCT_H
+
+#include "TPZMatBase.h"
+#include "TPZMatSingleSpace.h"
+
+class TPZMatL2Product :
+  public TPZMatBase<STATE, TPZMatSingleSpaceT<STATE>>
+{
+  using TBase = TPZMatBase<STATE, TPZMatSingleSpaceT<STATE>>;
+    
+public:
+    TPZMatL2Product(int matId, int dim) : TBase(matId), fDim(dim) {}
+
+    [[nodiscard]] int Dimension() const override { return fDim;}
+
+    [[nodiscard]] int NStateVariables() const override { return 1;}
+
+    void Contribute(const TPZMaterialDataT<STATE> &data, REAL weight,
+                    TPZFMatrix<STATE> &ek,
+                    TPZFMatrix<STATE> &ef) override;
+    
+    void ContributeVecShape(const TPZMaterialDataT<STATE> &data,
+                            REAL weight, TPZFMatrix<STATE> &ek,
+                            TPZFMatrix<STATE> &ef);
+
+    void ContributeScalarShape(const TPZMaterialDataT<STATE> &data,
+                              REAL weight, TPZFMatrix<STATE> &ek,
+                              TPZFMatrix<STATE> &ef);
+    
+    inline void ContributeBC(const TPZMaterialDataT<STATE> &data,
+                             REAL weight,
+                             TPZFMatrix<STATE> &ek,
+                             TPZFMatrix<STATE> &ef,
+                             TPZBndCondT<STATE> &bc) override {}
+private:
+    const int fDim{-1};
+};
+#endif

--- a/UnitTest_PZ/TestMesh/TestHDivConstant.cpp
+++ b/UnitTest_PZ/TestMesh/TestHDivConstant.cpp
@@ -6,6 +6,11 @@
 //  Copyright 2011 UNICAMP. All rights reserved.
 //
 
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+#include <catch2/catch_approx.hpp>
+
 #include "pzmanvector.h"
 #include "pzvec_extras.h"
 #include "pztrnsform.h"
@@ -19,25 +24,20 @@
 #include "pzcompel.h"
 #include "TPZCompElDisc.h"
 #include "tpzintpoints.h"
-#include "pztrnsform.h"
 #include "pzintel.h"
 #include "pzfstrmatrix.h"
 #include "pzskylstrmatrix.h"
 #include "pzstepsolver.h"
-
 #include "pzmultiphysicselement.h"
 #include "pzmultiphysicscompel.h"
 #include "TPZMultiphysicsInterfaceEl.h"
 #include "pzbuildmultiphysicsmesh.h"
 #include "TPZCompMeshTools.h"
-
 #include "TPZExtendGridDimension.h"
-
 #include "TPZLinearAnalysis.h"
-
-#include "pzshapelinear.h"
 #include "TPZRefPatternTools.h"
 #include "pzshtmat.h"
+#include "pzshapelinear.h"
 #include "pzshapequad.h"
 #include "pzshapetriang.h"
 #include "pzshapecube.h"
@@ -45,7 +45,6 @@
 #include "pzshapetetra.h"
 #include "pzshapepiram.h"
 #include "pzshapepiramHdiv.h"
-
 #include "TPZRefPattern.h"
 #include "tpzgeoelrefpattern.h"
 #include "pzgeopoint.h"
@@ -58,89 +57,176 @@
 #include "tpzarc3d.h"
 #include "pzgeotetrahedra.h"
 #include "pzgeoelrefless.h"
-
-
 #include "TPZVTKGeoMesh.h"
+#include "TPZMatL2Product.h"
+#include "TPZGeoMeshTools.h"
 
+enum class ESpace
+{
+    H1,
+    HCurl,
+    HDiv,
+    HDivConst,
+    L2
+};
+
+static const std::map<ESpace, const char *> names({{ESpace::H1, "H1"},
+                                                   {ESpace::HCurl, "HCurl"},
+                                                   {ESpace::HDiv, "HDiv"},
+                                                   {ESpace::HDivConst, "HDivConst"},
+                                                   {ESpace::L2, "L2"}});
 
 using namespace pzshape;
-
 
 #ifdef PZ_LOG
 static TPZLogger logger("pz.mesh.testhdivconstant");
 #endif
 
-#include <catch2/catch_test_macros.hpp>
-
-static int tetraedra_2[6][4]=
-{
-    {1,2,5,4},
-    {4,7,3,2},
-    {0,1,2,4},
-    {0,2,3,4},
-    {4,5,6,2},
-    {4,6,7,2}
-};
+static int tetraedra_2[6][4] =
+    {
+        {1, 2, 5, 4},
+        {4, 7, 3, 2},
+        {0, 1, 2, 4},
+        {0, 2, 3, 4},
+        {4, 5, 6, 2},
+        {4, 6, 7, 2}};
 
 static bool MyDoubleComparer(REAL a, REAL b)
 {
-    if (IsZero(a-b)){
+    if (IsZero(a - b))
+    {
         return true;
     }
-    else{
+    else
+    {
         return false;
     }
 }
 
 static void GenerateNodes(TPZGeoMesh *gmesh, int64_t nelem)
 {
-    gmesh->NodeVec().Resize((nelem+1)*(nelem+1)*(nelem+1));
-    for (int64_t i=0; i<=nelem; i++) {
-        for (int64_t j=0; j<=nelem; j++) {
-            for (int64_t k=0; k<=nelem; k++) {
-                TPZManVector<REAL,3> x(3);
-                x[0] = k*1./nelem;
-                x[1] = j*1./nelem;
-                x[2] = i*1./nelem;
-                gmesh->NodeVec()[i*(nelem+1)*(nelem+1)+j*(nelem+1)+k].Initialize(x, *gmesh);
+    gmesh->NodeVec().Resize((nelem + 1) * (nelem + 1) * (nelem + 1));
+    for (int64_t i = 0; i <= nelem; i++)
+    {
+        for (int64_t j = 0; j <= nelem; j++)
+        {
+            for (int64_t k = 0; k <= nelem; k++)
+            {
+                TPZManVector<REAL, 3> x(3);
+                x[0] = k * 1. / nelem;
+                x[1] = j * 1. / nelem;
+                x[2] = i * 1. / nelem;
+                gmesh->NodeVec()[i * (nelem + 1) * (nelem + 1) + j * (nelem + 1) + k].Initialize(x, *gmesh);
             }
         }
     }
 }
 
-
 static const int gfluxorder = 3;
 static TPZAutoPointer<TPZGeoMesh> GenerateMesh(MElementType type, int nelem = 3, int ndiv = 0);
-static TPZAutoPointer<TPZGeoMesh> TetrahedralMeshCubo(int64_t nelem,int MaterialId);
-
+static TPZAutoPointer<TPZGeoMesh> TetrahedralMeshCubo(int64_t nelem, int MaterialId);
 
 static void RotateGeomesh(TPZGeoMesh *gmesh, REAL CounterClockwiseAngle, int &Axis);
 
-template<class TSHAPE>
+TPZAutoPointer<TPZCompMesh> CreateCMesh(TPZAutoPointer<TPZGeoMesh> gmesh,
+                                        TPZMaterial *mat, const int matId,
+                                        const int k, ESpace space);
+
+int CalcRank(const TPZFMatrix<STATE> &S, const STATE tol);
+
+template <class TSHAPE>
 static void IntegralNormal();
 
+/** @brief Create three different shape data objects starting with the same connect orders.
+ * We decrease the facet connects order by one for the second shape and increase the volume connect order by two for the third shape.
+ * Then, we check if the number of facet functions for shapes 1 and 3 are equal and if the number of volume functions for shapes 1 and 3 are the same.
+    @param [in] kFacet polynomial order of the facet connects*/
+template <class TSHAPE>
+static void CheckConnectOrders(int kFacet);
+
+/** @brief Checks if the rank of the matrix composed by the L2 product of Hdiv shape functions is equal to the number of shape functions
+    Denoting by
+    - phi_i : basis functions of the refered space
+    This function creates the matrix
+    M = phi_i * phi_j
+
+    And then compare if rank(M) = length(phi).
+    @param [in] kFacet polynomial order of the facet connects*/
+template <ESpace Space, int dim>
+void CheckL2ProductRank(int kFacet);
+
 // Tests for the 'voidflux' class.
-TEST_CASE("integral_normal","[hdivconstant_tests]")
+TEST_CASE("integral_normal", "[hdivconstant_tests]")
 {
     std::cout << "Initializing vector_direction check\n";
-//    IntegralNormal<pzshape::TPZShapePrism>();
+    //    IntegralNormal<pzshape::TPZShapePrism>();
     IntegralNormal<pzshape::TPZShapeCube>();
     IntegralNormal<pzshape::TPZShapeTetra>();
     IntegralNormal<pzshape::TPZShapeTriang>();
     IntegralNormal<pzshape::TPZShapeQuad>();
-//    IntegralNormal<pzshape::TPZShapePrism>();
+    //    IntegralNormal<pzshape::TPZShapePrism>();
     std::cout << "Leaving integral_normal check\n";
 }
 
+TEMPLATE_TEST_CASE("Connect order compatibility", "[hdivconstant_tests]",
+                   (pzshape::TPZShapeTriang),
+                   (pzshape::TPZShapeQuad),
+                   (pzshape::TPZShapeCube),
+                   (pzshape::TPZShapeTetra))
+{
+    int kFacet = GENERATE(2, 3, 4);
+    SECTION("kFacet=" + std::to_string(kFacet))
+    {
+        CheckConnectOrders<TestType>(kFacet);
+    }
+}
+
+TEMPLATE_TEST_CASE("Linear Dependence", "[hdivconstant_tests]",
+                   (typename std::integral_constant<int, 2>),
+                   (typename std::integral_constant<int, 3>))
+{
+    // SVD requires LAPACK
+#ifndef PZ_USING_LAPACK
+    return;
+#endif
+    constexpr int dim = TestType::value;
+
+    ESpace space = GENERATE(ESpace::HDiv,
+                            ESpace::HDivConst);
+
+    SECTION(names.at(space))
+    {
+        int kFacet = GENERATE(1, 2, 3);
+        SECTION("kFacet=" + std::to_string(kFacet))
+        {
+            switch (space)
+            {
+            case ESpace::HDiv:
+            {
+                CheckL2ProductRank<ESpace::HDiv, dim>(kFacet);
+                break;
+            }
+            case ESpace::HDivConst:
+            {
+                CheckL2ProductRank<ESpace::HDivConst, dim>(kFacet);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+}
 
 static TPZAutoPointer<TPZGeoMesh> GenerateMesh(MElementType eltype, int nelem, int ndiv)
 {
     int dimmodel = 2;
-    TPZManVector<int,3> nx(2,nelem);
-    TPZManVector<REAL,3> x0(3,0.),x1(3,1.);
+    TPZManVector<int, 3> nx(2, nelem);
+    TPZManVector<REAL, 3> x0(3, 0.), x1(3, 1.);
     x1[2] = -1.;
-    TPZGenGrid2D grid(nx,x0,x1);
-    if (eltype == ETriangle|| eltype == EPrisma ) {
+    TPZGenGrid2D grid(nx, x0, x1);
+    if (eltype == ETriangle || eltype == EPrisma)
+    {
         grid.SetElementType(MMeshType::ETriangular);
     }
     TPZAutoPointer<TPZGeoMesh> gmesh = new TPZGeoMesh;
@@ -149,44 +235,42 @@ static TPZAutoPointer<TPZGeoMesh> GenerateMesh(MElementType eltype, int nelem, i
     grid.SetBC(gmesh, 5, -1);
     grid.SetBC(gmesh, 6, -1);
     grid.SetBC(gmesh, 7, -1);
-    
-    if(eltype==ETriangle||eltype==EPrisma||eltype==ECube||eltype==EQuadrilateral )
+
+    if (eltype == ETriangle || eltype == EPrisma || eltype == ECube || eltype == EQuadrilateral)
     {
-        for(int D = 0; D < ndiv; D++)
+        for (int D = 0; D < ndiv; D++)
         {
             int nels = gmesh->NElements();
-            for(int elem = 0; elem < nels; elem++)
+            for (int elem = 0; elem < nels; elem++)
             {
-                TPZVec< TPZGeoEl * > filhos;
-                TPZGeoEl * gel = gmesh->ElementVec()[elem];
+                TPZVec<TPZGeoEl *> filhos;
+                TPZGeoEl *gel = gmesh->ElementVec()[elem];
                 gel->Divide(filhos);
             }
         }
-        
-        
-        {   // queria tanto ver a malha 2d
+
+        { // queria tanto ver a malha 2d
             std::ofstream Dummyfile("GeometricMesh2d.vtk");
-            TPZVTKGeoMesh::PrintGMeshVTK(gmesh.operator->(),Dummyfile, true);
+            TPZVTKGeoMesh::PrintGMeshVTK(gmesh.operator->(), Dummyfile, true);
         }
-        
-        
-        
-        if (eltype == EPrisma || eltype == ECube) {
-            REAL thickness = 1.;//2.;
-            TPZExtendGridDimension extend(gmesh,thickness);
+
+        if (eltype == EPrisma || eltype == ECube)
+        {
+            REAL thickness = 1.; // 2.;
+            TPZExtendGridDimension extend(gmesh, thickness);
             int numlayers = nelem;
             int bctop = -2;
-            int bcbottom = -3 ;//normal negativa
-            gmesh = extend.ExtendedMesh(numlayers,bcbottom,bctop);
+            int bcbottom = -3; // normal negativa
+            gmesh = extend.ExtendedMesh(numlayers, bcbottom, bctop);
             gmesh->SetDimension(3);
             dimmodel = 3;
         }
     }
-    else if(eltype==ETetraedro)
+    else if (eltype == ETetraedro)
     {
         // aqui
         dimmodel = 3;
-        //gmesh = CreateOneCuboWithTetraedrons(ndiv); // AQUIDOUGLAS
+        // gmesh = CreateOneCuboWithTetraedrons(ndiv); // AQUIDOUGLAS
         ndiv = 1;
         const int64_t NumberOfEl = ndiv;
         const int matid = 1;
@@ -194,125 +278,123 @@ static TPZAutoPointer<TPZGeoMesh> GenerateMesh(MElementType eltype, int nelem, i
         gmesh->SetDimension(3);
         std::ofstream arg("gmesh.txt");
         gmesh->Print(arg);
-        
     }
     else
     {
         // Elemento nao contemplado
         DebugStop();
     }
-    
-    
+
     int Axis;
     REAL theta, dump = 0.0;
 
     theta = 48.0;
     Axis = 1;
-    RotateGeomesh(gmesh.operator->(), theta*dump, Axis);
+    RotateGeomesh(gmesh.operator->(), theta * dump, Axis);
 
     theta = -45.0;
     Axis = 2;
-    RotateGeomesh(gmesh.operator->(), theta*dump, Axis);
-    
+    RotateGeomesh(gmesh.operator->(), theta * dump, Axis);
+
     theta = 120.0;
     Axis = 3;
-    RotateGeomesh(gmesh.operator->(), theta*dump, Axis);
-    
+    RotateGeomesh(gmesh.operator->(), theta * dump, Axis);
+
     {
         //  Print Geometrical Base Mesh
         std::ofstream Dummyfile2("GeometricMesh3d.vtk");
-        TPZVTKGeoMesh::PrintGMeshVTK(gmesh,Dummyfile2, true);
+        TPZVTKGeoMesh::PrintGMeshVTK(gmesh, Dummyfile2, true);
     }
-    
+
 #ifdef PZ_LOG
     if (logger.isDebugEnabled())
     {
         std::stringstream sout;
-        sout<<"Malha Geo FINAl \n\n";
+        sout << "Malha Geo FINAl \n\n";
         gmesh->Print(sout);
-        //mphysics->Print(sout);
+        // mphysics->Print(sout);
         LOGPZ_DEBUG(logger, sout.str())
     }
 #endif
-    
 
-    
     return gmesh;
-
-
 }
 
-
-TPZAutoPointer<TPZGeoMesh> TetrahedralMeshCubo(int64_t nelem,int MaterialId)
+TPZAutoPointer<TPZGeoMesh> TetrahedralMeshCubo(int64_t nelem, int MaterialId)
 {
     TPZGeoMesh *gmesh = new TPZGeoMesh;
-    GenerateNodes(gmesh,nelem);
-    
-    for (int64_t i=0; i<nelem; i++) {
-        for (int64_t j=0; j<nelem; j++) {
-            for (int64_t k=0; k<nelem; k++) {
-                TPZManVector<int64_t,8> nodes(8,0);
-                nodes[0] = k*(nelem+1)*(nelem+1)+j*(nelem+1)+i;
-                nodes[1] = k*(nelem+1)*(nelem+1)+j*(nelem+1)+i+1;
-                nodes[2] = k*(nelem+1)*(nelem+1)+(j+1)*(nelem+1)+i+1;
-                nodes[3] = k*(nelem+1)*(nelem+1)+(j+1)*(nelem+1)+i;
-                nodes[4] = (k+1)*(nelem+1)*(nelem+1)+j*(nelem+1)+i;
-                nodes[5] = (k+1)*(nelem+1)*(nelem+1)+j*(nelem+1)+i+1;
-                nodes[6] = (k+1)*(nelem+1)*(nelem+1)+(j+1)*(nelem+1)+i+1;
-                nodes[7] = (k+1)*(nelem+1)*(nelem+1)+(j+1)*(nelem+1)+i;
+    GenerateNodes(gmesh, nelem);
+
+    for (int64_t i = 0; i < nelem; i++)
+    {
+        for (int64_t j = 0; j < nelem; j++)
+        {
+            for (int64_t k = 0; k < nelem; k++)
+            {
+                TPZManVector<int64_t, 8> nodes(8, 0);
+                nodes[0] = k * (nelem + 1) * (nelem + 1) + j * (nelem + 1) + i;
+                nodes[1] = k * (nelem + 1) * (nelem + 1) + j * (nelem + 1) + i + 1;
+                nodes[2] = k * (nelem + 1) * (nelem + 1) + (j + 1) * (nelem + 1) + i + 1;
+                nodes[3] = k * (nelem + 1) * (nelem + 1) + (j + 1) * (nelem + 1) + i;
+                nodes[4] = (k + 1) * (nelem + 1) * (nelem + 1) + j * (nelem + 1) + i;
+                nodes[5] = (k + 1) * (nelem + 1) * (nelem + 1) + j * (nelem + 1) + i + 1;
+                nodes[6] = (k + 1) * (nelem + 1) * (nelem + 1) + (j + 1) * (nelem + 1) + i + 1;
+                nodes[7] = (k + 1) * (nelem + 1) * (nelem + 1) + (j + 1) * (nelem + 1) + i;
 #ifdef PZ_LOG
-                if(logger.isDebugEnabled())
+                if (logger.isDebugEnabled())
                 {
                     std::stringstream sout;
                     sout << "Tetrahedral nodes " << nodes;
                     LOGPZ_DEBUG(logger, sout.str())
                 }
 #endif
-                for (int el=0; el<6; el++)
+                for (int el = 0; el < 6; el++)
                 {
-                    TPZManVector<int64_t,4> elnodes(4);
+                    TPZManVector<int64_t, 4> elnodes(4);
                     int64_t index;
-                    for (int il=0; il<4; il++) {
+                    for (int il = 0; il < 4; il++)
+                    {
                         elnodes[il] = nodes[tetraedra_2[el][il]];
                     }
-                    gmesh->CreateGeoElement(ETetraedro, elnodes, MaterialId, index,0);
+                    gmesh->CreateGeoElement(ETetraedro, elnodes, MaterialId, index, 0);
                 }
             }
         }
     }
     gmesh->BuildConnectivity();
-    
+
     // Boundary Conditions
     const int numelements = gmesh->NElements();
     const int bczMinus = -3, bczplus = -2, bcids = -1;
-//    const int bczMinus = -1, bczplus = -1, bcids = -1;
-    
-    for(int el=0; el<numelements; el++)
+    //    const int bczMinus = -1, bczplus = -1, bcids = -1;
+
+    for (int el = 0; el < numelements; el++)
     {
-        TPZManVector <TPZGeoNode,4> Nodefinder(4);
-        TPZManVector <REAL,3> nodecoord(3);
+        TPZManVector<TPZGeoNode, 4> Nodefinder(4);
+        TPZManVector<REAL, 3> nodecoord(3);
         TPZGeoEl *tetra = gmesh->ElementVec()[el];
         // na face x = 0
-        TPZVec<int64_t> ncoordVec(0); int64_t sizeOfVec = 0;
+        TPZVec<int64_t> ncoordVec(0);
+        int64_t sizeOfVec = 0;
         for (int i = 0; i < 4; i++)
         {
             int64_t pos = tetra->NodeIndex(i);
             Nodefinder[i] = gmesh->NodeVec()[pos];
             Nodefinder[i].GetCoordinates(nodecoord);
-            if (MyDoubleComparer(nodecoord[0],0.))
+            if (MyDoubleComparer(nodecoord[0], 0.))
             {
                 sizeOfVec++;
                 ncoordVec.Resize(sizeOfVec);
-                ncoordVec[sizeOfVec-1] = pos;
+                ncoordVec[sizeOfVec - 1] = pos;
             }
         }
-        if(ncoordVec.NElements() == 3)
+        if (ncoordVec.NElements() == 3)
         {
             int lado = tetra->WhichSide(ncoordVec);
             TPZGeoElSide tetraSide(tetra, lado);
-            TPZGeoElBC(tetraSide,bcids);	
+            TPZGeoElBC(tetraSide, bcids);
         }
-        
+
         ncoordVec.clear();
         sizeOfVec = 0;
         // na face x = 1
@@ -321,20 +403,20 @@ TPZAutoPointer<TPZGeoMesh> TetrahedralMeshCubo(int64_t nelem,int MaterialId)
             int64_t pos = tetra->NodeIndex(i);
             Nodefinder[i] = gmesh->NodeVec()[pos];
             Nodefinder[i].GetCoordinates(nodecoord);
-            if (MyDoubleComparer(nodecoord[0],1.))
+            if (MyDoubleComparer(nodecoord[0], 1.))
             {
                 sizeOfVec++;
                 ncoordVec.Resize(sizeOfVec);
-                ncoordVec[sizeOfVec-1] = pos;
+                ncoordVec[sizeOfVec - 1] = pos;
             }
         }
-        if(ncoordVec.NElements() == 3)
+        if (ncoordVec.NElements() == 3)
         {
             int lado = tetra->WhichSide(ncoordVec);
             TPZGeoElSide tetraSide(tetra, lado);
-            TPZGeoElBC(tetraSide,bcids);
+            TPZGeoElBC(tetraSide, bcids);
         }
-        
+
         ncoordVec.clear();
         sizeOfVec = 0;
         // na face y = 0
@@ -343,20 +425,20 @@ TPZAutoPointer<TPZGeoMesh> TetrahedralMeshCubo(int64_t nelem,int MaterialId)
             int64_t pos = tetra->NodeIndex(i);
             Nodefinder[i] = gmesh->NodeVec()[pos];
             Nodefinder[i].GetCoordinates(nodecoord);
-            if (MyDoubleComparer(nodecoord[1],0.))
+            if (MyDoubleComparer(nodecoord[1], 0.))
             {
                 sizeOfVec++;
                 ncoordVec.Resize(sizeOfVec);
-                ncoordVec[sizeOfVec-1] = pos;
+                ncoordVec[sizeOfVec - 1] = pos;
             }
         }
-        if(ncoordVec.NElements() == 3)
+        if (ncoordVec.NElements() == 3)
         {
             int lado = tetra->WhichSide(ncoordVec);
             TPZGeoElSide tetraSide(tetra, lado);
-            TPZGeoElBC(tetraSide,bcids);
+            TPZGeoElBC(tetraSide, bcids);
         }
-        
+
         ncoordVec.clear();
         sizeOfVec = 0;
         // na face y = 1
@@ -365,20 +447,20 @@ TPZAutoPointer<TPZGeoMesh> TetrahedralMeshCubo(int64_t nelem,int MaterialId)
             int64_t pos = tetra->NodeIndex(i);
             Nodefinder[i] = gmesh->NodeVec()[pos];
             Nodefinder[i].GetCoordinates(nodecoord);
-            if (MyDoubleComparer(nodecoord[1],1.))
+            if (MyDoubleComparer(nodecoord[1], 1.))
             {
                 sizeOfVec++;
                 ncoordVec.Resize(sizeOfVec);
-                ncoordVec[sizeOfVec-1] = pos;
+                ncoordVec[sizeOfVec - 1] = pos;
             }
         }
-        if(ncoordVec.NElements() == 3)
+        if (ncoordVec.NElements() == 3)
         {
             int lado = tetra->WhichSide(ncoordVec);
             TPZGeoElSide tetraSide(tetra, lado);
-            TPZGeoElBC(tetraSide,bcids);
+            TPZGeoElBC(tetraSide, bcids);
         }
-        
+
         ncoordVec.clear();
         sizeOfVec = 0;
         // na face z = 0
@@ -387,20 +469,20 @@ TPZAutoPointer<TPZGeoMesh> TetrahedralMeshCubo(int64_t nelem,int MaterialId)
             int64_t pos = tetra->NodeIndex(i);
             Nodefinder[i] = gmesh->NodeVec()[pos];
             Nodefinder[i].GetCoordinates(nodecoord);
-            if (MyDoubleComparer(nodecoord[2],0.))
+            if (MyDoubleComparer(nodecoord[2], 0.))
             {
                 sizeOfVec++;
                 ncoordVec.Resize(sizeOfVec);
-                ncoordVec[sizeOfVec-1] = pos;
+                ncoordVec[sizeOfVec - 1] = pos;
             }
         }
-        if(ncoordVec.NElements() == 3)
+        if (ncoordVec.NElements() == 3)
         {
             int lado = tetra->WhichSide(ncoordVec);
             TPZGeoElSide tetraSide(tetra, lado);
-            TPZGeoElBC(tetraSide,bczMinus);
+            TPZGeoElBC(tetraSide, bczMinus);
         }
-        
+
         ncoordVec.clear();
         sizeOfVec = 0;
         // na face z = 1
@@ -409,127 +491,409 @@ TPZAutoPointer<TPZGeoMesh> TetrahedralMeshCubo(int64_t nelem,int MaterialId)
             int64_t pos = tetra->NodeIndex(i);
             Nodefinder[i] = gmesh->NodeVec()[pos];
             Nodefinder[i].GetCoordinates(nodecoord);
-            if (MyDoubleComparer(nodecoord[2],1.))
+            if (MyDoubleComparer(nodecoord[2], 1.))
             {
                 sizeOfVec++;
                 ncoordVec.Resize(sizeOfVec);
-                ncoordVec[sizeOfVec-1] = pos;
+                ncoordVec[sizeOfVec - 1] = pos;
             }
         }
-        if(ncoordVec.NElements() == 3)
+        if (ncoordVec.NElements() == 3)
         {
             int lado = tetra->WhichSide(ncoordVec);
             TPZGeoElSide tetraSide(tetra, lado);
-            TPZGeoElBC(tetraSide,bczplus);
+            TPZGeoElBC(tetraSide, bczplus);
         }
-        
-        
-        
     }
-    
+
     return gmesh;
 }
 
-
-
-
 void RotateGeomesh(TPZGeoMesh *gmesh, REAL CounterClockwiseAngle, int &Axis)
 {
-    REAL theta =  (M_PI/180.0)*CounterClockwiseAngle;
+    REAL theta = (M_PI / 180.0) * CounterClockwiseAngle;
     // It represents a 3D rotation around the z axis.
-    TPZFMatrix<REAL> RotationMatrix(3,3,0.0);
+    TPZFMatrix<REAL> RotationMatrix(3, 3, 0.0);
 
-    switch (Axis) {
-        case 1:
-        {
-            RotationMatrix(0,0) = 1.0;
-            RotationMatrix(1,1) =   +cos(theta);
-            RotationMatrix(1,2) =   -sin(theta);
-            RotationMatrix(2,1) =   +sin(theta);
-            RotationMatrix(2,2) =   +cos(theta);
-        }
-            break;
-        case 2:
-        {
-            RotationMatrix(0,0) =   +cos(theta);
-            RotationMatrix(0,2) =   +sin(theta);
-            RotationMatrix(1,1) = 1.0;
-            RotationMatrix(2,0) =   -sin(theta);
-            RotationMatrix(2,2) =   +cos(theta);
-        }
-            break;
-        case 3:
-        {
-            RotationMatrix(0,0) =   +cos(theta);
-            RotationMatrix(0,1) =   -sin(theta);
-            RotationMatrix(1,0) =   +sin(theta);
-            RotationMatrix(1,1) =   +cos(theta);
-            RotationMatrix(2,2) = 1.0;
-        }
-            break;
-        default:
-        {
-            RotationMatrix(0,0) =   +cos(theta);
-            RotationMatrix(0,1) =   -sin(theta);
-            RotationMatrix(1,0) =   +sin(theta);
-            RotationMatrix(1,1) =   +cos(theta);
-            RotationMatrix(2,2) = 1.0;
-        }
-            break;
+    switch (Axis)
+    {
+    case 1:
+    {
+        RotationMatrix(0, 0) = 1.0;
+        RotationMatrix(1, 1) = +cos(theta);
+        RotationMatrix(1, 2) = -sin(theta);
+        RotationMatrix(2, 1) = +sin(theta);
+        RotationMatrix(2, 2) = +cos(theta);
     }
-    
-    TPZVec<REAL> iCoords(3,0.0);
-    TPZVec<REAL> iCoordsRotated(3,0.0);
-    
-    //RotationMatrix.Print("Rotation = ");
-    
+    break;
+    case 2:
+    {
+        RotationMatrix(0, 0) = +cos(theta);
+        RotationMatrix(0, 2) = +sin(theta);
+        RotationMatrix(1, 1) = 1.0;
+        RotationMatrix(2, 0) = -sin(theta);
+        RotationMatrix(2, 2) = +cos(theta);
+    }
+    break;
+    case 3:
+    {
+        RotationMatrix(0, 0) = +cos(theta);
+        RotationMatrix(0, 1) = -sin(theta);
+        RotationMatrix(1, 0) = +sin(theta);
+        RotationMatrix(1, 1) = +cos(theta);
+        RotationMatrix(2, 2) = 1.0;
+    }
+    break;
+    default:
+    {
+        RotationMatrix(0, 0) = +cos(theta);
+        RotationMatrix(0, 1) = -sin(theta);
+        RotationMatrix(1, 0) = +sin(theta);
+        RotationMatrix(1, 1) = +cos(theta);
+        RotationMatrix(2, 2) = 1.0;
+    }
+    break;
+    }
+
+    TPZVec<REAL> iCoords(3, 0.0);
+    TPZVec<REAL> iCoordsRotated(3, 0.0);
+
+    // RotationMatrix.Print("Rotation = ");
+
     int NumberofGeoNodes = gmesh->NNodes();
     for (int inode = 0; inode < NumberofGeoNodes; inode++)
     {
         TPZGeoNode GeoNode = gmesh->NodeVec()[inode];
         GeoNode.GetCoordinates(iCoords);
         // Apply rotation
-        iCoordsRotated[0] = RotationMatrix(0,0)*iCoords[0]+RotationMatrix(0,1)*iCoords[1]+RotationMatrix(0,2)*iCoords[2];
-        iCoordsRotated[1] = RotationMatrix(1,0)*iCoords[0]+RotationMatrix(1,1)*iCoords[1]+RotationMatrix(1,2)*iCoords[2];
-        iCoordsRotated[2] = RotationMatrix(2,0)*iCoords[0]+RotationMatrix(2,1)*iCoords[1]+RotationMatrix(2,2)*iCoords[2];
+        iCoordsRotated[0] = RotationMatrix(0, 0) * iCoords[0] + RotationMatrix(0, 1) * iCoords[1] + RotationMatrix(0, 2) * iCoords[2];
+        iCoordsRotated[1] = RotationMatrix(1, 0) * iCoords[0] + RotationMatrix(1, 1) * iCoords[1] + RotationMatrix(1, 2) * iCoords[2];
+        iCoordsRotated[2] = RotationMatrix(2, 0) * iCoords[0] + RotationMatrix(2, 1) * iCoords[1] + RotationMatrix(2, 2) * iCoords[2];
         GeoNode.SetCoord(iCoordsRotated);
         gmesh->NodeVec()[inode] = GeoNode;
     }
-    
 }
 
 #include "TPZShapeHDivConstant.h"
 
-template<class TSHAPE>
+template <class TSHAPE>
 void IntegralNormal()
 {
-    auto gmesh = GenerateMesh(TSHAPE::Type(),1,0);
+    auto gmesh = GenerateMesh(TSHAPE::Type(), 1, 0);
     int64_t nel = gmesh->NElements();
-    for(int64_t el = 0; el<nel; el++)
+    for (int64_t el = 0; el < nel; el++)
     {
         TPZGeoEl *gel = gmesh->Element(el);
-        if(gel->Type() != TSHAPE::Type()) continue;
+        if (gel->Type() != TSHAPE::Type())
+            continue;
         TPZManVector<int64_t> ids(gel->NCornerNodes());
         int nnodes = gel->NCornerNodes();
-        for(int no=0; no<nnodes; no++) ids[no] = gel->Node(no).Id();
+        for (int no = 0; no < nnodes; no++)
+            ids[no] = gel->Node(no).Id();
         TPZShapeHDivConstant<TSHAPE> shape;
         TPZShapeData data;
-        TPZManVector<int> orders(TSHAPE::NFacets+1,1);
-        TPZManVector<int> sideorient(TSHAPE::NFacets,1);
+        TPZManVector<int> orders(TSHAPE::NFacets + 1, 1);
+        TPZManVector<int> sideorient(TSHAPE::NFacets, 1);
         shape.Initialize(ids, orders, sideorient, data);
         // comment this out because it will break hcurl shape funcs
         // why was it here?
         // data.fSideTransformationId.Resize(TSHAPE::NFacets, 0);
         data.fSideOrient.Resize(TSHAPE::NFacets, 1);
         int nshape = shape.NHDivShapeF(data);
-        TPZManVector<REAL> pt(TSHAPE::Dimension,0.);
-        TPZFNMatrix<8,REAL> phi(TSHAPE::Dimension,nshape),divphi(nshape,1);
-        shape.Shape(pt,data,phi,divphi);
+        TPZManVector<REAL> pt(TSHAPE::Dimension, 0.);
+        TPZFNMatrix<8, REAL> phi(TSHAPE::Dimension, nshape), divphi(nshape, 1);
+        shape.Shape(pt, data, phi, divphi);
         // integrate the divergence. It should be one
         divphi *= TSHAPE::RefElVolume();
-        phi.Print("phi  = ",std::cout);
-        divphi.Print("divphi  = ",std::cout);
+        phi.Print("phi  = ", std::cout);
+        divphi.Print("divphi  = ", std::cout);
     }
 }
+
+template <class TSHAPE>
+void CheckConnectOrders(int kFacet)
+{
+    TPZMaterialDataT<REAL> data1, data2, data3;
+    TPZManVector<int64_t, 27> ids(TSHAPE::NCornerNodes, 0);
+    for (int i = 0; i < TSHAPE::NCornerNodes; i++)
+    {
+        ids[i] = i;
+    }
+    TPZManVector<int, 27> sideorient(TSHAPE::NFacets, 1);
+    TPZManVector<int, 27> orders1(TSHAPE::NFacets + 1, kFacet);
+    TPZManVector<int, 27> orders2(orders1);
+    for (int i = 0; i < TSHAPE::NFacets; i++)
+    {
+        orders2[i] -= 1;
+    }
+    TPZManVector<int, 27> orders3(orders1);
+    orders3[TSHAPE::NFacets] += 2;
+    TPZShapeHDivConstant<TSHAPE> hdivorig;
+    hdivorig.Initialize(ids, orders1, sideorient, data1);
+    hdivorig.Initialize(ids, orders2, sideorient, data2);
+    hdivorig.Initialize(ids, orders3, sideorient, data3);
+    int nshape1 = hdivorig.NHDivShapeF(data1);
+    int nshape2 = hdivorig.NHDivShapeF(data2);
+    int nshape3 = hdivorig.NHDivShapeF(data3);
+    int firstshape1 = 0, firstshape2 = 0, firstshape3 = 0;
+    for (int i = 0; i < TSHAPE::NFacets; i++)
+    {
+        firstshape1 += hdivorig.NConnectShapeF(i, data1);
+        firstshape2 += hdivorig.NConnectShapeF(i, data2);
+        firstshape3 += hdivorig.NConnectShapeF(i, data3);
+    }
+    int nvolshape1 = hdivorig.NConnectShapeF(TSHAPE::NFacets, data1);
+    int nvolshape2 = hdivorig.NConnectShapeF(TSHAPE::NFacets, data2);
+    int nvolshape3 = hdivorig.NConnectShapeF(TSHAPE::NFacets, data3);
+
+    auto hdivOrder1 = data1.fHDivConnectOrders;
+    auto hdivOrder2 = data2.fHDivConnectOrders;
+    auto hdivOrder3 = data3.fHDivConnectOrders;
+
+    auto hdivNshape1 = data1.fHDivNumConnectShape;
+    auto hdivNshape2 = data2.fHDivNumConnectShape;
+    auto hdivNshape3 = data3.fHDivNumConnectShape;
+
+    CAPTURE(orders1,orders2,orders3,hdivOrder1,hdivOrder2,hdivOrder3,hdivNshape1,hdivNshape2,hdivNshape3);
+    
+    REQUIRE(nvolshape1 == nvolshape2);
+    REQUIRE(firstshape1 + nvolshape1 == nshape1);
+    REQUIRE(firstshape2 + nvolshape2 == nshape2);
+    REQUIRE(firstshape3 + nvolshape3 == nshape3);
+    REQUIRE(firstshape1 == firstshape3);
+    
+    for (int i = 0; i < TSHAPE::NFacets+1; i++)
+    {
+        REQUIRE(hdivOrder1[i] == orders1[i]);
+        REQUIRE(hdivOrder2[i] == orders2[i]);
+        REQUIRE(hdivOrder3[i] == orders3[i]);
+        REQUIRE(hdivNshape1[i] == hdivorig.NConnectShapeF(i, data1));
+        REQUIRE(hdivNshape2[i] == hdivorig.NConnectShapeF(i, data2));
+        REQUIRE(hdivNshape3[i] == hdivorig.NConnectShapeF(i, data3));
+    }
+
+    // Evaluate the shape functions at the integration point.
+    // The volume shape functions must be equal for approximation spaces 1 and 2 at every integration point.
+    // The facet shape functions must be equal for approximation spaces 1 and 3 at every integration point.
+    int dim = TSHAPE::Dimension;
+    TPZFMatrix<REAL> phi1(dim, nshape1, 0.), phi2(dim, nshape2, 0.), phi3(dim, nshape3, 0.);
+    TPZFNMatrix<60, REAL> divphi1(nshape1, 1), divphi2(nshape2, 1), divphi3(nshape3, 1);
+    typename TSHAPE::IntruleType intrule(3);
+    int nintpoints = intrule.NPoints();
+    TPZManVector<REAL, 3> point(dim, 0.);
+    for (int ip = 0; ip < nintpoints; ip++)
+    {
+        REAL weight;
+        intrule.Point(ip, point, weight);
+        hdivorig.Shape(point, data1, phi1, divphi1);
+        hdivorig.Shape(point, data2, phi2, divphi2);
+        hdivorig.Shape(point, data3, phi3, divphi3);
+
+        for (int i = 0; i < nvolshape1; i++)
+        {
+            for (int j = 0; j < dim; j++)
+            {
+                REAL val1 = phi1(j, i + firstshape1);
+                REAL val2 = phi2(j, i + firstshape2);
+                if (abs(val1-val2) > 1.e-10)
+                {
+                    std::cout << "val1 " << val1 << " val2 " << val2 << std::endl;
+                }
+                REQUIRE((val1 - val2) == Catch::Approx(0.));
+            }
+        }
+
+        for (int i = 0; i < firstshape1; i++)
+        {
+            for (int j = 0; j < dim; j++)
+            {
+                REAL val1 = phi1(j, i);
+                REAL val3 = phi3(j, i);
+                if (abs(val1-val3) > 1.e-10)
+                {
+                    std::cout << "val1 " << val1 << " val3 " << val3 << std::endl;
+                }
+                REQUIRE((val1 - val3) == Catch::Approx(0.));
+            }
+        }
+    }
+}
+
+template <ESpace space, int dim>
+void CheckL2ProductRank(int kFacet)
+{
+
+    /******************************************
+    CHECK FUNCTION DECLARATION FOR MORE DETAILS
+    *******************************************/
+    // select element type
+    auto elType = GENERATE(MMeshType::ETriangular,
+                           MMeshType::EQuadrilateral,
+                           MMeshType::ETetrahedral,
+                           MMeshType::EHexahedral,
+                           MMeshType::EPrismatic);
+
+    SECTION(MMeshType_Name(elType))
+    {
+        if (elType == MMeshType::EPrismatic && space == ESpace::HDivConst)
+        {
+            return; // TODOFIX
+        }
+        const auto elDim = MMeshType_Dimension(elType);
+        if (elType == MMeshType::EPrismatic && space == ESpace::HCurl)
+        {
+            return; // TODOFIX
+        }
+
+        // if dimension does not correspond, skip
+        if (elDim != dim)
+            return;
+
+        // creating mesh
+        TPZAutoPointer<TPZGeoMesh> gmesh{nullptr};
+        TPZAutoPointer<TPZCompMesh> cmesh{nullptr};
+
+        constexpr int matId = 1;
+
+        auto *material = new TPZMatL2Product(matId, dim);
+
+        constexpr bool singleElement{true};
+
+        if constexpr (singleElement)
+        {
+            constexpr bool createBoundEls{false};
+            gmesh = TPZGeoMeshTools::CreateGeoMeshSingleEl(elType, matId, createBoundEls);
+        }
+        else
+        {
+            gmesh = CreateGMesh(dim, elType, matId);
+        }
+
+        auto EnrichMesh = [](TPZAutoPointer<TPZCompMesh> cmesh, const int k)
+        {
+            for (auto cel : cmesh->ElementVec())
+            {
+                if (cel->Dimension() != dim)
+                    continue;
+                auto intel =
+                    dynamic_cast<TPZInterpolatedElement *>(cel);
+                const auto nsides = intel->Reference()->NSides();
+                intel->SetSideOrder(nsides - 1, k + 1);
+                intel->AdjustIntegrationRule();
+            }
+            cmesh->ExpandSolution();
+        };
+
+        cmesh = CreateCMesh(gmesh, material, matId, kFacet, space);
+
+        int enrichLvl = GENERATE(-1, 0, 1);
+        // SECTION("Enrichment Level: " + std::to_string(enrichLvl+1));
+        EnrichMesh(cmesh, kFacet + enrichLvl);
+
+        // for debuggin
+        const auto spaceName = names.at(space);
+        const auto elName = MMeshType_Name(elType);
+        CAPTURE(spaceName, elName);
+
+        // stores the matrices
+        TPZAutoPointer<TPZMatrix<STATE>> matPtr = nullptr;
+        {
+            constexpr int nThreads{0};
+            TPZLinearAnalysis an(cmesh, RenumType::ENone);
+
+            TPZFStructMatrix<STATE> strmtrx(cmesh);
+            strmtrx.SetNumThreads(nThreads);
+            an.SetStructuralMatrix(strmtrx);
+
+            TPZStepSolver<STATE> step;
+            step.SetDirect(ELU);
+
+            an.SetSolver(step);
+
+            an.Assemble();
+
+            matPtr = an.MatrixSolver<STATE>().Matrix();
+        }
+
+        TPZFMatrix<STATE> mat(*matPtr);
+
+        const int nShapeHDiv = mat.Rows();
+
+        TPZFMatrix<STATE> S;
+        {
+            TPZFMatrix<STATE> Udummy, VTdummy;
+            mat.SVD(Udummy, S, VTdummy, 'N', 'N');
+        }
+        static constexpr auto tol = std::numeric_limits<STATE>::epsilon() * 10000;
+
+        TPZManVector<int, 27> connectorder(cmesh->NConnects(), 0);
+        for (int i = 0; i < cmesh->NConnects(); i++)
+        {
+            connectorder[i] = cmesh->ConnectVec()[i].Order();
+        }
+
+        TPZManVector<int, 27> nshape(cmesh->NConnects(), 0);
+        for (int i = 0; i < cmesh->NConnects(); i++)
+        {
+            nshape[i] = cmesh->ConnectVec()[i].NShape();
+        }
+
+        // rank of matrix (phi_i * phi_j)
+        const int rank = CalcRank(S, tol);
+
+        CAPTURE(kFacet, nShapeHDiv, rank);
+        CAPTURE(connectorder, nshape);
+        REQUIRE(rank == nShapeHDiv);
+    }
+}
+
+TPZAutoPointer<TPZCompMesh> CreateCMesh(TPZAutoPointer<TPZGeoMesh> gmesh,
+                                        TPZMaterial *mat, const int matId,
+                                        const int k, ESpace space)
+{
+
+    TPZAutoPointer<TPZCompMesh> cmesh = new TPZCompMesh(gmesh);
+    const int nel = cmesh->NElements();
+    cmesh->SetDefaultOrder(k);
+    cmesh->SetDimModel(gmesh->Dimension());
+    cmesh->InsertMaterialObject(mat);
+    switch (space)
+    {
+    case ESpace::H1:
+        cmesh->SetAllCreateFunctionsContinuous();
+        break;
+    case ESpace::HCurl:
+        cmesh->SetAllCreateFunctionsHCurl();
+        break;
+    case ESpace::HDiv:
+        cmesh->SetAllCreateFunctionsHDiv();
+        break;
+    case ESpace::HDivConst:
+        cmesh->ApproxSpace().SetHDivFamily(HDivFamily::EHDivConstant);
+        cmesh->SetAllCreateFunctionsHDiv();
+        break;
+    case ESpace::L2:
+        if (k == 0)
+            cmesh->SetAllCreateFunctionsDiscontinuous();
+        else
+            cmesh->SetAllCreateFunctionsContinuous();
+        cmesh->ApproxSpace().CreateDisconnectedElements(true);
+        break;
+    }   
+    cmesh->AutoBuild();
+    cmesh->CleanUpUnconnectedNodes();
+    return cmesh;
+}
+
+int CalcRank(const TPZFMatrix<STATE> &S, const STATE tol)
+{
+    int rank = 0;
+    const int dimMat = S.Rows();
+    for (int i = 0; i < dimMat; i++)
+    {
+        rank += S.GetVal(i, 0) > tol ? 1 : 0;
+    }
+    return rank;
+};
 
 template void IntegralNormal<pzshape::TPZShapeQuad>();


### PR DESCRIPTION
This PR aims to fix a bug in the construction of HDiv Constant spaces with enriched internal functions when using hexahedra elements.

Also, two new tests were included in `TestHDivConstant`, named: _Connect Order Compatibility_ and _Linear Dependence_.