### PR TITLE
Shape data refactor

### DIFF
--- a/Material/DarcyFlow/TPZDarcyFlow.cpp
+++ b/Material/DarcyFlow/TPZDarcyFlow.cpp
@@ -30,7 +30,7 @@ void TPZDarcyFlow::SetDimension(int dim) {
 void TPZDarcyFlow::Contribute(const TPZMaterialDataT<STATE> &data, STATE weight, TPZFMatrix<STATE> &ek,
                               TPZFMatrix<STATE> &ef) {
 
-    const TPZFMatrix<REAL> &phi = data.fPhi;
+    const TPZFMatrix<REAL> &phi = data.fH1.fPhi;
     const TPZFMatrix<REAL> &dphi = data.dphix;
     const TPZVec<REAL> &x = data.x;
     const TPZFMatrix<REAL> &axes = data.axes;

--- a/Material/DarcyFlow/TPZMixedDarcyFractureFlow.cpp
+++ b/Material/DarcyFlow/TPZMixedDarcyFractureFlow.cpp
@@ -123,9 +123,9 @@ void TPZMixedDarcyFractureFlow::Contribute(const TPZVec<TPZMaterialDataT<STATE>>
     int first_transverse_q = 0;
     // first index in fVecShapeIndex corresponding to the second transverse flux
     int second_transverse_q = 0;
-    int nconnects = datavec[qb].fHDivNumConnectShape.size();
-    second_transverse_q = nvecs-datavec[qb].fHDivNumConnectShape[nconnects-1];
-    first_transverse_q = second_transverse_q-datavec[qb].fHDivNumConnectShape[nconnects-2];
+    int nconnects = datavec[qb].fHDiv.fNumConnectShape.size();
+    second_transverse_q = nvecs-datavec[qb].fHDiv.fNumConnectShape[nconnects-1];
+    first_transverse_q = second_transverse_q-datavec[qb].fHDiv.fNumConnectShape[nconnects-2];
     /*
     for(int i=0; i< nphi_q; i++)
     {

--- a/Material/Elasticity/TPZElasticity2D.cpp
+++ b/Material/Elasticity/TPZElasticity2D.cpp
@@ -108,7 +108,7 @@ void TPZElasticity2D::Contribute(const TPZMaterialDataT<STATE> &data,
     }
     
 	const TPZFMatrix<REAL> &dphi = data.dphix;
-	const TPZFMatrix<REAL> &phi = data.fPhi;
+	const TPZFMatrix<REAL> &phi = data.fH1.fPhi;
 	const TPZFMatrix<REAL> &axes=data.axes;
 	
 	int phc,phr,dphc,dphr,efr,efc,ekr,ekc;
@@ -228,7 +228,7 @@ void TPZElasticity2D::ContributeBC(const TPZMaterialDataT<STATE> &data,
         return;
     }
     
-	const TPZFMatrix<REAL> &phi = data.fPhi;
+	const TPZFMatrix<REAL> &phi = data.fH1.fPhi;
      int dim = Dimension();
 
 	const auto &BIGNUMBER  = TPZMaterial::fBigNumber;
@@ -807,7 +807,7 @@ void TPZElasticity2D::ContributeVecShape(const TPZMaterialDataT<STATE> &data,
                                          TPZFMatrix<STATE> &ek,TPZFMatrix<STATE> &ef)
 {
     const TPZFMatrix<REAL> &dphi = data.dphix;
-	const TPZFMatrix<REAL> &phi = data.fPhi;
+	const TPZFMatrix<REAL> &phi = data.fH1.fPhi;
 	const TPZFMatrix<REAL> &axes=data.axes;
 	
 	int phc,phr,dphc,dphr,efr,efc,ekr,ekc;
@@ -901,7 +901,7 @@ void TPZElasticity2D::ContributeVecShapeBC(const TPZMaterialDataT<STATE> &data,
                                            TPZFMatrix<STATE> &ef,
                                            TPZBndCondT<STATE> &bc) {
     
-    const TPZFMatrix<REAL> &phi = data.fPhi;
+    const TPZFMatrix<REAL> &phi = data.fH1.fPhi;
     
 	const REAL &BIGNUMBER  = TPZMaterial::fBigNumber;
     

--- a/Material/Elasticity/TPZElasticity3D.cpp
+++ b/Material/Elasticity/TPZElasticity3D.cpp
@@ -94,7 +94,7 @@ void TPZElasticity3D::Contribute(const TPZMaterialDataT<STATE> &data,
     }
     
 //    TPZFMatrix<REAL> &dphi = data.dphix;
-	const TPZFMatrix<REAL> &phi = data.fPhi;
+	const TPZFMatrix<REAL> &phi = data.fH1.fPhi;
 	const TPZManVector<REAL,3> &x = data.x;
     
     TPZFNMatrix<666,REAL> dphi(3,data.dphix.Cols());
@@ -416,7 +416,7 @@ void TPZElasticity3D::ContributeVecShape(const TPZMaterialDataT<STATE> &data,
                                          TPZFMatrix<STATE> &ek, TPZFMatrix<STATE> &ef)
 {
     const TPZFMatrix<REAL> & dphi = data.dphix;
-	const TPZFMatrix<REAL> & phi = data.fPhi;
+	const TPZFMatrix<REAL> & phi = data.fH1.fPhi;
 	
 	int phc = phi.Cols();
 	int efc = ef.Cols();
@@ -511,7 +511,7 @@ void TPZElasticity3D::ContributeVecShapeBC(const TPZMaterialDataT<STATE> & data,
                                            TPZFMatrix<STATE> & ef,
                                            TPZBndCondT<STATE> &bc)
 {
-    const TPZFMatrix<REAL> & phi = data.fPhi;
+    const TPZFMatrix<REAL> & phi = data.fH1.fPhi;
     
 	const REAL BIGNUMBER  = TPZMaterial::fBigNumber;
     
@@ -625,7 +625,7 @@ void TPZElasticity3D::ContributeBC(const TPZMaterialDataT<STATE> &data,
         return;
     }
     
-	const TPZFMatrix<REAL> &phi = data.fPhi;
+	const TPZFMatrix<REAL> &phi = data.fH1.fPhi;
 	
 	const STATE BIGNUMBER  = 1.e12;
 	

--- a/Material/TPZMaterialData.cpp
+++ b/Material/TPZMaterialData.cpp
@@ -41,7 +41,7 @@ void TPZMaterialData::Print(std::ostream &out) const
     out << "Shape function type " << ShapeFunctionType() << std::endl;
     out << "Active Approximation Space " << fActiveApproxSpace << std::endl;
     phi.Print("phi",out);
-    fDPhi.Print("fDPhi",out);
+    fH1.fDPhi.Print("H1 fDPhi",out);
     dphix.Print("dphix",out);
     out << "Number dual functions " << numberdualfunctions << std::endl;
     divphi.Print("div phi",out);
@@ -56,7 +56,8 @@ void TPZMaterialData::Print(std::ostream &out) const
     out << "HSize " << HSize << std::endl;
     out << "detjac " << detjac << std::endl;
     out << "XCenter " << XCenter << std::endl;
-    out << "fMasterDirections" << fMasterDirections << std::endl;
+    out << "HDiv fMasterDirections" << fHDiv.fMasterDirections << std::endl;
+    out << "HCurl fMasterDirections" << fHCurl.fMasterDirections << std::endl;
     out << "fDeformedDirections" << fDeformedDirections << std::endl;
     if(fNeedsDeformedDirectionsFad){
         fDeformedDirectionsFad.Print(out);
@@ -88,7 +89,7 @@ void TPZMaterialData::Print(std::ostream &out) const
 void TPZMaterialData::PrintMathematica(std::ostream &out) const
 {
     phi.Print("phi = ",out,EMathematicaInput);
-    fDPhi.Print("fDPhi = ",out,EMathematicaInput);
+    fH1.fDPhi.Print("H1 fDPhi = ",out,EMathematicaInput);
     dphix.Print("dphix = ",out,EMathematicaInput);
     axes.Print("axes = ",out,EMathematicaInput);
     jacobian.Print("jacobian = ",out,EMathematicaInput);
@@ -99,7 +100,8 @@ void TPZMaterialData::PrintMathematica(std::ostream &out) const
     out << "HSize = " << HSize << ";" << std::endl;
     out << "detjac = " << detjac << ";" << std::endl;
     out << "XCenter = {" << XCenter << "};" << std::endl;
-    out << "fMasterDirections" << fMasterDirections << std::endl;
+    out << "HDivfMasterDirections" << fHDiv.fMasterDirections << std::endl;
+    out << "HCurlfMasterDirections" << fHCurl.fMasterDirections << std::endl;
     out << "intLocPtIndex = " << intLocPtIndex << ";" <<std::endl;
     out << "intGlobPtIndex = " << intGlobPtIndex << ";" <<std::endl;
     out << "NintPts = " << NintPts << ";" <<std::endl;

--- a/Material/TPZMaterialDataT.cpp
+++ b/Material/TPZMaterialDataT.cpp
@@ -13,7 +13,7 @@ void TPZMaterialDataT<TVar>::ComputeFunctionDivergence()
     // Getting test and basis functions
     //TPZFMatrix<REAL> dphi_s       = dphi; // Derivative For H1  test functions
     TPZShapeData *shapedata = this;
-    int n_phi_v = shapedata->fSDVecShapeIndex.NElements();
+    int n_phi_v = shapedata->fHDiv.fSDVecShapeIndex.NElements();
 #ifdef PZDEBUG
     if(divphi.Rows() < n_phi_v) DebugStop();
 #endif
@@ -24,14 +24,14 @@ void TPZMaterialDataT<TVar>::ComputeFunctionDivergence()
     
     for (int iq = 0; iq < n_phi_v; iq++)
     {
-        i_vec = shapedata->fSDVecShapeIndex[iq].first;
-        i_phi_s = shapedata->fSDVecShapeIndex[iq].second;
+        i_vec = shapedata->fHDiv.fSDVecShapeIndex[iq].first;
+        i_phi_s = shapedata->fHDiv.fSDVecShapeIndex[iq].second;
         divphi(iq,0) = 0.;
 
-        int n_dir = shapedata->fDPhi.Rows();
+        int n_dir = shapedata->fH1.fDPhi.Rows();
         divphi(iq,0) = 0.;
         for (int k = 0; k < n_dir; k++) {
-            divphi(iq,0) +=  shapedata->fDPhi(k,i_phi_s)*shapedata->fMasterDirections(k,i_vec)/detjac;
+            divphi(iq,0) +=  shapedata->fH1.fDPhi(k,i_phi_s)*shapedata->fHDiv.fMasterDirections(k,i_vec)/detjac;
         }
     }
         

--- a/Mesh/TPZCompElDisc.cpp
+++ b/Mesh/TPZCompElDisc.cpp
@@ -247,7 +247,7 @@ void TPZCompElDisc::ComputeShape(TPZVec<REAL> &intpoint, TPZVec<REAL> &X,
 }
 
 void TPZCompElDisc::ComputeShape(TPZVec<REAL> &intpoint,TPZMaterialData &data){
-    this->ComputeShape(intpoint, data.x, data.jacobian, data.axes,data.detjac, data.jacinv, data.phi, data.fDPhi, data.dphix);
+    this->ComputeShape(intpoint, data.x, data.jacobian, data.axes,data.detjac, data.jacinv, data.phi, data.fH1.fDPhi, data.dphix);
 }
 
 

--- a/Mesh/TPZCompElH1.cpp
+++ b/Mesh/TPZCompElH1.cpp
@@ -113,7 +113,7 @@ void TPZCompElH1<TSHAPE>::InitMaterialData(TPZMaterialData &data){
     TPZShapeH1<TSHAPE>::Initialize(ids, orders, shapedata);
     mat->FillDataRequirements(data);
     const int dim = this->Dimension();
-    const int nshape = data.fPhi.Rows();
+    const int nshape = data.fH1.fPhi.Rows();
     const int nstate = this->Material()->NStateVariables();
     data.fShapeType = TPZMaterialData::EScalarShape;
     data.phi.Redim(nshape,1);
@@ -140,12 +140,12 @@ template<class TSHAPE>
 void TPZCompElH1<TSHAPE>::ComputeShape(TPZVec<REAL> &intpoint, TPZMaterialData &data){
     
     TPZShapeData &shapedata = data;
-    TPZShapeH1<TSHAPE>::Shape(intpoint,shapedata,shapedata.fPhi,shapedata.fDPhi);
+    TPZShapeH1<TSHAPE>::Shape(intpoint,shapedata,shapedata.fH1.fPhi,shapedata.fH1.fDPhi);
     int tranpose = 1;
     REAL alpha = 1.;
     REAL beta = 0.;
-    data.jacinv.MultAdd(shapedata.fDPhi, data.dphix, data.dphix,alpha,beta,tranpose);
-    data.phi = shapedata.fPhi;
+    data.jacinv.MultAdd(shapedata.fH1.fDPhi, data.dphix, data.dphix,alpha,beta,tranpose);
+    data.phi = shapedata.fH1.fPhi;
 }
 
 template<class TSHAPE>
@@ -345,8 +345,8 @@ void TPZCompElH1<TSHAPE>::SideShapeFunction(int side,TPZVec<REAL> &point,TPZFMat
                 break;
         }
     }
-    phi = data.fPhi;
-    dphi = data.fDPhi;
+    phi = data.fH1.fPhi;
+    dphi = data.fH1.fDPhi;
 }
 
 template<class TSHAPE>
@@ -365,8 +365,8 @@ void TPZCompElH1<TSHAPE>::Shape(TPZVec<REAL> &pt, TPZFMatrix<REAL> &phi, TPZFMat
     TPZShapeData data;
     locshape.Initialize(id, ord, data);
 	locshape.Shape(pt,data);
-    phi = data.fPhi;
-    dphi = data.fDPhi;
+    phi = data.fH1.fPhi;
+    dphi = data.fH1.fDPhi;
 }
 
 

--- a/Mesh/TPZCompElHCurl.cpp
+++ b/Mesh/TPZCompElHCurl.cpp
@@ -299,7 +299,7 @@ void TPZCompElHCurl<TSHAPE>::InitMaterialData(TPZMaterialData &data){
         ids[i] = ref->NodePtr(i)->Id();
     }
     
-    auto &conOrders = shapedata.fHDivConnectOrders;
+    auto &conOrders = shapedata.fHCurl.fConnectOrders;
     constexpr auto nConnects = TSHAPE::NSides - TSHAPE::NCornerNodes;
     conOrders.Resize(nConnects,-1);
     for(auto i = 0; i < nConnects; i++){

--- a/Mesh/TPZCompElKernelHDiv.cpp
+++ b/Mesh/TPZCompElKernelHDiv.cpp
@@ -71,7 +71,7 @@ void TPZCompElKernelHDiv<TSHAPE>::InitMaterialData(TPZMaterialData &data)
 
     mat->FillDataRequirements(data);
     const int dim = this->Dimension();
-    const int nshape = data.fPhi.Rows();
+    const int nshape = data.fH1.fPhi.Rows();
     const int nstate = this->Material()->NStateVariables();
     data.fShapeType = TPZMaterialData::EScalarShape;
     data.phi.Redim(nshape,1);

--- a/Mesh/TPZCompElKernelHDiv3D.cpp
+++ b/Mesh/TPZCompElKernelHDiv3D.cpp
@@ -72,7 +72,7 @@ void TPZCompElKernelHDiv3D<TSHAPE>::InitMaterialData(TPZMaterialData &data){
         ids[i] = ref->NodePtr(i)->Id();
     }
     
-    auto &conOrders = shapedata.fHDivConnectOrders;
+    auto &conOrders = shapedata.fHDiv.fConnectOrders;
     constexpr auto nConnects = TSHAPE::NSides - TSHAPE::NCornerNodes;
     conOrders.Resize(nConnects,-1);
     // For Tetrahedra we increase the polynomial order by one. The internal connect is increased by two

--- a/Mesh/TPZSBFemVolume.cpp
+++ b/Mesh/TPZSBFemVolume.cpp
@@ -95,9 +95,9 @@ void TPZSBFemVolume::ComputeKMatrices(TPZElementMatrixT<STATE> &E0, TPZElementMa
     TPZMaterialDataT<STATE> data2d;
     CSkeleton->InitMaterialData(data1d);
     CSkeleton->InitMaterialData(data2d);
-    int nshape = data2d.fPhi.Rows();
-    data2d.fPhi.Redim(nshape * 2, 1);
-    data2d.fDPhi.Redim(dim2, 2 * nshape);
+    int nshape = data2d.fH1.fPhi.Rows();
+    data2d.fH1.fPhi.Redim(nshape * 2, 1);
+    data2d.fH1.fDPhi.Redim(dim2, 2 * nshape);
     data2d.dphix.Redim(dim2, 2 * nshape);
     data2d.dsol[0].Redim(dim2, nstate);
 
@@ -160,7 +160,7 @@ void TPZSBFemVolume::ComputeKMatrices(TPZElementMatrixT<STATE> &E0, TPZElementMa
         for (int i = 0; i < nshape; i++) {
             for (int j = 0; j < nshape; j++) {
                 for (int st = 0; st < nstate; st++) {
-                    M0.fMat(i * nstate + st, j * nstate + st) += weight * data1d.fPhi(i, 0) * data1d.fPhi(j, 0) * fDensity;
+                    M0.fMat(i * nstate + st, j * nstate + st) += weight * data1d.fH1.fPhi(i, 0) * data1d.fH1.fPhi(j, 0) * fDensity;
                 }
             }
         }
@@ -239,17 +239,17 @@ void TPZSBFemVolume::AdjustAxes3D(const TPZFMatrix<REAL> &axes2D, TPZFMatrix<REA
 void TPZSBFemVolume::ExtendShapeFunctions(TPZMaterialDataT<STATE> &data1d, TPZMaterialDataT<STATE> &data2d)
 {
     int dim = Reference()->Dimension();
-    int64_t nshape = data2d.fPhi.Rows() / 2;
+    int64_t nshape = data2d.fH1.fPhi.Rows() / 2;
     for (int ish = 0; ish < nshape; ish++) {
-        data2d.fPhi(ish + nshape, 0) = data1d.fPhi(ish, 0);
+        data2d.fH1.fPhi(ish + nshape, 0) = data1d.fH1.fPhi(ish, 0);
         for (int d = 0; d < dim - 1; d++) {
-            data2d.fDPhi(d, ish + nshape) = data1d.fDPhi(d, ish);
-            data2d.fDPhi(d, ish) = 0.;
+            data2d.fH1.fDPhi(d, ish + nshape) = data1d.fH1.fDPhi(d, ish);
+            data2d.fH1.fDPhi(d, ish) = 0.;
         }
-        data2d.fDPhi(dim - 1, ish) = -data1d.fPhi(ish) / 2.;
-        data2d.fDPhi(dim - 1, ish + nshape) = 0.;
+        data2d.fH1.fDPhi(dim - 1, ish) = -data1d.fH1.fPhi(ish) / 2.;
+        data2d.fH1.fDPhi(dim - 1, ish + nshape) = 0.;
     }
-    TPZInterpolationSpace::Convert2Axes(data2d.fDPhi, data2d.jacinv, data2d.dphix);
+    TPZInterpolationSpace::Convert2Axes(data2d.fH1.fDPhi, data2d.jacinv, data2d.dphix);
 }
 
 TPZCompEl * CreateSBFemCompEl(TPZGeoEl *gel, TPZCompMesh &mesh)
@@ -351,7 +351,7 @@ void TPZSBFemVolume::ReallyComputeSolution(TPZMaterialDataT<STATE>& data)
     axes = data2d.axes;
     CSkeleton->ComputeRequiredData(data1d, qsilow);
 
-    int nshape = data1d.fPhi.Rows();
+    int nshape = data1d.fH1.fPhi.Rows();
     int nstate = mat2d->NStateVariables();
 #ifdef PZDEBUG
     if (fPhi.Cols() != fCoeficients.Rows()) {
@@ -397,7 +397,7 @@ void TPZSBFemVolume::ReallyComputeSolution(TPZMaterialDataT<STATE>& data)
             std::stringstream sout;
             sout << "uh_xi " << uh_xi << std::endl;
             sout << "Duh_xi " << Duh_xi << std::endl;
-            data1d.fPhi.Print(sout);
+            data1d.fH1.fPhi.Print(sout);
             LOGPZ_DEBUG(logger, sout.str())
         }
 #endif
@@ -407,10 +407,10 @@ void TPZSBFemVolume::ReallyComputeSolution(TPZMaterialDataT<STATE>& data)
         TPZManVector<STATE, 3> dsolxi(nstate, 0.);
         for (int ishape = 0; ishape < nshape; ishape++) {
             for (int istate = 0; istate < nstate; istate++) {
-                sol[s][istate] += data1d.fPhi(ishape) * uh_xi[ishape * nstate + istate];
-                dsolxi[istate] += data1d.fPhi(ishape) * Duh_xi[ishape * nstate + istate];
+                sol[s][istate] += data1d.fH1.fPhi(ishape) * uh_xi[ishape * nstate + istate];
+                dsolxi[istate] += data1d.fH1.fPhi(ishape) * Duh_xi[ishape * nstate + istate];
                 for (int d = 0; d < dim - 1; d++) {
-                    dsolxieta(d, istate) += data1d.fDPhi(d, ishape) * uh_xi[ishape * nstate + istate];
+                    dsolxieta(d, istate) += data1d.fH1.fDPhi(d, ishape) * uh_xi[ishape * nstate + istate];
                 }
                 dsolxieta(dim - 1, istate) = -dsolxi[istate] / 2.;
             }
@@ -478,9 +478,9 @@ void TPZSBFemVolume::ComputeSolutionWithBubbles(TPZVec<REAL> &qsi,
     }
     axes = data2d.axes;
     CSkeleton->ComputeRequiredData(data1d, qsilow);
-    CSkeleton->Shape(qsilow, data1d.fPhi, data1d.fDPhi);
+    CSkeleton->Shape(qsilow, data1d.fH1.fPhi, data1d.fH1.fDPhi);
     
-    int nshape = data1d.fPhi.Rows();
+    int nshape = data1d.fH1.fPhi.Rows();
     int nstate = mat2d->NStateVariables();
     int numeig = fEigenvalues.size();
 #ifdef PZDEBUG
@@ -552,7 +552,7 @@ void TPZSBFemVolume::ComputeSolutionWithBubbles(TPZVec<REAL> &qsi,
             std::stringstream sout;
             sout << "uh_xi " << uh_xi << std::endl;
             sout << "Duh_xi " << Duh_xi << std::endl;
-            data1d.fPhi.Print(sout);
+            data1d.fH1.fPhi.Print(sout);
             LOGPZ_DEBUG(logger, sout.str())
         }
 #endif
@@ -562,10 +562,10 @@ void TPZSBFemVolume::ComputeSolutionWithBubbles(TPZVec<REAL> &qsi,
         TPZManVector<STATE, 3> dsolxi(nstate, 0.);
         for (int ishape = 0; ishape < nshape; ishape++) {
             for (int istate = 0; istate < nstate; istate++) {
-                sol[s][istate] += data1d.fPhi(ishape) * uh_xi[ishape * nstate + istate].real();
-                dsolxi[istate] += data1d.fPhi(ishape) * Duh_xi[ishape * nstate + istate].real();
+                sol[s][istate] += data1d.fH1.fPhi(ishape) * uh_xi[ishape * nstate + istate].real();
+                dsolxi[istate] += data1d.fH1.fPhi(ishape) * Duh_xi[ishape * nstate + istate].real();
                 for (int d = 0; d < dim - 1; d++) {
-                    dsolxieta(d, istate) += data1d.fDPhi(d, ishape) * uh_xi[ishape * nstate + istate].real();
+                    dsolxieta(d, istate) += data1d.fH1.fDPhi(d, ishape) * uh_xi[ishape * nstate + istate].real();
                 }
                 dsolxieta(dim - 1, istate) = -dsolxi[istate] / 2.;
             }
@@ -666,7 +666,7 @@ void TPZSBFemVolume::Shape(TPZVec<REAL> &qsi, TPZFMatrix<REAL> &phi, TPZFMatrix<
     }
     CSkeleton->ComputeRequiredData(data1d, qsilow);
 
-    int nshape = data1d.fPhi.Rows();
+    int nshape = data1d.fH1.fPhi.Rows();
 #ifdef PZDEBUG
     if (fPhi.Cols() != fCoeficients.Rows()) {
         DebugStop();
@@ -713,7 +713,7 @@ void TPZSBFemVolume::Shape(TPZVec<REAL> &qsi, TPZFMatrix<REAL> &phi, TPZFMatrix<
             std::stringstream sout;
             sout << "uh_xi " << uh_xi << std::endl;
             sout << "Duh_xi " << Duh_xi << std::endl;
-            data1d.fPhi.Print(sout);
+            data1d.fH1.fPhi.Print(sout);
             LOGPZ_DEBUG(logger, sout.str())
         }
 #endif
@@ -721,10 +721,10 @@ void TPZSBFemVolume::Shape(TPZVec<REAL> &qsi, TPZFMatrix<REAL> &phi, TPZFMatrix<
         TPZManVector<STATE, 3> dsolxi(nstate, 0.);
         for (int ishape = 0; ishape < nshape; ishape++) {
             for (int istate = 0; istate < nstate; istate++) {
-                phi(s * nstate + istate, 0) += data1d.fPhi(ishape) * uh_xi[ishape * nstate + istate].real();
-                dsolxi[istate] += data1d.fPhi(ishape) * Duh_xi[ishape * nstate + istate].real();
+                phi(s * nstate + istate, 0) += data1d.fH1.fPhi(ishape) * uh_xi[ishape * nstate + istate].real();
+                dsolxi[istate] += data1d.fH1.fPhi(ishape) * Duh_xi[ishape * nstate + istate].real();
                 for (int d = 0; d < dim - 1; d++) {
-                    dsollow(d, istate) += data1d.fDPhi(d, ishape) * uh_xi[ishape * nstate + istate].real();
+                    dsollow(d, istate) += data1d.fH1.fDPhi(d, ishape) * uh_xi[ishape * nstate + istate].real();
                 }
             }
         }
@@ -943,8 +943,8 @@ void TPZSBFemVolume::InitMaterialData(TPZMaterialData &data)
     const int dim = this->Dimension();
     const int nshape = this->NShapeF();
     const int nstate = this->Material()->NStateVariables();
-    data.fPhi.Redim(nstate * nshape*dim, 1);
-    data.fDPhi.Redim(dim*nstate, nshape * nstate);
+    data.fH1.fPhi.Redim(nstate * nshape*dim, 1);
+    data.fH1.fDPhi.Redim(dim*nstate, nshape * nstate);
     data.dphix.Redim(dim*nstate, nshape * nstate);
     data.axes.Redim(dim, 3);
     data.jacobian.Redim(dim, dim);
@@ -1086,7 +1086,7 @@ void TPZSBFemVolume::LocalBodyForces(TPZFNMatrix<100,std::complex<double>> &f, T
         for (int i=0; i<problemdimension-1; i++) {
             intskel[i] = intpoint[i];
         }
-        CSkeleton->Shape(intskel, data1d.fPhi, data1d.fDPhi);
+        CSkeleton->Shape(intskel, data1d.fH1.fPhi, data1d.fH1.fDPhi);
         
         Ref2D->X(intpoint, data.x);
         if (mat2d->HasForcingFunction())
@@ -1103,9 +1103,9 @@ void TPZSBFemVolume::LocalBodyForces(TPZFNMatrix<100,std::complex<double>> &f, T
             } else {
                 xiexp = pow(sbfemparam, -eigval[c] - 0.5*(dim2-2) );
             }
-            for (int i = 0; i < data1d.fPhi.Rows(); i++) {
+            for (int i = 0; i < data1d.fH1.fPhi.Rows(); i++) {
                 for (int istate = 0; istate < nstate; istate++) {
-                    eflocal(i*nstate + istate, c) += xiexp * data1d.fPhi(i,0) * bodyforce[istate] * weight;
+                    eflocal(i*nstate + istate, c) += xiexp * data1d.fH1.fPhi(i,0) * bodyforce[istate] * weight;
                 }
             }
         }
@@ -1116,9 +1116,9 @@ void TPZSBFemVolume::LocalBodyForces(TPZFNMatrix<100,std::complex<double>> &f, T
             } else {
                 xiexp = pow(sbfemparam, -eigvalbubbles[c]);
             }
-            for (int i = 0; i < data1d.fPhi.Rows(); i++) {
+            for (int i = 0; i < data1d.fH1.fPhi.Rows(); i++) {
                 for (int istate = 0; istate < nstate; istate++) {
-                    eflocalbubble(i*nstate + istate, c) += xiexp * data1d.fPhi(i,0) * bodyforce[istate] * weight;
+                    eflocalbubble(i*nstate + istate, c) += xiexp * data1d.fH1.fPhi(i,0) * bodyforce[istate] * weight;
                 }
             }
         }

--- a/Mesh/TPZSBFemVolumeHdiv.cpp
+++ b/Mesh/TPZSBFemVolumeHdiv.cpp
@@ -194,7 +194,7 @@ void TPZSBFemVolumeHdiv::ReallyComputeSolution(TPZMaterialDataT<STATE> & data)
                     for (int d = 0; d < dim; d++)
                     {
                         int id = (ishape + is)* nstate + istate;
-                        data.sol[s][d] += data.fPhi(id) * data.fDeformedDirections(d,id) * uh_xi[id].real();
+                        data.sol[s][d] += data.fH1.fPhi(id) * data.fDeformedDirections(d,id) * uh_xi[id].real();
                     }
                 }
             }

--- a/Mesh/TPZSBFemVolumeL2.cpp
+++ b/Mesh/TPZSBFemVolumeL2.cpp
@@ -100,7 +100,7 @@ void TPZSBFemVolumeL2::ReallyComputeSolution(TPZMaterialDataT<STATE> & data)
     Ref2D->Jacobian(qsi, data2d.jacobian, data2d.axes, data2d.detjac, data2d.jacinv);
     axes = data2d.axes;
 
-    int nshape = data1d.fPhi.Rows();
+    int nshape = data1d.fH1.fPhi.Rows();
     int nstate = mat2d->NStateVariables();
 #ifdef PZDEBUG
     if (fPhi.Cols() != fCoeficients.Rows()) {
@@ -147,10 +147,10 @@ void TPZSBFemVolumeL2::ReallyComputeSolution(TPZMaterialDataT<STATE> & data)
         TPZManVector<STATE, 3> dsolxi(nstate, 0.);
         for (int ishape = 0; ishape < nshape; ishape++) {
             for (int istate = 0; istate < nstate; istate++) {
-                sol[s][istate] += data1d.fPhi(ishape) * uh_xi[ishape * nstate + istate].real();
-                dsolxi[istate] += data1d.fPhi(ishape) * Duh_xi[ishape * nstate + istate].real();
+                sol[s][istate] += data1d.fH1.fPhi(ishape) * uh_xi[ishape * nstate + istate].real();
+                dsolxi[istate] += data1d.fH1.fPhi(ishape) * Duh_xi[ishape * nstate + istate].real();
                 for (int d = 0; d < dim - 1; d++) {
-                    dsollow(d, istate) += data1d.fDPhi(d, ishape) * uh_xi[ishape * nstate + istate].real();
+                    dsollow(d, istate) += data1d.fH1.fDPhi(d, ishape) * uh_xi[ishape * nstate + istate].real();
                 }
             }
         }

--- a/Mesh/pzinterpolationspace.cpp
+++ b/Mesh/pzinterpolationspace.cpp
@@ -196,7 +196,7 @@ void TPZInterpolationSpace::ComputeShape(TPZVec<REAL> &intpoint, TPZVec<REAL> &X
 void TPZInterpolationSpace::ComputeShape(TPZVec<REAL> &intpoint, TPZMaterialData &data){
     
     
-    this->ComputeShape(intpoint,data.x,data.jacobian,data.axes,data.detjac,data.jacinv,data.phi,data.fDPhi,data.dphix);
+    this->ComputeShape(intpoint,data.x,data.jacobian,data.axes,data.detjac,data.jacinv,data.phi,data.fH1.fDPhi,data.dphix);
     
 }
 
@@ -225,7 +225,7 @@ void TPZInterpolationSpace::InitMaterialData(TPZMaterialData &data){
 	const int nstate = this->Material()->NStateVariables();
     data.fShapeType = TPZMaterialData::EScalarShape;
 	data.phi.Redim(nshape,1);
-	data.fDPhi.Redim(dim,nshape);
+	data.fH1.fDPhi.Redim(dim,nshape);
 	data.dphix.Redim(dim,nshape);
 	data.axes.Redim(dim,3);
 	data.jacobian.Redim(dim,dim);

--- a/Shape/TPZShapeData.cpp
+++ b/Shape/TPZShapeData.cpp
@@ -30,13 +30,24 @@ std::string TPZShapeData::ShapeFunctionType() const
 void TPZShapeData::Print(std::ostream &out) const
 {
     out << "Shape function type " << ShapeFunctionType() << std::endl;
-    fPhi.Print("phi",out);
-    fDPhi.Print("dphi",out);
-    out << "fMasterDirections" << fMasterDirections << std::endl;
-    if (fSDVecShapeIndex.size()) {
+    out << "H1 data" << std::endl;
+    fH1.fPhi.Print("phi",out);
+    fH1.fDPhi.Print("dphi",out);
+    out << "HDiv data" << std::endl;
+    out << "fMasterDirections" << fHDiv.fMasterDirections << std::endl;
+    if (fHDiv.fSDVecShapeIndex.size()) {
         out << "VecShapeIndex: ";
-        for (int64_t i = 0; i < fSDVecShapeIndex.size(); i++) {
-            out << fSDVecShapeIndex[i].first << '/' << fSDVecShapeIndex[i].second << ' ';
+        for (int64_t i = 0; i < fHDiv.fSDVecShapeIndex.size(); i++) {
+            out << fHDiv.fSDVecShapeIndex[i].first << '/' << fHDiv.fSDVecShapeIndex[i].second << ' ';
+        }
+        out << '\n';
+    }
+    out << "HCurl data" << std::endl;
+    out << "fMasterDirections" << fHCurl.fMasterDirections << std::endl;
+    if (fHCurl.fSDVecShapeIndex.size()) {
+        out << "VecShapeIndex: ";
+        for (int64_t i = 0; i < fHCurl.fSDVecShapeIndex.size(); i++) {
+            out << fHCurl.fSDVecShapeIndex[i].first << '/' << fHCurl.fSDVecShapeIndex[i].second << ' ';
         }
         out << '\n';
     }
@@ -45,9 +56,10 @@ void TPZShapeData::Print(std::ostream &out) const
 /** Print the data in a format suitable for Mathematica */
 void TPZShapeData::PrintMathematica(std::ostream &out) const
 {
-    fPhi.Print("phi = ",out,EMathematicaInput);
-    fDPhi.Print("dphi = ",out,EMathematicaInput);
-    out << "fMasterDirections" << fMasterDirections << std::endl;
+    fH1.fPhi.Print("H1phi = ",out,EMathematicaInput);
+    fH1.fDPhi.Print("H1dphi = ",out,EMathematicaInput);
+    out << "HDivfMasterDirections = " << fHDiv.fMasterDirections << std::endl;
+    out << "HCurlfMasterDirections = " << fHCurl.fMasterDirections << std::endl;
 }
 
 

--- a/Shape/TPZShapeData.h
+++ b/Shape/TPZShapeData.h
@@ -61,31 +61,54 @@ public:
     MShapeFunctionType fShapeType{EEmpty};
     //! Corner node ids determine the parameter transformations to the sides
     TPZManVector<int64_t,8> fCornerNodeIds;
-    //! Connect orders determine the number of shape functions
-    TPZManVector<int,27> fH1ConnectOrders;
-    //! Number of shape functions by connect
-    TPZManVector<int,27> fH1NumConnectShape;
-    //! Parametric transforms from the interior to the side
-    TPZManVector<TPZTransform<REAL>, 20> fSideTransforms;
-    //! Transformation ids for each side
-    TPZManVector<int, 20> fSideTransformationId;
-    //! Vector of shapefunctions (format is dependent on the value of shapetype) over the master element
-    TPZFNMatrix<MatDataNumPhi, REAL> fPhi;
-    //! Values of the derivative of the shape functions over the master element
-    TPZFNMatrix<3*MatDataNumPhi, REAL> fDPhi;
+    
+    //Data structure
+    struct H1
+    {
+        //! Connect orders determine the number of shape functions
+        TPZManVector<int, 27> fConnectOrders;
+        //! Number of shape functions by connect
+        TPZManVector<int, 27> fNumConnectShape;
+        //! Parametric transforms from the interior to the side
+        TPZManVector<TPZTransform<REAL>, 20> fSideTransforms;
+        //! Transformation ids for each side
+        TPZManVector<int, 20> fSideTransformationId;
+        //! Vector of shapefunctions (format is dependent on the value of shapetype) over the master element
+        TPZFNMatrix<MatDataNumPhi, REAL> fPhi;
+        //! Values of the derivative of the shape functions over the master element
+        TPZFNMatrix<3 * MatDataNumPhi, REAL> fDPhi;
+    };
 
-    // NEEDED BY HDIV OR HCURL
-    //! Connect orders determine the number of shape functions
-    TPZManVector<int,27> fHDivConnectOrders;
-    //! Number of shape functions by connect
-    TPZManVector<int,27> fHDivNumConnectShape;
-    //! The orientation of the sides (either -1 or +1)
-    TPZManVector<int,20> fSideOrient;
-    //! Directions on the master element
-    TPZFNMatrix<3*MatDataNumDir> fMasterDirections;
-    //! Correspondence between direction vector index and index of the shape functions. Used for H(div) and H(curl) approximation spaces.
-    TPZManVector<std::pair<int,int64_t>, MatDataNumPhi > fSDVecShapeIndex;
-        
+    struct HDiv
+    {
+        //! Connect orders determine the number of shape functions
+        TPZManVector<int, 27> fConnectOrders;
+        //! Number of shape functions by connect
+        TPZManVector<int, 27> fNumConnectShape;
+        //! The orientation of the sides (either -1 or +1)
+        TPZManVector<int, 20> fSideOrient;
+        //! Directions on the master element
+        TPZFNMatrix<3 * MatDataNumDir> fMasterDirections;
+        //! Correspondence between direction vector index and index of the shape functions
+        TPZManVector<std::pair<int, int64_t>, MatDataNumPhi> fSDVecShapeIndex;
+    };
+
+    struct HCurl
+    {
+        //! Connect orders determine the number of shape functions
+        TPZManVector<int, 27> fConnectOrders;
+        //! Number of shape functions by connect
+        TPZManVector<int, 27> fNumConnectShape;
+        //! The orientation of the sides (either -1 or +1)
+        TPZManVector<int, 20> fSideOrient;
+        //! Directions on the master element
+        TPZFNMatrix<3 * MatDataNumDir> fMasterDirections;
+        //! Correspondence between direction vector index and index of the shape functions.
+        TPZManVector<std::pair<int, int64_t>, MatDataNumPhi> fSDVecShapeIndex;
+    };
+    H1 fH1;
+    HDiv fHDiv;
+    HCurl fHCurl;
 };
 #endif
 

--- a/Shape/TPZShapeDisc.cpp
+++ b/Shape/TPZShapeDisc.cpp
@@ -499,14 +499,14 @@ void  TPZShapeDisc::Shape2DFull(REAL C,TPZVec<REAL> &X0,TPZVec<REAL> &X,int degr
 /// initialize the TPZShapeData datastructure
 void TPZShapeDisc::Initialize(int order, int dimension, MShapeType shapetype, TPZShapeData &data)
 {
-    data.fH1ConnectOrders.resize(1);
-    data.fH1ConnectOrders[0] = order;
+    data.fH1.fConnectOrders.resize(1);
+    data.fH1.fConnectOrders[0] = order;
     data.fCornerNodeIds.resize(0);
-    data.fH1NumConnectShape.resize(1);
+    data.fH1.fNumConnectShape.resize(1);
     int64_t nshape = NShapeF(order, dimension, shapetype);
-    data.fH1NumConnectShape[0] = nshape;
-    data.fPhi.Resize(nshape,1);
-    data.fDPhi.Resize(dimension, nshape);
+    data.fH1.fNumConnectShape[0] = nshape;
+    data.fH1.fPhi.Resize(nshape,1);
+    data.fH1.fDPhi.Resize(dimension, nshape);
 
 }
 

--- a/Shape/TPZShapeH1.h
+++ b/Shape/TPZShapeH1.h
@@ -19,7 +19,7 @@ struct TPZShapeH1
 
     static void Shape(const TPZVec<REAL> &pt, TPZShapeData &data)
     {
-        TPZShapeH1<TSHAPE>::Shape(pt,data,data.fPhi,data.fDPhi);
+        TPZShapeH1<TSHAPE>::Shape(pt,data,data.fH1.fPhi,data.fH1.fDPhi);
     }
 
     static void ShapeOrders(TPZGenMatrix<int> &shapeorders, TPZShapeData &data);

--- a/Shape/TPZShapeHCurl.cpp
+++ b/Shape/TPZShapeHCurl.cpp
@@ -108,7 +108,7 @@ void TPZShapeHCurl<TSHAPE>::ComputeVecandShape(TPZShapeData &data) {
     }
     data.fHCurl.fSDVecShapeIndex.Resize(nshape);
 
-    TPZVec<unsigned int> shapeCountVec(TSHAPE::NSides - nNodes, 0);
+    TPZManVector<unsigned int,TSHAPE::NSides - nNodes> shapeCountVec(TSHAPE::NSides - nNodes, 0);
     TPZVec<std::pair<int,int64_t>> & indexVecShape = data.fHCurl.fSDVecShapeIndex;
     TPZVec<int> &connOrder = data.fHCurl.fConnectOrders;
     TPZManVector<int64_t, TSHAPE::NSides - nNodes> firstH1ShapeFunc(TSHAPE::NSides - nNodes,
@@ -383,7 +383,7 @@ void TPZShapeHCurl<TSHAPE>::CalcH1ShapeOrders(
 template<class TSHAPE>
 void TPZShapeHCurl<TSHAPE>::StaticIndexShapeToVec(TPZShapeData &data) {
     const int nNodes = TSHAPE::NCornerNodes;
-    TPZVec<unsigned int> shapeCountVec(TSHAPE::NSides - nNodes, 0);
+    TPZManVector<unsigned int,TSHAPE::NSides - nNodes> shapeCountVec(TSHAPE::NSides - nNodes, 0);
     TPZVec<std::pair<int,int64_t>> & indexVecShape = data.fHCurl.fSDVecShapeIndex;
     TPZVec<int> &connectOrder = data.fHCurl.fConnectOrders;
     TPZManVector<int64_t, TSHAPE::NSides - nNodes> firstH1ShapeFunc(TSHAPE::NSides - nNodes,
@@ -773,7 +773,7 @@ void TPZShapeHCurl<TSHAPE>::StaticIndexShapeToVec(TPZShapeData &data) {
         v[vi] = vs;
     };
 
-    TPZVec<std::pair<int,int>> funcXYZ, funcX, funcY, funcZ;
+    TPZManVector<std::pair<int,int>,200> funcXYZ, funcX, funcY, funcZ;
     
     
     for(auto iFunc = 0; iFunc < nH1Internal; iFunc++ ){

--- a/Shape/TPZShapeHCurl.cpp
+++ b/Shape/TPZShapeHCurl.cpp
@@ -23,31 +23,31 @@ void TPZShapeHCurl<TSHAPE>::Initialize(const TPZVec<int64_t> &ids,
     constexpr int NCorners = TSHAPE::NCornerNodes;
     constexpr int NSides = TSHAPE::NSides;
     if(connectorders.size() != ncon) DebugStop();
-    CalcH1ShapeOrders(connectorders, data.fH1ConnectOrders);
-    TPZShapeH1<TSHAPE>::Initialize(ids, data.fH1ConnectOrders, data);
-    data.fSideTransformationId.Resize(NSides-NCorners, 0);
+    CalcH1ShapeOrders(connectorders, data.fH1.fConnectOrders);
+    TPZShapeH1<TSHAPE>::Initialize(ids, data.fH1.fConnectOrders, data);
+    data.fH1.fSideTransformationId.Resize(NSides-NCorners, 0);
     for (int iside = NCorners; iside< NSides ; iside++) {
         int pos = iside - NCorners;
         int trans_id = TSHAPE::GetTransformId(iside, ids); // Foi criado
-        data.fSideTransformationId[iside-NCorners] = trans_id;
+        data.fH1.fSideTransformationId[iside-NCorners] = trans_id;
     }
 
-    data.fHDivConnectOrders = connectorders;
+    data.fHCurl.fConnectOrders = connectorders;
 
-    data.fHDivNumConnectShape.Resize(ncon);
+    data.fHCurl.fNumConnectShape.Resize(ncon);
     int nShape = 0;
     for (int i = 0; i < ncon; i++)
     {
-        data.fHDivNumConnectShape[i] = ComputeNConnectShapeF(i,connectorders[i]);
-        nShape += data.fHDivNumConnectShape[i];
+        data.fHCurl.fNumConnectShape[i] = ComputeNConnectShapeF(i,connectorders[i]);
+        nShape += data.fHCurl.fNumConnectShape[i];
     }
     
-    data.fSDVecShapeIndex.Resize(nShape);
+    data.fHCurl.fSDVecShapeIndex.Resize(nShape);
     TPZFNMatrix<9,REAL> gradX(TSHAPE::Dimension, TSHAPE::Dimension, 0);
     gradX.Identity();
 
-    data.fMasterDirections.Redim(TSHAPE::Dimension, 3*NSides);
-    TSHAPE::ComputeHCurlDirections(gradX,data.fMasterDirections,data.fSideTransformationId);
+    data.fHCurl.fMasterDirections.Redim(TSHAPE::Dimension, 3*NSides);
+    TSHAPE::ComputeHCurlDirections(gradX,data.fHCurl.fMasterDirections,data.fH1.fSideTransformationId);
 
     ComputeVecandShape(data);
 }
@@ -104,21 +104,21 @@ void TPZShapeHCurl<TSHAPE>::ComputeVecandShape(TPZShapeData &data) {
     int nshape = NHCurlShapeF(data);
     //we need to take into account 0-th order edges (they need more h1 funcs)
     for(int ie = 0; ie < nEdges; ie++){
-        if (data.fHDivConnectOrders[ie] == 0){nshape++;}
+        if (data.fHCurl.fConnectOrders[ie] == 0){nshape++;}
     }
-    data.fSDVecShapeIndex.Resize(nshape);
+    data.fHCurl.fSDVecShapeIndex.Resize(nshape);
 
     TPZVec<unsigned int> shapeCountVec(TSHAPE::NSides - nNodes, 0);
-    TPZVec<std::pair<int,int64_t>> & indexVecShape = data.fSDVecShapeIndex;
-    TPZVec<int> &connOrder = data.fHDivConnectOrders;
+    TPZVec<std::pair<int,int64_t>> & indexVecShape = data.fHCurl.fSDVecShapeIndex;
+    TPZVec<int> &connOrder = data.fHCurl.fConnectOrders;
     TPZManVector<int64_t, TSHAPE::NSides - nNodes> firstH1ShapeFunc(TSHAPE::NSides - nNodes,
                                                                                   0);
     firstH1ShapeFunc[0] = nNodes;
     for (int iSide = nNodes + 1; iSide < TSHAPE::NSides; iSide++) {
         const int iCon = iSide - nNodes;
-        firstH1ShapeFunc[iCon] = firstH1ShapeFunc[iCon - 1] + data.fH1NumConnectShape[iCon-1];
+        firstH1ShapeFunc[iCon] = firstH1ShapeFunc[iCon - 1] + data.fH1.fNumConnectShape[iCon-1];
     }
-    TPZVec<int> &sidesH1Ord = data.fH1ConnectOrders;
+    TPZVec<int> &sidesH1Ord = data.fH1.fConnectOrders;
     auto &nodeIds = data.fCornerNodeIds;
     StaticIndexShapeToVec(data);
 }
@@ -127,8 +127,8 @@ template<class TSHAPE>
 int TPZShapeHCurl<TSHAPE>::NHCurlShapeF(const TPZShapeData &data)
 {
     int nshape = 0;
-    int nc = data.fHDivNumConnectShape.size();
-    for(int ic = 0; ic<nc; ic++) nshape += data.fHDivNumConnectShape[ic];
+    int nc = data.fHCurl.fNumConnectShape.size();
+    for(int ic = 0; ic<nc; ic++) nshape += data.fHCurl.fNumConnectShape[ic];
     return nshape;
 }
 
@@ -148,8 +148,8 @@ void TPZShapeHCurl<TSHAPE>::Shape(const TPZVec<T> &pt, TPZShapeData &data, TPZFM
     constexpr int nvol = dim == 3 ? 1 : 0;
     constexpr int nedges = nsides - nvol - nfaces - ncorner;
     
-    TPZFNMatrix<100,T> locphi(data.fPhi.Rows(),data.fPhi.Cols(),0.);
-    TPZFNMatrix<100*dim,T> dphi(data.fDPhi.Rows(),data.fDPhi.Cols(),0.);
+    TPZFNMatrix<100,T> locphi(data.fH1.fPhi.Rows(),data.fH1.fPhi.Cols(),0.);
+    TPZFNMatrix<100*dim,T> dphi(data.fH1.fDPhi.Rows(),data.fH1.fDPhi.Cols(),0.);
     
     TPZShapeH1<TSHAPE>::Shape(pt,data, locphi, dphi);
 
@@ -160,7 +160,7 @@ void TPZShapeHCurl<TSHAPE>::Shape(const TPZVec<T> &pt, TPZShapeData &data, TPZFM
                          const int isca,
                          const int ivec){
             for(int d = 0; d<TSHAPE::Dimension; d++){
-                phi(d,iphi) = locphi(isca,0)*data.fMasterDirections(d,ivec);
+                phi(d,iphi) = locphi(isca,0)*data.fHCurl.fMasterDirections(d,ivec);
             }
         };
 
@@ -173,13 +173,13 @@ void TPZShapeHCurl<TSHAPE>::Shape(const TPZVec<T> &pt, TPZShapeData &data, TPZFM
             if constexpr (dim==1){
                 curlphi(0,iphi) =
                     dphi.GetVal( 0,ivec) *
-                    data.fMasterDirections.GetVal(0,ivec);
+                    data.fHCurl.fMasterDirections.GetVal(0,ivec);
             }else if constexpr (dim==2){
                 curlphi(0,iphi) =
                     dphi.GetVal(0,isca) *
-                    data.fMasterDirections.GetVal(1,ivec) -
+                    data.fHCurl.fMasterDirections.GetVal(1,ivec) -
                     dphi.GetVal(1,isca) *
-                    data.fMasterDirections.GetVal(0,ivec);
+                    data.fHCurl.fMasterDirections.GetVal(0,ivec);
             }
             else if constexpr(dim==3){
                 for(auto d = 0; d < dim; d++) {
@@ -187,9 +187,9 @@ void TPZShapeHCurl<TSHAPE>::Shape(const TPZVec<T> &pt, TPZShapeData &data, TPZFM
                     const auto dj = (d+2)%dim;
                     curlphi(d,iphi) =
                         dphi.GetVal(di,isca) *
-                        data.fMasterDirections.GetVal(dj,ivec)-
+                        data.fHCurl.fMasterDirections.GetVal(dj,ivec)-
                         dphi.GetVal(dj,isca) *
-                        data.fMasterDirections.GetVal(di,ivec);
+                        data.fHCurl.fMasterDirections.GetVal(di,ivec);
                 }
             }else{
                 if constexpr (std::is_same_v<TSHAPE,TSHAPE>){
@@ -201,7 +201,7 @@ void TPZShapeHCurl<TSHAPE>::Shape(const TPZVec<T> &pt, TPZShapeData &data, TPZFM
     /*
       edges need special attention: the functions are to be recombined
      */
-    const auto &connectorders = data.fHDivConnectOrders;
+    const auto &connectorders = data.fHCurl.fConnectOrders;
 
     //current index of data.fSDVecShapeIndex
     int vs_index = 0;
@@ -211,13 +211,13 @@ void TPZShapeHCurl<TSHAPE>::Shape(const TPZVec<T> &pt, TPZShapeData &data, TPZFM
     TPZFNMatrix<dim*nedges,T> phi_lo(dim,nedges,0.);
     TPZFNMatrix<curldim*nedges,T> curlphi_lo(curldim,nedges,0.);
 
-    TSHAPE::ComputeConstantHCurl(pt, phi_lo, curlphi_lo, data.fSideTransformationId);
+    TSHAPE::ComputeConstantHCurl(pt, phi_lo, curlphi_lo, data.fH1.fSideTransformationId);
 
 
     TPZManVector<int64_t,nedges> firstH1edgeFunc(nedges,0);
     firstH1edgeFunc[0] = ncorner;
     for (int icon = 1; icon < nedges; icon++){
-        firstH1edgeFunc[icon] = firstH1edgeFunc[icon-1] + data.fH1NumConnectShape[icon-1];
+        firstH1edgeFunc[icon] = firstH1edgeFunc[icon-1] + data.fH1.fNumConnectShape[icon-1];
     }
     
     //we iterate through edges...
@@ -248,9 +248,9 @@ void TPZShapeHCurl<TSHAPE>::Shape(const TPZVec<T> &pt, TPZShapeData &data, TPZFM
     }
 
     //now we got for faces and volumes
-    for(;vs_index < data.fSDVecShapeIndex.size(); phi_index++, vs_index++)
+    for(;vs_index < data.fHCurl.fSDVecShapeIndex.size(); phi_index++, vs_index++)
     {
-        const auto &it = data.fSDVecShapeIndex[vs_index];
+        const auto &it = data.fHCurl.fSDVecShapeIndex[vs_index];
         const int vecindex = it.first;
         const int scalindex = it.second;
 
@@ -258,7 +258,7 @@ void TPZShapeHCurl<TSHAPE>::Shape(const TPZVec<T> &pt, TPZShapeData &data, TPZFM
         ComputeCurl(curlphi,phi_index,scalindex,vecindex);
     }
 // #ifdef PZDEBUG
-    if(vs_index!=data.fSDVecShapeIndex.size()){
+    if(vs_index!=data.fHCurl.fSDVecShapeIndex.size()){
         DebugStop();
     }
     if(phi_index != phi.Cols()){
@@ -384,16 +384,16 @@ template<class TSHAPE>
 void TPZShapeHCurl<TSHAPE>::StaticIndexShapeToVec(TPZShapeData &data) {
     const int nNodes = TSHAPE::NCornerNodes;
     TPZVec<unsigned int> shapeCountVec(TSHAPE::NSides - nNodes, 0);
-    TPZVec<std::pair<int,int64_t>> & indexVecShape = data.fSDVecShapeIndex;
-    TPZVec<int> &connectOrder = data.fHDivConnectOrders;
+    TPZVec<std::pair<int,int64_t>> & indexVecShape = data.fHCurl.fSDVecShapeIndex;
+    TPZVec<int> &connectOrder = data.fHCurl.fConnectOrders;
     TPZManVector<int64_t, TSHAPE::NSides - nNodes> firstH1ShapeFunc(TSHAPE::NSides - nNodes,
                                                                                   0);
     firstH1ShapeFunc[0] = nNodes;
     for (int iSide = nNodes + 1; iSide < TSHAPE::NSides; iSide++) {
         const int iCon = iSide - nNodes;
-        firstH1ShapeFunc[iCon] = firstH1ShapeFunc[iCon - 1] + data.fH1NumConnectShape[iCon-1];
+        firstH1ShapeFunc[iCon] = firstH1ShapeFunc[iCon - 1] + data.fH1.fNumConnectShape[iCon-1];
     }
-    TPZVec<int> &sidesH1Ord = data.fH1ConnectOrders;
+    TPZVec<int> &sidesH1Ord = data.fH1.fConnectOrders;
     auto &nodeIds = data.fCornerNodeIds;
 
     /******************************************************************************************************************
@@ -714,7 +714,7 @@ void TPZShapeHCurl<TSHAPE>::StaticIndexShapeToVec(TPZShapeData &data) {
         const auto faceSide = iFace + nEdges + nNodes;
         const auto faceType = TSHAPE::Type(faceSide);
         const auto faceDim = TSHAPE::SideDimension(faceSide);
-        const auto faceOrderH1 =data.fH1ConnectOrders[faceSide-nNodes];
+        const auto faceOrderH1 =data.fH1.fConnectOrders[faceSide-nNodes];
         const auto nH1FaceFuncs =
             TSHAPE::NConnectShapeF(faceSide,faceOrderH1);
         const auto vecIndex = firstVfOrthVec + iFace;

--- a/Shape/TPZShapeHCurlNoGrads.cpp
+++ b/Shape/TPZShapeHCurlNoGrads.cpp
@@ -16,10 +16,10 @@ void TPZShapeHCurlNoGrads<TSHAPE>::Initialize(const TPZVec<int64_t> &ids,
 {
   TPZShapeHCurl<TSHAPE>::Initialize(ids,connectorders,data);
   constexpr int ncon = TSHAPE::NSides-TSHAPE::NCornerNodes;
-  data.fHDivNumConnectShape.Resize(ncon);
+  data.fHCurl.fNumConnectShape.Resize(ncon);
   //we need to update the number of filtered hcurl functions
   for (int i = 0; i < ncon; i++){
-    data.fHDivNumConnectShape[i] = ComputeNConnectShapeF(i,connectorders[i]);
+    data.fHCurl.fNumConnectShape[i] = ComputeNConnectShapeF(i,connectorders[i]);
   }
 }
 
@@ -51,7 +51,7 @@ void TPZShapeHCurlNoGrads<TSHAPE>::Shape(const TPZVec<REAL> &pt, TPZShapeData &d
     const int nedges = TSHAPE::NumSides(1);
     
     //calculates # of unfiltered hcurl functions
-    const auto &connectorders = data.fHDivConnectOrders;
+    const auto &connectorders = data.fHCurl.fConnectOrders;
     //first_hcurl_side[i] is the index of the first shape function associated with side i
     TPZManVector<int,ncon> first_hcurl_side(ncon,0);
     //total number of unfiltered funcs
@@ -124,7 +124,7 @@ void TPZShapeHCurlNoGrads<TSHAPE>::Shape(const TPZVec<Fad<REAL>> &pt, TPZShapeDa
     const int nedges = TSHAPE::NumSides(1);
     
     //calculates # of unfiltered hcurl functions
-    const auto &connectorders = data.fHDivConnectOrders;
+    const auto &connectorders = data.fHCurl.fConnectOrders;
     //first_hcurl_side[i] is the index of the first shape function associated with side i
     TPZManVector<int,ncon> first_hcurl_side(ncon,0);
     //total number of unfiltered funcs

--- a/Shape/TPZShapeHDivBound.cpp
+++ b/Shape/TPZShapeHDivBound.cpp
@@ -19,30 +19,30 @@ void TPZShapeHDivBound<TSHAPE>::Initialize(const TPZVec<int64_t> &ids,
         DebugStop();
     }
 #endif
-    data.fSideOrient.Resize(1);
-    data.fSideOrient[0] = sideorient;
+    data.fHDiv.fSideOrient.Resize(1);
+    data.fHDiv.fSideOrient[0] = sideorient;
     int connectOrdersSize = nsides-ncorner;
     if (TSHAPE::Type() == EPoint){
         connectOrdersSize = 1;
     }
-    data.fH1ConnectOrders.Resize(connectOrdersSize, connectorder);
-    data.fH1ConnectOrders.Fill(connectorder);
+    data.fH1.fConnectOrders.Resize(connectOrdersSize, connectorder);
+    data.fH1.fConnectOrders.Fill(connectorder);
     if(connectorder > 0)
     {
-        TPZShapeH1<TSHAPE>::Initialize(ids,data.fH1ConnectOrders,data);
+        TPZShapeH1<TSHAPE>::Initialize(ids,data.fH1.fConnectOrders,data);
     }
 }
 
 template <class TSHAPE>
 int TPZShapeHDivBound<TSHAPE>::NShape(const TPZShapeData &data)
 {
-    if(data.fH1ConnectOrders[0] == 0) return 1;
-    return data.fPhi.Rows();
+    if(data.fH1.fConnectOrders[0] == 0) return 1;
+    return data.fH1.fPhi.Rows();
 }
 
 template <>
 void TPZShapeHDivBound<class pzshape::TPZShapePoint>::Shape(const TPZVec<REAL> &pt, TPZShapeData &data, TPZFMatrix<REAL> &phi) {
-    phi(0,0) = data.fSideOrient[0];
+    phi(0,0) = data.fHDiv.fSideOrient[0];
 }
 
 
@@ -56,31 +56,31 @@ void TPZShapeHDivBound<TSHAPE>::Shape(const TPZVec<REAL> &pt, TPZShapeData &data
     const int ncorner = TSHAPE::NCornerNodes;
     const int nsides = TSHAPE::NSides;
     const REAL volume = TSHAPE::RefElVolume();
-    if(data.fH1ConnectOrders[0] == 0)
+    if(data.fH1.fConnectOrders[0] == 0)
     {
         phi(0,0) = 1./volume;
         return;
     }
-    const REAL scale = data.fSideOrient[0]*ncorner/volume;
-    TPZShapeH1<TSHAPE>::Shape(pt,data,data.fPhi,data.fDPhi);
+    const REAL scale = data.fHDiv.fSideOrient[0]*ncorner/volume;
+    TPZShapeH1<TSHAPE>::Shape(pt,data,data.fH1.fPhi,data.fH1.fDPhi);
     TPZManVector<int, 9> permutegather(nsides);
     TPZShapeHDiv<TSHAPE>::HDivPermutation(TSHAPE::Type(), data.fCornerNodeIds, permutegather);
-    for(int c=0; c < ncorner; c++) phi(c,0) = data.fPhi(permutegather[c],0)*scale;
+    for(int c=0; c < ncorner; c++) phi(c,0) = data.fH1.fPhi(permutegather[c],0)*scale;
     int count = ncorner;
     TPZManVector<int,9> firstshape(nsides-ncorner+1,ncorner);
     for(int side = ncorner; side < nsides; side++)
     {
-        int nshape = data.fH1NumConnectShape[side-ncorner];
+        int nshape = data.fH1.fNumConnectShape[side-ncorner];
         firstshape[side+1-ncorner] = firstshape[side-ncorner]+ nshape;
     }
     for(int side = ncorner; side < nsides; side++)
     {
         int sidebound = permutegather[side];
-        int nshape = data.fH1NumConnectShape[sidebound-ncorner];
+        int nshape = data.fH1.fNumConnectShape[sidebound-ncorner];
         int fsh = firstshape[sidebound-ncorner];
         for(int sh = 0; sh<nshape; sh++)
         {
-            phi(count,0) = data.fPhi(fsh+sh,0)*scale;
+            phi(count,0) = data.fH1.fPhi(fsh+sh,0)*scale;
             count++;
         }
     }

--- a/Shape/TPZShapeHDivCollapsed.cpp
+++ b/Shape/TPZShapeHDivCollapsed.cpp
@@ -27,23 +27,23 @@ void TPZShapeHDivCollapsed<TSHAPE>::Initialize(const TPZVec<int64_t> &ids,
     TPZManVector<int,20> hdivsideorient(sideorient);
     hdivsideorient.Resize(TSHAPE::NFacets+1, 0);
     TPZShapeHDiv<TSHAPE>::Initialize(ids, hdivconnectorders, hdivsideorient, data);
-    int nphi = data.fPhi.Rows();
+    int nphi = data.fH1.fPhi.Rows();
     // extend the dimension of the master element directions
-    const int ndirections = data.fMasterDirections.Cols();
-    data.fMasterDirections.Resize(TSHAPE::Dimension+1, ndirections+2);
+    const int ndirections = data.fHDiv.fMasterDirections.Cols();
+    data.fHDiv.fMasterDirections.Resize(TSHAPE::Dimension+1, ndirections+2);
     for (int idir = 0; idir < ndirections+2; idir++) {
-        data.fMasterDirections(dim,idir) = 0.;
+        data.fHDiv.fMasterDirections(dim,idir) = 0.;
     }
     for (int d = 0; d<dim+1; d++) {
-        data.fMasterDirections(d,ndirections) = 0.;
-        data.fMasterDirections(d,ndirections+1) = 0.;
+        data.fHDiv.fMasterDirections(d,ndirections) = 0.;
+        data.fHDiv.fMasterDirections(d,ndirections+1) = 0.;
     }
-    data.fMasterDirections(dim,ndirections) = 1.;
-    data.fMasterDirections(dim,ndirections+1) = -1.;
+    data.fHDiv.fMasterDirections(dim,ndirections) = 1.;
+    data.fHDiv.fMasterDirections(dim,ndirections+1) = -1.;
     // extend the dimensions of the connect orders
-    data.fHDivConnectOrders = connectorders;
-    data.fSideOrient = sideorient;
-    data.fHDivNumConnectShape.Resize(TSHAPE::NFacets+3);
+    data.fHDiv.fConnectOrders = connectorders;
+    data.fHDiv.fSideOrient = sideorient;
+    data.fHDiv.fNumConnectShape.Resize(TSHAPE::NFacets+3);
     // compute the number of shape functions of the top and bottom fluxes
     {
         TPZShapeData locdata;
@@ -51,10 +51,10 @@ void TPZShapeHDivCollapsed<TSHAPE>::Initialize(const TPZVec<int64_t> &ids,
         TPZShapeHDivBound<TSHAPE> bound;
         bound.Initialize(ids,connectorders[connect],sideorient[TSHAPE::NFacets],locdata);
         const int nphibound = bound.NShape(locdata);
-        data.fHDivNumConnectShape[connect] = nphibound;
+        data.fHDiv.fNumConnectShape[connect] = nphibound;
         nphi += nphibound;
-        data.fPhi.Resize(nphi,data.fPhi.Cols());
-        data.fDPhi.Resize(data.fDPhi.Rows(),nphi);
+        data.fH1.fPhi.Resize(nphi,data.fH1.fPhi.Cols());
+        data.fH1.fDPhi.Resize(data.fH1.fDPhi.Rows(),nphi);
     }
     {
         TPZShapeData locdata;
@@ -62,10 +62,10 @@ void TPZShapeHDivCollapsed<TSHAPE>::Initialize(const TPZVec<int64_t> &ids,
         TPZShapeHDivBound<TSHAPE> bound;
         bound.Initialize(ids,connectorders[connect],sideorient[TSHAPE::NFacets+1],locdata);
         const int nphibound = bound.NShape(locdata);
-        data.fHDivNumConnectShape[connect] = nphibound;
+        data.fHDiv.fNumConnectShape[connect] = nphibound;
         nphi += nphibound;
-        data.fPhi.Resize(nphi,data.fPhi.Cols());
-        data.fDPhi.Resize(data.fDPhi.Rows(),nphi);
+        data.fH1.fPhi.Resize(nphi,data.fH1.fPhi.Cols());
+        data.fH1.fDPhi.Resize(data.fH1.fDPhi.Rows(),nphi);
     }
 }
 
@@ -75,7 +75,7 @@ int TPZShapeHDivCollapsed<TSHAPE>::NShapeF(TPZShapeData &data)
     int nshape = 0;
     for(int i = 0; i< TSHAPE::NFacets+3; i++)
     {
-        nshape += data.fHDivNumConnectShape[i];
+        nshape += data.fHDiv.fNumConnectShape[i];
     }
     return nshape;
 }
@@ -92,29 +92,29 @@ void TPZShapeHDivCollapsed<TSHAPE>::Shape(const TPZVec<REAL> &pt, TPZShapeData &
     const int ncorner = TSHAPE::NCornerNodes;
     const int nsides = TSHAPE::NSides;
     const int dim = TSHAPE::Dimension;
-    TPZShapeH1<TSHAPE>::Shape(pt,data,data.fPhi,data.fDPhi);
-    for(int i = 0; i< data.fSDVecShapeIndex.size(); i++)
+    TPZShapeH1<TSHAPE>::Shape(pt,data,data.fH1.fPhi,data.fH1.fDPhi);
+    for(int i = 0; i< data.fHDiv.fSDVecShapeIndex.size(); i++)
     {
-        auto it = data.fSDVecShapeIndex[i];
+        auto it = data.fHDiv.fSDVecShapeIndex[i];
         int vecindex = it.first;
         int scalindex = it.second;
         divphi(i,0) = 0.;
         for(int d = 0; d<= TSHAPE::Dimension; d++)
         {
-            phi(d,i) = data.fPhi(scalindex,0)*data.fMasterDirections(d,vecindex);
+            phi(d,i) = data.fH1.fPhi(scalindex,0)*data.fHDiv.fMasterDirections(d,vecindex);
         }
         for(int d = 0; d<TSHAPE::Dimension; d++)
         {
-            divphi(i,0) += data.fDPhi(d,scalindex)*data.fMasterDirections(d,vecindex);
+            divphi(i,0) += data.fH1.fDPhi(d,scalindex)*data.fHDiv.fMasterDirections(d,vecindex);
         }
     }
     // compute the number of shape functions of the top and bottom fluxes
-    int firstshape = data.fSDVecShapeIndex.size();
+    int firstshape = data.fHDiv.fSDVecShapeIndex.size();
     {
         TPZShapeData locdata;
         const int connect = TSHAPE::NFacets+1;
-        TPZShapeHDivBound<TSHAPE>::Initialize(data.fCornerNodeIds,data.fHDivConnectOrders[connect],data.fSideOrient[TSHAPE::NFacets],locdata);
-        TPZFNMatrix<25> locphi(data.fHDivNumConnectShape[connect],1);
+        TPZShapeHDivBound<TSHAPE>::Initialize(data.fCornerNodeIds,data.fHDiv.fConnectOrders[connect],data.fHDiv.fSideOrient[TSHAPE::NFacets],locdata);
+        TPZFNMatrix<25> locphi(data.fHDiv.fNumConnectShape[connect],1);
         TPZShapeHDivBound<TSHAPE>::Shape(pt, locdata, locphi);
         for (int ish = 0; ish < locphi.Rows(); ish++) {
             phi(dim,firstshape+ish) = locphi(ish,0);
@@ -125,8 +125,8 @@ void TPZShapeHDivCollapsed<TSHAPE>::Shape(const TPZVec<REAL> &pt, TPZShapeData &
     {
         TPZShapeData locdata;
         const int connect = TSHAPE::NFacets+2;
-        TPZShapeHDivBound<TSHAPE>::Initialize(data.fCornerNodeIds,data.fHDivConnectOrders[connect],data.fSideOrient[TSHAPE::NFacets+1],locdata);
-        TPZFNMatrix<25> locphi(data.fHDivNumConnectShape[connect],1);
+        TPZShapeHDivBound<TSHAPE>::Initialize(data.fCornerNodeIds,data.fHDiv.fConnectOrders[connect],data.fHDiv.fSideOrient[TSHAPE::NFacets+1],locdata);
+        TPZFNMatrix<25> locphi(data.fHDiv.fNumConnectShape[connect],1);
         TPZShapeHDivBound<TSHAPE>::Shape(pt, locdata, locphi);
         for (int ish = 0; ish < locphi.Rows(); ish++) {
             phi(dim,firstshape+ish) = locphi(ish,0);

--- a/Shape/TPZShapeHDivConstant.cpp
+++ b/Shape/TPZShapeHDivConstant.cpp
@@ -223,7 +223,6 @@ void TPZShapeHDivConstant<TSHAPE>::Shape(const TPZVec<Fad<REAL>> &pt, TPZShapeDa
     TPZManVector<Fad<REAL>,nfacets> div(nfacets);
     vecDiv.Zero();
     div.Fill(0.);
-    // std::cout << "fHDiv.fSide trans ID = " << data.fHDiv.fSideTransformationId << std::endl;
     TSHAPE::ComputeConstantHDiv(pt, vecDiv, div);
 
     int nshape = data.fH1.fPhi.Rows();
@@ -266,46 +265,15 @@ void TPZShapeHDivConstant<TSHAPE>::Shape(const TPZVec<Fad<REAL>> &pt, TPZShapeDa
     }
     else if constexpr(dim == 3)
     {
-        //Adjusting the data structure to HCurl pattern
-        TPZShapeData dataHCurl = data;
-        constexpr int nHCurlCon = nsides - ncorner;
-        dataHCurl.fHDiv.fConnectOrders.resize(nHCurlCon);
-        dataHCurl.fHDiv.fConnectOrders.Fill(1);
-        for (int ic = nedges; ic < nHCurlCon; ic++)
-        {
-            dataHCurl.fHDiv.fConnectOrders[ic] = data.fHDiv.fConnectOrders[ic - nedges];
-        }
-        if constexpr(TSHAPE::Type() == ETetraedro)
-        {
-            for (int ic = nedges; ic < nHCurlCon; ic++)
-            {
-                dataHCurl.fHDiv.fConnectOrders[ic]++;
-            }
-            int ic = nHCurlCon - 1;
-            dataHCurl.fHDiv.fConnectOrders[ic]++;
-        }
-
-        dataHCurl.fHDiv.fNumConnectShape.resize(nHCurlCon);
-        dataHCurl.fHDiv.fNumConnectShape.Fill(1);
-        //For the facets, we subtract the constant function
-        for (int ic = 0; ic < nfacets; ic++)
-        {
-            int numshape = data.fHDiv.fNumConnectShape[ic] - 1;
-            dataHCurl.fHDiv.fNumConnectShape[nedges + ic] = numshape;
-        }
-        int ic = nHCurlCon - 1;
-        int numshape = data.fHDiv.fNumConnectShape[nfacets];
-        dataHCurl.fHDiv.fNumConnectShape[ic] = numshape;
-
         divphi.Zero();
-        int nshapehcurl = TPZShapeHCurlNoGrads<TSHAPE>::NHCurlShapeF(dataHCurl);
+        int nshapehcurl = TPZShapeHCurlNoGrads<TSHAPE>::NHCurlShapeF(data);
         int nshape = NHDivShapeF(data);
 
         TPZFNMatrix<200, Fad<REAL>> phiAux(dim, nshapehcurl), curlPhiAux(3, nshapehcurl);
         phiAux.Zero();
         curlPhiAux.Zero();
 
-        TPZShapeHCurlNoGrads<TSHAPE>::Shape(pt, dataHCurl, phiAux, curlPhiAux);
+        TPZShapeHCurlNoGrads<TSHAPE>::Shape(pt, data, phiAux, curlPhiAux);
 
         int count = 0;
         int countKernel = nedges;
@@ -313,7 +281,6 @@ void TPZShapeHDivConstant<TSHAPE>::Shape(const TPZVec<Fad<REAL>> &pt, TPZShapeDa
         // Face functions
         for (int i = 0; i < nfacets; i++)
         {
-            // std::cout << "Side orient - " << i << " " << data.fHDiv.fSideOrient[i] << std::endl;
             // RT0 Function
             for (auto d = 0; d < dim; d++)
             {
@@ -323,7 +290,7 @@ void TPZShapeHDivConstant<TSHAPE>::Shape(const TPZVec<Fad<REAL>> &pt, TPZShapeDa
             count++;
 
             // Kernel HDiv functions
-            for (int k = 0; k < dataHCurl.fHDiv.fNumConnectShape[nedges]; k++)
+            for (int k = 0; k < data.fHCurl.fNumConnectShape[nedges]; k++)
             {
                 for (auto d = 0; d < dim; d++)
                 {
@@ -334,7 +301,7 @@ void TPZShapeHDivConstant<TSHAPE>::Shape(const TPZVec<Fad<REAL>> &pt, TPZShapeDa
             }
         }
         // Internal Functions - HDivKernel
-        for (int i = 0; i < dataHCurl.fHDiv.fNumConnectShape[TSHAPE::NSides - TSHAPE::NCornerNodes - 1]; i++)
+        for (int i = 0; i < data.fHCurl.fNumConnectShape[TSHAPE::NSides - TSHAPE::NCornerNodes - 1]; i++)
         {
             for (auto d = 0; d < dim; d++)
             {
@@ -343,9 +310,6 @@ void TPZShapeHDivConstant<TSHAPE>::Shape(const TPZVec<Fad<REAL>> &pt, TPZShapeDa
             countKernel++;
             count++;
         }
-        // std::cout << "VecDiv = " << vecDiv << std::endl;
-        // std::cout << "divphi = " << divphi << std::endl;
-        // std::cout << "phi = " << phi << std::endl;
     }
     else
     {

--- a/Shape/TPZShapeHDivConstantBound.cpp
+++ b/Shape/TPZShapeHDivConstantBound.cpp
@@ -21,20 +21,20 @@ void TPZShapeHDivConstantBound<TSHAPE>::Initialize(const TPZVec<int64_t> &ids,
 #endif
     if(TSHAPE::Type() == ETriangle || TSHAPE::Type() == EOned) connectorder++;
 
-    data.fSideOrient.Resize(1);
-    data.fSideOrient[0] = sideorient;
-    data.fH1ConnectOrders.Resize(nsides-ncorner, connectorder);
-    data.fH1ConnectOrders.Fill(connectorder);
+    data.fHDiv.fSideOrient.Resize(1);
+    data.fHDiv.fSideOrient[0] = sideorient;
+    data.fH1.fConnectOrders.Resize(nsides-ncorner, connectorder);
+    data.fH1.fConnectOrders.Fill(connectorder);
 
     if(TSHAPE::Dimension == 1)
     {
-        TPZShapeH1<TSHAPE>::Initialize(ids,data.fH1ConnectOrders,data);
+        TPZShapeH1<TSHAPE>::Initialize(ids,data.fH1.fConnectOrders,data);
     } else if (TSHAPE::Dimension == 2){
         const int nedges = TSHAPE::NSides-TSHAPE::NCornerNodes-1;
         TPZManVector<int,15> locconorders(TSHAPE::NSides-TSHAPE::NCornerNodes,1);
         for(int ic = nedges; ic<TSHAPE::NSides-TSHAPE::NCornerNodes; ic++)
         {
-            locconorders[ic] = data.fH1ConnectOrders[ic-nedges];
+            locconorders[ic] = data.fH1.fConnectOrders[ic-nedges];
         }
         TPZShapeHCurlNoGrads<TSHAPE>::Initialize(ids,locconorders,data);
     } else {
@@ -45,13 +45,13 @@ void TPZShapeHDivConstantBound<TSHAPE>::Initialize(const TPZVec<int64_t> &ids,
 template <class TSHAPE>
 int TPZShapeHDivConstantBound<TSHAPE>::NShape(const TPZShapeData &data)
 {
-    if(data.fH1ConnectOrders[0] == 0) return 1;
-    return data.fPhi.Rows();
+    if(data.fH1.fConnectOrders[0] == 0) return 1;
+    return data.fH1.fPhi.Rows();
 }
 
 template <>
 void TPZShapeHDivConstantBound<class pzshape::TPZShapePoint>::Shape(const TPZVec<REAL> &pt, TPZShapeData &data, TPZFMatrix<REAL> &phi) {
-    phi(0,0) = data.fSideOrient[0];
+    phi(0,0) = data.fHDiv.fSideOrient[0];
 }
 
 
@@ -62,23 +62,23 @@ void TPZShapeHDivConstantBound<TSHAPE>::Shape(const TPZVec<REAL> &pt, TPZShapeDa
     const int nsides = TSHAPE::NSides;
     const int dim = TSHAPE::Dimension;
     const auto nEdges = TSHAPE::NumSides(1);
-    TPZShapeH1<TSHAPE>::Shape(pt,data,data.fPhi,data.fDPhi);
+    TPZShapeH1<TSHAPE>::Shape(pt,data,data.fH1.fPhi,data.fH1.fDPhi);
 
     if (dim == 1){
-        phi(0,0) = 0.5 * data.fSideOrient[0];
+        phi(0,0) = 0.5 * data.fHDiv.fSideOrient[0];
 
-        int nshape = data.fPhi.Rows();
+        int nshape = data.fH1.fPhi.Rows();
 
         for (int i = 0; i < nshape-ncorner; i++){
-            phi(i+1,0) = -data.fDPhi(0,i+ncorner);
+            phi(i+1,0) = -data.fH1.fDPhi(0,i+ncorner);
         }
     } else if (dim == 2) {
         
         
         if (TSHAPE::Type() == EQuadrilateral){
-            phi(0,0) = 0.25 * data.fSideOrient[0];
+            phi(0,0) = 0.25 * data.fHDiv.fSideOrient[0];
         } else if (TSHAPE::Type() == ETriangle){
-            phi(0,0) = 2. * data.fSideOrient[0];
+            phi(0,0) = 2. * data.fHDiv.fSideOrient[0];
         }
 
         int nshape = TPZShapeHCurlNoGrads<TSHAPE>::NHCurlShapeF(data);

--- a/Shape/TPZShapeHDivKernel2D.cpp
+++ b/Shape/TPZShapeHDivKernel2D.cpp
@@ -11,8 +11,8 @@ template<class TSHAPE>
 int TPZShapeHDivKernel2D<TSHAPE>::NHDivShapeF(TPZShapeData &data)
 {
     int nshape = 0;
-    int nc = data.fHDivNumConnectShape.size();
-    for(int ic = 0; ic<nc; ic++) nshape += data.fHDivNumConnectShape[ic];
+    int nc = data.fHDiv.fNumConnectShape.size();
+    for(int ic = 0; ic<nc; ic++) nshape += data.fHDiv.fNumConnectShape[ic];
     return nshape;
 }
 
@@ -23,24 +23,24 @@ void TPZShapeHDivKernel2D<TSHAPE>::Shape(TPZVec<REAL> &pt, TPZShapeData &data, T
 {
 
     const int dim = TSHAPE::Dimension;
-    TPZShapeH1<TSHAPE>::Shape(pt,data,data.fPhi,data.fDPhi);
+    TPZShapeH1<TSHAPE>::Shape(pt,data,data.fH1.fPhi,data.fH1.fDPhi);
     divphi.Zero();
 
-    int nshape = data.fPhi.Rows();
+    int nshape = data.fH1.fPhi.Rows();
     phi.Resize(2,nshape);
 
     switch (dim)
     {
     case 1:
         for (int i = 0; i < nshape; i++){
-            phi(0,i) = data.fDPhi(0,i);
+            phi(0,i) = data.fH1.fDPhi(0,i);
         }
         break;
     
     case 2:
         for (int i = 0; i < nshape; i++){
-            phi(0,i) =  data.fDPhi(1,i);
-            phi(1,i) = -data.fDPhi(0,i);
+            phi(0,i) =  data.fH1.fDPhi(1,i);
+            phi(1,i) = -data.fH1.fDPhi(0,i);
         }
         break;
     

--- a/UnitTest_PZ/TestMaterial/TestDarcyFlow.cpp
+++ b/UnitTest_PZ/TestMaterial/TestDarcyFlow.cpp
@@ -27,7 +27,7 @@ static void computeStiffnessH1(TPZFMatrix<STATE> &ek)
     TPZManVector<int> connectorders = {1,1,1,1,1};
     
     TPZShapeH1<pzshape::TPZShapeQuad>::Initialize(ids,connectorders,DataVec[0]);
-    int64_t nshape = DataVec[0].fPhi.Rows();
+    int64_t nshape = DataVec[0].fH1.fPhi.Rows();
 //    int order = 0;
 //    int dimension = 2;
 //    pzshape::TPZShapeDisc::MShapeType shtype = pzshape::TPZShapeDisc::ETensorial;
@@ -42,8 +42,8 @@ static void computeStiffnessH1(TPZFMatrix<STATE> &ek)
     {
         REAL weight;
         integrule.Point(p, pt, weight);
-        TPZShapeH1<pzshape::TPZShapeQuad>::Shape(pt, DataVec[0], DataVec[0].fPhi,DataVec[0].fDPhi);
-        DataVec[0].dphix = DataVec[0].fDPhi;
+        TPZShapeH1<pzshape::TPZShapeQuad>::Shape(pt, DataVec[0], DataVec[0].fH1.fPhi,DataVec[0].fH1.fDPhi);
+        DataVec[0].dphix = DataVec[0].fH1.fDPhi;
         material.Contribute(DataVec[0], weight, ek, ef);
     }
 }
@@ -56,7 +56,7 @@ static void computeStiffnessHybrid(TPZFMatrix<STATE> &ek)
     TPZManVector<int> connectorders = {1,1,1,1,1};
     
     TPZShapeH1<pzshape::TPZShapeQuad>::Initialize(ids,connectorders,DataVec[1]);
-    int64_t nshape = DataVec[1].fPhi.Rows();
+    int64_t nshape = DataVec[1].fH1.fPhi.Rows();
     int order = 0;
     int dimension = 2;
     pzshape::TPZShapeDisc::MShapeType shtype = pzshape::TPZShapeDisc::ETensorial;
@@ -72,12 +72,12 @@ static void computeStiffnessHybrid(TPZFMatrix<STATE> &ek)
     {
         REAL weight;
         integrule.Point(p, pt, weight);
-        TPZShapeH1<pzshape::TPZShapeQuad>::Shape(pt, DataVec[1],DataVec[1].fPhi,DataVec[1].fDPhi);
+        TPZShapeH1<pzshape::TPZShapeQuad>::Shape(pt, DataVec[1],DataVec[1].fH1.fPhi,DataVec[1].fH1.fDPhi);
         int degree = 0;
-        pzshape::TPZShapeDisc::Shape(dimension,degree,pt,DataVec[2].fPhi,DataVec[2].fDPhi,shtype);
-        pzshape::TPZShapeDisc::Shape(dimension,degree,pt,DataVec[3].fPhi,DataVec[3].fDPhi,shtype);
-        DataVec[1].dphix = DataVec[1].fDPhi;
-        DataVec[1].phi = DataVec[1].fPhi;
+        pzshape::TPZShapeDisc::Shape(dimension,degree,pt,DataVec[2].fH1.fPhi,DataVec[2].fH1.fDPhi,shtype);
+        pzshape::TPZShapeDisc::Shape(dimension,degree,pt,DataVec[3].fH1.fPhi,DataVec[3].fH1.fDPhi,shtype);
+        DataVec[1].dphix = DataVec[1].fH1.fDPhi;
+        DataVec[1].phi = DataVec[1].fH1.fPhi;
         material.Contribute(DataVec, weight, ek, ef);
     }
 }

--- a/UnitTest_PZ/TestMaterial/TestMaterial.cpp
+++ b/UnitTest_PZ/TestMaterial/TestMaterial.cpp
@@ -30,7 +30,7 @@ TPZFMatrix<STATE> computeStressStrain()
 	dphi(0,0) = 1;
 	dphi(1,1) = 1;
 	dphi(2,2) = 1;
-	cubodata.fPhi = phi;
+	cubodata.fH1.fPhi = phi;
 	cubodata.dphix = dphi;
 	cubodata.x = pt;
 	cubodata.axes.Redim(3, 3);

--- a/UnitTest_PZ/TestMesh/TestHDiv.cpp
+++ b/UnitTest_PZ/TestMesh/TestHDiv.cpp
@@ -1222,8 +1222,8 @@ void CheckShapeOrder(int order)
                     TPZShapeData data;
                     h1.Initialize(ids, orders, data);
                     h1.Shape(point, data);
-                    phi = data.fPhi;
-                    dphi = data.fDPhi;
+                    phi = data.fH1.fPhi;
+                    dphi = data.fH1.fDPhi;
 //                    tshape::SideShape(is, point, locids, orders, phi, dphi);
                     
 //                    for (int ishape = firstshape; ishape<firstshape+nsideshape; ishape++) {
@@ -2616,12 +2616,12 @@ void CheckOutsideDirections()
     int64_t numvec = TSHAPE::Dimension*TSHAPE::NSides;
     const int dim = TSHAPE::Dimension;
     TPZShapeData data;
-    data.fMasterDirections.Resize(3,numvec);
+    data.fHDiv.fMasterDirections.Resize(3,numvec);
     TPZFNMatrix<9,REAL> gradx(3,TSHAPE::Dimension,0.);
     for (int i = 0; i < TSHAPE::Dimension; i++) {
         gradx(i,i) = 1.;
     }
-    TSHAPE::ComputeHDivDirections(gradx, data.fMasterDirections);
+    TSHAPE::ComputeHDivDirections(gradx, data.fHDiv.fMasterDirections);
     TPZManVector<REAL,TSHAPE::Dimension> elcenter(TSHAPE::Dimension,0.);
     TSHAPE::CenterPoint(TSHAPE::NSides-1,elcenter);
     int firstface = TSHAPE::NSides - TSHAPE::NFacets - 1;
@@ -2638,14 +2638,14 @@ void CheckOutsideDirections()
             REAL inner = 0.;
             for (int il = 0; il<dim; il++)
             {
-              inner += data.fMasterDirections(il,ivet+cont) *delx[il];
+              inner += data.fHDiv.fMasterDirections(il,ivet+cont) *delx[il];
             }
             if(inner < 0.)
             {
                 std::cout << "side = " << side << " delx " << delx << "\n";
                 std::cout << "side center " << sidecenter << std::endl;
                 std::cout << "Master direction ";
-                for(int il=0; il<dim; il++) std::cout << data.fMasterDirections(il,ivet+cont) << ' ';
+                for(int il=0; il<dim; il++) std::cout << data.fHDiv.fMasterDirections(il,ivet+cont) << ' ';
                 std::cout << "This is a bug\n";
             }
         }
@@ -2679,14 +2679,14 @@ void VerifyDeformedDirections(TPZInterpolationSpace *intel, TPZMaterialDataT<STA
             REAL inner = 0.;
             for (int il = 0; il<dim; il++)
             {
-              inner += data.fMasterDirections(il,ivet+cont) *delx[il];
+              inner += data.fHDiv.fMasterDirections(il,ivet+cont) *delx[il];
             }
             if(inner < 0.)
             {
                 std::cout << "side = " << side << " delx " << delx << "\n";
                 std::cout << "side center " << sidecenter << std::endl;
                 std::cout << "Master direction ";
-                for(int il=0; il<dim; il++) std::cout << data.fMasterDirections(il,ivet+cont) << ' ';
+                for(int il=0; il<dim; il++) std::cout << data.fHDiv.fMasterDirections(il,ivet+cont) << ' ';
                 std::cout << "This is a bug\n";
             }
         }

--- a/UnitTest_PZ/TestMesh/TestHDivConstant.cpp
+++ b/UnitTest_PZ/TestMesh/TestHDivConstant.cpp
@@ -598,7 +598,7 @@ void IntegralNormal()
         // comment this out because it will break hcurl shape funcs
         // why was it here?
         // data.fSideTransformationId.Resize(TSHAPE::NFacets, 0);
-        data.fSideOrient.Resize(TSHAPE::NFacets, 1);
+        data.fHDiv.fSideOrient.Resize(TSHAPE::NFacets, 1);
         int nshape = shape.NHDivShapeF(data);
         TPZManVector<REAL> pt(TSHAPE::Dimension, 0.);
         TPZFNMatrix<8, REAL> phi(TSHAPE::Dimension, nshape), divphi(nshape, 1);
@@ -646,13 +646,13 @@ void CheckConnectOrders(int kFacet)
     int nvolshape2 = hdivorig.NConnectShapeF(TSHAPE::NFacets, data2);
     int nvolshape3 = hdivorig.NConnectShapeF(TSHAPE::NFacets, data3);
 
-    auto hdivOrder1 = data1.fHDivConnectOrders;
-    auto hdivOrder2 = data2.fHDivConnectOrders;
-    auto hdivOrder3 = data3.fHDivConnectOrders;
+    auto hdivOrder1 = data1.fHDiv.fConnectOrders;
+    auto hdivOrder2 = data2.fHDiv.fConnectOrders;
+    auto hdivOrder3 = data3.fHDiv.fConnectOrders;
 
-    auto hdivNshape1 = data1.fHDivNumConnectShape;
-    auto hdivNshape2 = data2.fHDivNumConnectShape;
-    auto hdivNshape3 = data3.fHDivNumConnectShape;
+    auto hdivNshape1 = data1.fHDiv.fNumConnectShape;
+    auto hdivNshape2 = data2.fHDiv.fNumConnectShape;
+    auto hdivNshape3 = data3.fHDiv.fNumConnectShape;
 
     CAPTURE(orders1,orders2,orders3,hdivOrder1,hdivOrder2,hdivOrder3,hdivNshape1,hdivNshape2,hdivNshape3);
     

--- a/UnitTest_PZ/TestSBFem/TPZDarcySBFemHdiv.cpp
+++ b/UnitTest_PZ/TestSBFem/TPZDarcySBFemHdiv.cpp
@@ -51,8 +51,8 @@ void TPZHybridPoissonCollapsed::Contribute(const TPZVec<TPZMaterialDataT<STATE>>
     const REAL inv_perm = 1 / perm;
 
     // Setting the phis
-    TPZFMatrix<REAL> &phiQ = datavec[0].fPhi;
-    TPZFMatrix<REAL> &phip = datavec[1].fPhi;
+    TPZFMatrix<REAL> &phiQ = datavec[0].fH1.fPhi;
+    TPZFMatrix<REAL> &phip = datavec[1].fH1.fPhi;
     TPZFMatrix<REAL> &dphiQ = datavec[0].dphix;
     TPZFMatrix<REAL> &dphiP = datavec[1].dphix;
     TPZFNMatrix<9, REAL> dphiPXY(3, dphiP.Cols());
@@ -120,7 +120,7 @@ void TPZHybridPoissonCollapsed::ContributeBC(const TPZVec<TPZMaterialDataT<STATE
 {
     int dim = Dimension();
 
-    TPZFMatrix<REAL> &phiP = datavec[1].fPhi;
+    TPZFMatrix<REAL> &phiP = datavec[1].fH1.fPhi;
     int phrp = phiP.Rows();
 
     REAL v2 = bc.Val2()[0];

--- a/UnitTest_PZ/TestShapeFAD/ShapeFADUnitTest.cpp
+++ b/UnitTest_PZ/TestShapeFAD/ShapeFADUnitTest.cpp
@@ -410,13 +410,13 @@ void ComputePhiFAD(const TPZVec<Fad<REAL>> &pt, TPZVec<int64_t> &nodeids, TPZFMa
     TPZShapeData data;
     shapeh1.Initialize(nodeids, orders, data);
     
-    TPZFMatrix<REAL> phi(data.fPhi);
-    dphi.Resize(data.fDPhi.Rows(),data.fDPhi.Cols());
+    TPZFMatrix<REAL> phi(data.fH1.fPhi);
+    dphi.Resize(data.fH1.fDPhi.Rows(),data.fH1.fDPhi.Cols());
     TPZManVector<REAL> xiReal(pt.size());
     for(int i=0; i<xiReal.size(); i++) xiReal[i] = pt[i].val();
     shapeh1.Shape(xiReal, data, phi, dphi);
-    phiFAD.Resize(data.fPhi.Rows(),1);
-    TPZFMatrix<Fad<REAL>> dphiFAD(pt.size(),data.fDPhi.Cols());
+    phiFAD.Resize(data.fH1.fPhi.Rows(),1);
+    TPZFMatrix<Fad<REAL>> dphiFAD(pt.size(),data.fH1.fDPhi.Cols());
     shapeh1.Shape(pt, data, phiFAD, dphiFAD);
 }
 
@@ -474,7 +474,7 @@ void VerifyDivergenceCompatibility(const TPZVec<Fad<REAL>> &qsifad, const TPZFMa
     TPZManVector<REAL,3> xiReal(dim);
     for(int i=0; i<dim; i++) xiReal[i]=qsifad[i].val();
     shapehdiv.Shape(xiReal, data, phi, divphimaster);
-    TPZFMatrix<Fad<REAL>> dphiFAD(2,data.fDPhi.Cols()),phiFAD;
+    TPZFMatrix<Fad<REAL>> dphiFAD(2,data.fH1.fDPhi.Cols()),phiFAD;
     shapehdiv.Shape(qsifad, data, phiFAD, dphiFAD);
     TPZFMatrix<Fad<REAL>> dirHDiv;
     auto detjac = DetJac(gradX);

--- a/UnitTest_PZ/TestTopology/TestTopology.cpp
+++ b/UnitTest_PZ/TestTopology/TestTopology.cpp
@@ -208,7 +208,7 @@ namespace topologytests{
         TPZShapeData shapedata;
         TPZManVector<int64_t,nCorner> ids(nCorner,0);
         for(auto i=0; i<nCorner; i++) ids[i] = i;        
-        auto &conOrders = shapedata.fHDivConnectOrders;
+        auto &conOrders = shapedata.fHDiv.fConnectOrders;
         constexpr auto nConnects = nFaces + 1;
         conOrders.Resize(nConnects,-1);
         for(auto i = 0; i < nConnects; i++) conOrders[i] = 1;
@@ -217,15 +217,15 @@ namespace topologytests{
 
         TPZShapeHDiv<TSHAPE>::Initialize(ids, conOrders, sideorient, shapedata);
 
-        shapedata.fSideTransformationId.Resize(nSides-nCorner, 0);
+        shapedata.fH1.fSideTransformationId.Resize(nSides-nCorner, 0);
         for (int iside = nCorner; iside< nSides ; iside++) {
             int pos = iside - nCorner;
             int trans_id = TSHAPE::GetTransformId(iside, ids); // Foi criado
-            shapedata.fSideTransformationId[iside-nCorner] = trans_id;
+            shapedata.fH1.fSideTransformationId[iside-nCorner] = trans_id;
         }
 
         const int npts = intRule->NPoints();
-        auto nshape = shapedata.fSDVecShapeIndex.size();
+        auto nshape = shapedata.fHDiv.fSDVecShapeIndex.size();
 
         for (auto ipt = 0; ipt < npts; ipt++) {
             REAL w;
@@ -344,7 +344,7 @@ namespace topologytests{
         TPZShapeData shapedata;
         TPZManVector<int64_t,nCorner> ids(nCorner,0);
         for(auto i=0; i<nCorner; i++) ids[i] = i;        
-        auto &conOrders = shapedata.fHDivConnectOrders;
+        auto &conOrders = shapedata.fHDiv.fConnectOrders;
         constexpr auto nConnects = nSides - nCorner;
         conOrders.Resize(nConnects,-1);
         for(auto i = 0; i < nConnects; i++) conOrders[i] = 0;
@@ -373,7 +373,7 @@ namespace topologytests{
             // std::cout << "curlHCurl =  " << curlHCurl << std::endl;
             
             //Compute the curl for each edge
-            top::ComputeConstantHCurl(node,N0Function,curlN0,shapedata.fSideTransformationId);
+            top::ComputeConstantHCurl(node,N0Function,curlN0,shapedata.fH1.fSideTransformationId);
 
             // std::cout << "Constant phi = " << N0Function << std::endl;
             // std::cout << "Constant Curl = " << curlN0 << std::endl;


### PR DESCRIPTION
This PR changes the way `TPZShapeData `stores the data that are useful to H1, HDiv and HCurl spaces. Up to this point, the attributes named _fHDivConnectOrders_, _fHDivNumConnectShape_, _fSideOrient_, _fMasterDirections_ and _fSDVecShapeIndex_ were used for both `TPZShapeHdiv `and `TPZShapeHCurl `classes. This behaviour is not ideal, specifically when using TPZShapeHDivConstant, since it needs to keep track of both data structures.

The modifications were carried out in the file `TPZShapeData`, where three new attributes named _fH1_, _fHDiv_ and _fHCurl_ were created. Each one of them now stores the data that is going to be used for calling the methods Initiallize() and Shape() of the respective shape.

This PR mainly affects the way data is handled outside the class. For example, when accessing the vector that stores the connect orders of H1 approximation, before it was done `TPZShapeData::fH1ConnectOrders`, now it shall be performed `TPZShapeData::fH1.fConnectOrders`. The same is true for HDiv and HCurl data: `TPZShapeData::fHDiv.fConnectOrders` and `TPZShapeData::fHCurl.fConnectOrders`.

