### PR TITLE
Added a new HDiv Shape called TPZShapeHDivOptimized

### DIFF
--- a/Mesh/TPZCompElHDivDuplConnects.cpp
+++ b/Mesh/TPZCompElHDivDuplConnects.cpp
@@ -2,6 +2,7 @@
 #include "TPZCompElHDivDuplConnectsBound.h"
 #include "TPZMaterial.h"
 #include "TPZShapeHDiv.h"
+#include "TPZShapeHDivOptimized.h"
 #include "TPZShapeHDivConstant.h"
 #include "pzlog.h"
 #include "pzconnect.h"
@@ -108,6 +109,26 @@ int TPZCompElHDivDuplConnects<TSHAPE>::NConnectShapeF(int connect, int order)con
             return nshape;
         }
         break;
+    case HDivFamily::EHDivOptimized:
+        {
+            int conCorrect = connect/2;
+            int res = connect % 2;
+            int nshape;
+            if (!fDuplicationActive){
+                return TPZShapeHDivOptimized<TSHAPE>::ComputeNConnectShapeF(connect,order);
+            } else {
+                nshape = TPZShapeHDivOptimized<TSHAPE>::ComputeNConnectShapeF(conCorrect,order);
+            }
+            if (res == 1){ 
+                nshape -= 1;
+            } else {
+                if (connect != 2*TSHAPE::NFacets){
+                    nshape = 1;
+                }
+            }
+            return nshape;   
+        }
+        break;
     
     default:
         return -1;
@@ -144,6 +165,10 @@ void TPZCompElHDivDuplConnects<TSHAPE>::InitMaterialData(TPZMaterialData &data)
     case HDivFamily::EHDivConstant:
         TPZShapeHDivConstant<TSHAPE>::Initialize(ids, orders, sideorient, data);
         nvec_shape = this->NShapeF();
+        break;
+    case HDivFamily::EHDivOptimized:
+        TPZShapeHDivOptimized<TSHAPE>::Initialize(ids, orders, sideorient, data);
+        nvec_shape = TPZShapeHDivOptimized<TSHAPE>::NShapeF(shapedata);
         break;
     
     default:

--- a/Mesh/pzelchdiv.cpp
+++ b/Mesh/pzelchdiv.cpp
@@ -21,6 +21,7 @@
 #include "tpzline.h"
 #include "tpztriangle.h"
 #include "TPZShapeHDiv.h"
+#include "TPZShapeHDivOptimized.h"
 #include "TPZShapeH1.h"
 #include "TPZShapeHDivConstant.h"
 #include "TPZShapeHCurlNoGrads.h"
@@ -255,7 +256,9 @@ int TPZCompElHDiv<TSHAPE>::NConnectShapeF(int connect, int order)const
     case HDivFamily::EHDivConstant:
         return TPZShapeHDivConstant<TSHAPE>::ComputeNConnectShapeF(connect,order);
         break;
-    
+    case HDivFamily::EHDivOptimized:
+        return TPZShapeHDivOptimized<TSHAPE>::ComputeNConnectShapeF(connect,order);
+        break;
     default:
         return -1;
         break;
@@ -879,7 +882,10 @@ void TPZCompElHDiv<TSHAPE>::InitMaterialData(TPZMaterialData &data)
         TPZShapeHDivConstant<TSHAPE>::Initialize(ids, orders, sideorient, data);
         nvec_shape = this->NShapeF();
         break;
-    
+    case HDivFamily::EHDivOptimized:
+        TPZShapeHDivOptimized<TSHAPE>::Initialize(ids, orders, sideorient, data);
+        nvec_shape = TPZShapeHDivOptimized<TSHAPE>::NShapeF(shapedata);
+        break;
     default:
         break;
     }
@@ -940,13 +946,14 @@ void TPZCompElHDiv<TSHAPE>::ComputeShape(TPZVec<REAL> &qsi, TPZMaterialData &dat
     case HDivFamily::EHDivStandard:
         TPZShapeHDiv<TSHAPE>::Shape(qsi, shapedata, phiMaster, data.divphi);
         break;
-
     case HDivFamily::EHDivConstant:
         phiMaster.Resize(TSHAPE::Dimension,nshape);
         data.divphi.Resize(nshape,1);
         TPZShapeHDivConstant<TSHAPE>::Shape(qsi, shapedata, phiMaster, data.divphi);
         break;
-
+    case HDivFamily::EHDivOptimized:
+        TPZShapeHDivOptimized<TSHAPE>::Shape(qsi, shapedata, phiMaster, data.divphi);
+        break;
     default:
         DebugStop();
         break;
@@ -992,13 +999,15 @@ void TPZCompElHDiv<TSHAPE>::ComputeShape(TPZVec<REAL> &qsi, TPZMaterialData &dat
         switch (fhdivfam)
         {
         case HDivFamily::EHDivStandard:
-                TPZShapeHDiv<TSHAPE>::Shape(qsifad, shapedata, phiMasterFad, divphiFad);
+            TPZShapeHDiv<TSHAPE>::Shape(qsifad, shapedata, phiMasterFad, divphiFad);
             break;
-
         case HDivFamily::EHDivConstant:
             phiMasterFad.Resize(TSHAPE::Dimension,nshape);
             divphiFad.Resize(nshape,1);
             TPZShapeHDivConstant<TSHAPE>::Shape(qsifad, shapedata, phiMasterFad, divphiFad);
+            break;
+        case HDivFamily::EHDivOptimized:
+            TPZShapeHDivOptimized<TSHAPE>::Shape(qsifad, shapedata, phiMasterFad, divphiFad);
             break;
 
         default:

--- a/Mesh/pzelchdivbound2.cpp
+++ b/Mesh/pzelchdivbound2.cpp
@@ -70,7 +70,7 @@ TPZIntelGen<TSHAPE>(mesh,gel,1), fSideOrient(1), fhdivfam(hdivfam){
 	this->fIntRule.SetOrder(order);
 
 
-    if (fhdivfam == HDivFamily::EHDivConstant) {
+    if (fhdivfam == HDivFamily::EHDivConstant || fhdivfam == HDivFamily::EHDivOptimized) {
         // For HDiv constant, polynomial order was compatibilized in connectorders, 
         // see TPZShapeHDivConstantBound<TSHAPE>::Initialize. So now we need to update
         // the number of shape functions and also the integration rule
@@ -407,6 +407,7 @@ void TPZCompElHDivBound2<TSHAPE>::InitMaterialData(TPZMaterialData &data)
         TPZShapeHDivBound<TSHAPE>::Initialize(id, connectorder, sideorient, data);
         break;
     case HDivFamily::EHDivConstant:
+    case HDivFamily::EHDivOptimized:
         TPZShapeHDivConstantBound<TSHAPE>::Initialize(id, connectorder, sideorient, data);
         break;
     
@@ -580,6 +581,7 @@ void TPZCompElHDivBound2<TSHAPE>::ComputeShape(TPZVec<REAL> &intpoint, TPZMateri
         }
         break;
     case HDivFamily::EHDivConstant:
+    case HDivFamily::EHDivOptimized:
         {
             data.phi.Resize(this->NShapeF(), 1);
             TPZShapeHDivConstantBound<TSHAPE>::Shape(intpoint, shapedata, data.phi);

--- a/Pre/TPZHDivApproxCreator.cpp
+++ b/Pre/TPZHDivApproxCreator.cpp
@@ -77,8 +77,8 @@ void TPZHDivApproxCreator::CheckSetupConsistency() {
         DebugStop();
     }
 
-    if(fHybridType == HybridizationType::ESemi && fHDivFam != HDivFamily::EHDivConstant){
-        std::cout << "The only HDiv space with available Semi hybridization is HDivConstant" << std::endl;
+    if(fHybridType == HybridizationType::ESemi && (fHDivFam != HDivFamily::EHDivConstant && fHDivFam != HDivFamily::EHDivOptimized)){
+        std::cout << "The only HDiv spaces with available Semi hybridization is HDivConstant and HDivOptimized" << std::endl;
         DebugStop();
     }
   

--- a/Pre/pzcreateapproxspace.cpp
+++ b/Pre/pzcreateapproxspace.cpp
@@ -537,7 +537,7 @@ void TPZCreateApproximationSpace::SetAllCreateFunctionsHDivDuplConnects(int dime
     fStyle = EHDiv;
     const HDivFamily &hdivfam = this->fhdivfam;
 
-    if (hdivfam != HDivFamily::EHDivConstant){
+    if (hdivfam != HDivFamily::EHDivConstant || hdivfam != HDivFamily::EHDivOptimized){
         std::cout << "HDiv Dupl Connects not implemented yet for this HDiv family!" << std::endl;
         DebugStop();
     }

--- a/Shape/CMakeLists.txt
+++ b/Shape/CMakeLists.txt
@@ -31,6 +31,7 @@ set(headers
     TPZShapeHDivBound.h
     TPZShapeHDivCollapsed.h
     TPZEnumApproxFamily.h
+    TPZShapeHDivOptimized.h
     )
 
 set(sources
@@ -55,6 +56,7 @@ set(sources
     TPZShapeHCurlNoGrads.cpp
     TPZShapeHDivBound.cpp
     TPZShapeHDivCollapsed.cpp
+    TPZShapeHDivOptimized.cpp
     )
 
 install(FILES ${headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Shape)

--- a/Shape/TPZEnumApproxFamily.h
+++ b/Shape/TPZEnumApproxFamily.h
@@ -2,7 +2,7 @@
 #define TPZENUMAPPROXFAMILY_H
 
 /// Enum stating which flavor of HDiv spaces is being used
-enum class HDivFamily {EHDivStandard,EHDivConstant,EHDivKernel};
+enum class HDivFamily {EHDivStandard,EHDivConstant,EHDivKernel,EHDivOptimized};
 
 /// Enum stating which flavor of H1 spaces is being used
 enum class H1Family {EH1Standard};

--- a/Shape/TPZShapeData.h
+++ b/Shape/TPZShapeData.h
@@ -46,7 +46,7 @@ public:
     /** @brief Prints the data in a format suitable for Mathematica */
     void PrintMathematica(std::ostream &out) const;    
 
-    static constexpr int MatDataNumPhi{60};
+    static constexpr int MatDataNumPhi{200};
     static constexpr int MatDataNumDir{81};
     static constexpr int MatDataDimSol{10};//TODO:Remove?
     static constexpr int MatDataNumSol{20};//TODO:Remove?

--- a/Shape/TPZShapeHDiv.cpp
+++ b/Shape/TPZShapeHDiv.cpp
@@ -178,7 +178,7 @@ void TPZShapeHDiv<TSHAPE>::ComputeVecandShape(TPZShapeData &data) {
     // VectorSide indicates the side associated with each vector entry
     TPZManVector<int64_t,27> FirstIndex(TSHAPE::NSides+1);
     // the first index of the shape functions
-    FirstShapeIndex(FirstIndex,scalarorder);
+    FirstShapeIndex(FirstIndex,data.fH1.fConnectOrders);
 
     int64_t nvec = VectorSides.NElements();
     count = 0;
@@ -378,14 +378,14 @@ void TPZShapeHDiv<TSHAPE>::Shape(const TPZVec<Fad<REAL>> &pt, TPZShapeData &data
 
 
 template<class TSHAPE>
-void TPZShapeHDiv<TSHAPE>::FirstShapeIndex(TPZVec<int64_t> &Index, int &scalarorders) {
+void TPZShapeHDiv<TSHAPE>::FirstShapeIndex(TPZVec<int64_t> &Index, const TPZVec<int> &scalarorders) {
     Index[0] = 0;
 
     for(int iside=0;iside<TSHAPE::NSides;iside++)
     {
         int sideorder = 1;
         if (iside >= TSHAPE::NCornerNodes) {
-            sideorder = scalarorders;
+            sideorder = scalarorders[iside-TSHAPE::NCornerNodes];
         }
         int temp = Index[iside] + TSHAPE::NConnectShapeF(iside,sideorder);
         Index[iside+1] = temp;

--- a/Shape/TPZShapeHDiv.h
+++ b/Shape/TPZShapeHDiv.h
@@ -32,7 +32,7 @@ struct TPZShapeHDiv
     
     static void IndexShapeToVec(TPZShapeData &data);
     
-    static void FirstShapeIndex(TPZVec<int64_t> &Index, int &scalarorders);
+    static void FirstShapeIndex(TPZVec<int64_t> &Index, const TPZVec<int> &scalarorders);
     
     static void FillOrderScalarShapeFunctions(const TPZVec<int> &connectorders, TPZVec<int> &scalarOrder);
     

--- a/Shape/TPZShapeHDivOptimized.cpp
+++ b/Shape/TPZShapeHDivOptimized.cpp
@@ -19,6 +19,83 @@ static TPZLogger logger("pz.shapehdiv");
 
 template <class TSHAPE>
 TPZShapeHDivOptimized<TSHAPE>::TPZShapeHDivOptimized() {}
+template <class TSHAPE>
+int TPZShapeHDivOptimized<TSHAPE>::NConnectShapeF(int connect, const TPZShapeData &shapedata)
+{
+    return shapedata.fHDiv.fNumConnectShape[connect];
+}
+
+template <class TSHAPE>
+int TPZShapeHDivOptimized<TSHAPE>::NShapeF(const TPZShapeData &shapedata)
+{
+    const int nconnect = shapedata.fHDiv.fNumConnectShape.size();
+    int nshape = 0;
+    for (int ic = 0; ic < nconnect; ic++)
+        nshape += shapedata.fHDiv.fNumConnectShape[ic];
+    return nshape;
+}
+
+template <class TSHAPE>
+int TPZShapeHDivOptimized<TSHAPE>::ComputeNConnectShapeF(int connect, int order)
+{
+#ifdef DEBUG
+    if (connect < 0 || connect > TSHAPE::NFacets)
+    {
+        DebugStop();
+    }
+#endif
+    MElementType thistype = TSHAPE::Type();
+
+    // For the facet connects, it should return the same number of functions as HDivConstant
+    // For the internal connect, it should return the same number of functions as HDiv Standard
+
+    if (thistype == EOned)
+    {
+        if (connect < 2)
+            return 0;
+        else
+            return order;
+    }
+    else if (thistype == ETriangle)
+    {
+        if (connect < TSHAPE::NFacets)
+            return (order + 1);
+        else
+            return (order + 1) * (order + 1) - 1;
+    }
+    else if (thistype == EQuadrilateral)
+    {
+        if (connect < TSHAPE::NFacets)
+            return (order + 1);
+        else
+            return 2 * order * (order + 1);
+    }
+    else if (thistype == ETetraedro)
+    {
+        if (connect < TSHAPE::NFacets)
+            return (order + 1) * (order + 2) / 2;
+        else
+            return order * (order + 2) * (order + 3) / 2;
+    }
+    else if (thistype == EPrisma)
+    {
+        if (connect == 0 || connect == 4)
+            return (order + 1) * (order + 2) / 2;
+        else if (connect < TSHAPE::NFacets)
+            return (order + 1) * (order + 1);
+        else
+            return order * order * (3 * order + 5) / 2 + 7 * order - 2;
+    }
+    else if (thistype == ECube)
+    {
+        if (connect < TSHAPE::NFacets)
+            return (order + 1) * (order + 1);
+        else
+            return 3 * order * (order + 1) * (order + 1);
+    }
+    DebugStop();
+    unreachable();
+}
 
 template struct TPZShapeHDivOptimized<pzshape::TPZShapeLinear>;
 

--- a/Shape/TPZShapeHDivOptimized.cpp
+++ b/Shape/TPZShapeHDivOptimized.cpp
@@ -126,6 +126,139 @@ void TPZShapeHDivOptimized<TSHAPE>::Initialize(const TPZVec<int64_t> &ids,
     }
 #endif
 }
+
+template <class TSHAPE>
+void TPZShapeHDivOptimized<TSHAPE>::Shape(const TPZVec<REAL> &pt, TPZShapeData &data, TPZFMatrix<REAL> &phi, TPZFMatrix<REAL> &divphi)
+{
+
+    constexpr int ncorner = TSHAPE::NCornerNodes;
+    constexpr int nsides = TSHAPE::NSides;
+    constexpr int dim = TSHAPE::Dimension;
+    constexpr int nfacets = TSHAPE::NFacets;
+    const int nedges = TSHAPE::NumSides(1);
+
+    if (phi.Rows() != dim || phi.Cols() != data.fHDiv.fSDVecShapeIndex.size())
+    {
+        phi.Resize(dim, data.fHDiv.fSDVecShapeIndex.size());
+        phi.Zero();
+    }
+    if (divphi.Rows() != data.fHDiv.fSDVecShapeIndex.size())
+    {
+        divphi.Resize(data.fHDiv.fSDVecShapeIndex.size(), 1);
+        divphi.Zero();
+    }
+
+    // Compute constant Hdiv functions
+    TPZFNMatrix<dim * nfacets, REAL> RT0phi(dim, nfacets);
+    TPZManVector<REAL, nfacets> RT0div(nfacets);
+    RT0phi.Zero();
+    RT0div.Fill(0.);
+    TSHAPE::ComputeConstantHDiv(pt, RT0phi, RT0div);
+
+    // For dim = 2, we use the gradient of H1 functions to compute the facet HDiv functions, while the internal functions come from the standard HDiv
+    if constexpr (dim == 2)
+    {
+        TPZShapeH1<TSHAPE>::Shape(pt, data, data.fH1.fPhi, data.fH1.fDPhi);
+
+        int count = 0;
+        int countKernel = ncorner;
+        // Edge functions
+        for (int i = 0; i < nedges; i++)
+        {
+            // RT0 Function
+            phi(0, count) = RT0phi(0, i) * data.fHDiv.fSideOrient[i];
+            phi(1, count) = RT0phi(1, i) * data.fHDiv.fSideOrient[i];
+            divphi(count, 0) = RT0div[i] * data.fHDiv.fSideOrient[i];
+            count++;
+
+            // Kernel Hdiv
+            for (int j = 1; j < data.fHDiv.fNumConnectShape[i]; j++)
+            {
+                phi(0, count) = -data.fH1.fDPhi(1, countKernel);
+                phi(1, count) = data.fH1.fDPhi(0, countKernel);
+                count++;
+                countKernel++;
+            }
+        }
+
+        // Internal functions
+        const int nfacetfunc = count;
+        for (int i = nfacetfunc; i < data.fHDiv.fSDVecShapeIndex.size(); i++)
+        {
+            auto it = data.fHDiv.fSDVecShapeIndex[i];
+            int vecindex = it.first;
+            int scalindex = it.second;
+            divphi(i, 0) = 0.;
+            for (int d = 0; d < dim; d++)
+            {
+                phi(d, i) = data.fH1.fPhi(scalindex, 0) * data.fHDiv.fMasterDirections(d, vecindex);
+                divphi(i, 0) += data.fH1.fDPhi(d, scalindex) * data.fHDiv.fMasterDirections(d, vecindex);
+            }
+            count++;
+        }
+    }
+    // For dim = 3, the facet functions come from HCurlNoGrads, while the internal functions are computed according to standard HDiv
+    else if constexpr (dim == 3)
+    {
+        divphi.Zero();
+        int nshapehcurl = TPZShapeHCurlNoGrads<TSHAPE>::NHCurlShapeF(data);
+        int nshape = NShapeF(data);
+
+        TPZFNMatrix<200, REAL> phiAux(dim, nshapehcurl), curlPhiAux(3, nshapehcurl);
+        phiAux.Zero();
+        curlPhiAux.Zero();
+
+        TPZShapeHCurlNoGrads<TSHAPE>::Shape(pt, data, phiAux, curlPhiAux);
+
+        int count = 0;
+        int countKernel = nedges;
+
+        // Face functions
+        for (int i = 0; i < nfacets; i++)
+        {
+            // RT0 Function
+            for (auto d = 0; d < dim; d++)
+            {
+                phi(d, count) = RT0phi(d, i) * data.fHDiv.fSideOrient[i];
+            }
+            divphi(count, 0) = RT0div[i] * data.fHDiv.fSideOrient[i];
+            count++;
+
+            // Kernel HDiv functions
+            for (int k = 0; k < data.fHCurl.fNumConnectShape[nedges + i]; k++)
+            {
+                for (auto d = 0; d < dim; d++)
+                {
+                    phi(d, count) = curlPhiAux(d, countKernel);
+                }
+                countKernel++;
+                count++;
+            }
+        }
+        // Internal functions
+        const int nfacetfunc = count;
+        TPZShapeH1<TSHAPE>::Shape(pt, data, data.fH1.fPhi, data.fH1.fDPhi);
+        for (int i = nfacetfunc; i < data.fHDiv.fSDVecShapeIndex.size(); i++)
+        {
+            auto it = data.fHDiv.fSDVecShapeIndex[i];
+            int vecindex = it.first;
+            int scalindex = it.second;
+            divphi(i, 0) = 0.;
+            for (int d = 0; d < dim; d++)
+            {
+                phi(d, i) = data.fH1.fPhi(scalindex, 0) * data.fHDiv.fMasterDirections(d, vecindex);
+                divphi(i, 0) += data.fH1.fDPhi(d, scalindex) * data.fHDiv.fMasterDirections(d, vecindex);
+            }
+            count++;
+        }
+        if (count != nshape)
+            DebugStop();
+    }
+    else
+    {
+        DebugStop();
+    }
+}
 template <class TSHAPE>
 int TPZShapeHDivOptimized<TSHAPE>::NConnectShapeF(int connect, const TPZShapeData &shapedata)
 {

--- a/Shape/TPZShapeHDivOptimized.cpp
+++ b/Shape/TPZShapeHDivOptimized.cpp
@@ -1,0 +1,33 @@
+#include "TPZShapeHDivOptimized.h"
+#include "TPZShapeH1.h"
+#include "TPZShapeHCurl.h"
+#include "pzshapelinear.h"
+#include "pzshapetriang.h"
+#include "pzshapequad.h"
+#include "pzshapetetra.h"
+#include "pzshapecube.h"
+#include "pzshapeprism.h"
+#include "pzshapepiram.h"
+#include "pzgeoel.h"
+#include "pzgnode.h"
+#include "TPZShapeData.h"
+#include "pzlog.h"
+
+#ifdef PZ_LOG
+static TPZLogger logger("pz.shapehdiv");
+#endif
+
+template <class TSHAPE>
+TPZShapeHDivOptimized<TSHAPE>::TPZShapeHDivOptimized() {}
+
+template struct TPZShapeHDivOptimized<pzshape::TPZShapeLinear>;
+
+template struct TPZShapeHDivOptimized<pzshape::TPZShapeTriang>;
+
+template struct TPZShapeHDivOptimized<pzshape::TPZShapeQuad>;
+
+template struct TPZShapeHDivOptimized<pzshape::TPZShapeTetra>;
+
+template struct TPZShapeHDivOptimized<pzshape::TPZShapeCube>;
+
+template struct TPZShapeHDivOptimized<pzshape::TPZShapePrism>;

--- a/Shape/TPZShapeHDivOptimized.h
+++ b/Shape/TPZShapeHDivOptimized.h
@@ -1,0 +1,41 @@
+/**
+ * @file
+ * @brief Contains TPZShapeHDivOptimized class which implements HDiv shape using HCurlNoGrads functions on the facet and HDiv standard interior functions
+ * @author Giovane Avancini
+ */
+
+#pragma once
+
+#include "pzreal.h"
+#include "pzvec.h"
+#include "pztrnsform.h"
+#include "pzeltype.h"
+#include "TPZShapeHCurlNoGrads.h"
+#include "TPZShapeHDiv.h"
+
+template <class T>
+class TPZFMatrix;
+
+class TPZShapeData;
+
+template <class TSHAPE>
+struct TPZShapeHDivOptimized : public TPZShapeHDiv<TSHAPE>, TPZShapeHCurlNoGrads<TSHAPE>
+{
+    TPZShapeHDivOptimized();
+
+    static void Initialize(const TPZVec<int64_t> &ids,
+                           const TPZVec<int> &connectorders,
+                           const TPZVec<int> &sideorient, TPZShapeData &data);
+
+    static void Shape(const TPZVec<REAL> &pt, TPZShapeData &data, TPZFMatrix<REAL> &phi, TPZFMatrix<REAL> &divphi);
+
+    static void Shape(const TPZVec<Fad<REAL>> &pt, TPZShapeData &data, TPZFMatrix<Fad<REAL>> &phi, TPZFMatrix<Fad<REAL>> &divphi);
+
+    static int ComputeNConnectShapeF(int connect, int order);
+
+    static int NConnectShapeF(int connect, const TPZShapeData &data);
+
+    static int NShapeF(const TPZShapeData &shapedata);
+
+    static void CheckH1ConnectOrder(const TPZVec<int> &connectorders, TPZVec<int> &H1Orders);
+};

--- a/UnitTest_PZ/TestMesh/TestHDivConstant.cpp
+++ b/UnitTest_PZ/TestMesh/TestHDivConstant.cpp
@@ -144,6 +144,9 @@ static void IntegralNormal();
 template <class TSHAPE>
 static void CheckConnectOrders(int kFacet);
 
+template <class TSHAPE>
+void TestHDivOptimized(int kFacet);
+
 /** @brief Checks if the rank of the matrix composed by the L2 product of Hdiv shape functions is equal to the number of shape functions
     Denoting by
     - phi_i : basis functions of the refered space
@@ -171,13 +174,26 @@ TEST_CASE("integral_normal", "[hdivconstant_tests]")
 TEMPLATE_TEST_CASE("Connect order compatibility", "[hdivconstant_tests]",
                    (pzshape::TPZShapeTriang),
                    (pzshape::TPZShapeQuad),
-                   (pzshape::TPZShapeCube),
-                   (pzshape::TPZShapeTetra))
+                   (pzshape::TPZShapeTetra),
+                   (pzshape::TPZShapeCube))
 {
     int kFacet = GENERATE(2, 3, 4);
     SECTION("kFacet=" + std::to_string(kFacet))
     {
         CheckConnectOrders<TestType>(kFacet);
+    }
+}
+
+TEMPLATE_TEST_CASE("Test New HDiv Shape", "[hdivconstant_tests]",
+                   (pzshape::TPZShapeTriang),
+                   (pzshape::TPZShapeQuad),
+                   (pzshape::TPZShapeTetra),
+                   (pzshape::TPZShapeCube))
+{
+    int kFacet = GENERATE(1, 2, 3, 4);
+    SECTION("kFacet=" + std::to_string(kFacet))
+    {
+        TestHDivOptimized<TestType>(kFacet);
     }
 }
 
@@ -575,6 +591,8 @@ void RotateGeomesh(TPZGeoMesh *gmesh, REAL CounterClockwiseAngle, int &Axis)
 }
 
 #include "TPZShapeHDivConstant.h"
+#include "TPZShapeHDiv.h"
+#include "TPZShapeHDivOptimized.h"
 
 template <class TSHAPE>
 void IntegralNormal()
@@ -714,6 +732,108 @@ void CheckConnectOrders(int kFacet)
                     std::cout << "val1 " << val1 << " val3 " << val3 << std::endl;
                 }
                 REQUIRE((val1 - val3) == Catch::Approx(0.));
+            }
+        }
+    }
+}
+
+template <class TSHAPE>
+void TestHDivOptimized(int kFacet)
+{
+    TPZMaterialDataT<REAL> dataHDiv, dataHDivOptimized, dataHDivConst;
+    TPZManVector<int64_t, 27> ids(TSHAPE::NCornerNodes, 0);
+    for (int i = 0; i < TSHAPE::NCornerNodes; i++)
+    {
+        ids[i] = i;
+    }
+    TPZManVector<int, 27> sideorient(TSHAPE::NFacets, 1);
+    TPZManVector<int, 27> orders(TSHAPE::NFacets + 1, kFacet);
+    TPZShapeHDiv<TSHAPE> hdiv_std;
+    TPZShapeHDivOptimized<TSHAPE> hdiv_opt;
+    TPZShapeHDivConstant<TSHAPE> hdiv_const;
+    hdiv_std.Initialize(ids, orders, sideorient, dataHDiv);
+    hdiv_opt.Initialize(ids, orders, sideorient, dataHDivOptimized);
+    hdiv_const.Initialize(ids, orders, sideorient, dataHDivConst);
+    int nshape_std = hdiv_std.NShapeF(dataHDiv);
+    int nshape_opt = hdiv_opt.NShapeF(dataHDivOptimized);
+    int nshape_const = hdiv_const.NHDivShapeF(dataHDivConst);
+    int nfacet_std = 0, nfacet_opt = 0, nfacet_const = 0;
+    for (int i = 0; i < TSHAPE::NFacets; i++)
+    {
+        nfacet_std += hdiv_std.NConnectShapeF(i, dataHDiv);
+        nfacet_opt += hdiv_opt.NConnectShapeF(i, dataHDivOptimized);
+        nfacet_const += hdiv_const.NConnectShapeF(i, dataHDivConst);
+    }
+    int nvol_std = hdiv_std.NConnectShapeF(TSHAPE::NFacets, dataHDiv);
+    int nvol_opt = hdiv_opt.NConnectShapeF(TSHAPE::NFacets, dataHDivOptimized);
+    int nvol_const = hdiv_const.NConnectShapeF(TSHAPE::NFacets, dataHDivConst);
+
+    auto hdiv_std_order = dataHDiv.fHDiv.fConnectOrders;
+    auto hdiv_opt_order = dataHDivOptimized.fHDiv.fConnectOrders;
+    auto hdiv_const_order = dataHDivConst.fHDiv.fConnectOrders;
+
+    auto hdiv_std_shape = dataHDiv.fHDiv.fNumConnectShape;
+    auto hdiv_opt_shape = dataHDivOptimized.fHDiv.fNumConnectShape;
+    auto hdiv_const_shape = dataHDivConst.fHDiv.fNumConnectShape;
+
+    CAPTURE(orders,hdiv_std_order,hdiv_opt_order, hdiv_const_order, hdiv_std_shape, hdiv_opt_shape, hdiv_const_shape);
+    
+    REQUIRE(nvol_std == nvol_opt);
+    REQUIRE(nfacet_opt == nfacet_const);
+    REQUIRE(nfacet_std + nvol_std == nshape_std);
+    REQUIRE(nfacet_opt + nvol_opt == nshape_opt);
+    
+    for (int i = 0; i < TSHAPE::NFacets+1; i++)
+    {
+        REQUIRE(hdiv_std_order[i] == orders[i]);
+        REQUIRE(hdiv_opt_order[i] == orders[i]);
+        REQUIRE(hdiv_std_shape[i] == hdiv_std.NConnectShapeF(i, dataHDiv));
+        REQUIRE(hdiv_opt_shape[i] == hdiv_opt.NConnectShapeF(i, dataHDivOptimized));
+        REQUIRE(hdiv_const_shape[i] == hdiv_const.NConnectShapeF(i, dataHDivConst));
+    }
+
+    // Evaluate the shape functions at the integration point.
+    // The volume shape functions must be equal for hdiv_std and hdiv_opt at every integration point.
+    // The facet shape functions must be equal for hdiv_opt and hdiv_const at every integration point.
+    constexpr int dim = TSHAPE::Dimension;
+    TPZFMatrix<REAL> phi_std(dim, nshape_std, 0.), phi_opt(dim, nshape_opt, 0.), phi_const(dim, nshape_const, 0.);
+    TPZFNMatrix<60, REAL> div_std(nshape_std, 1), div_opt(nshape_opt, 1), div_const(nshape_const, 1);
+    typename TSHAPE::IntruleType intrule(3);
+    int nintpoints = intrule.NPoints();
+    TPZManVector<REAL, 3> point(dim, 0.);
+    for (int ip = 0; ip < nintpoints; ip++)
+    {
+        REAL weight;
+        intrule.Point(ip, point, weight);
+        hdiv_std.Shape(point, dataHDiv, phi_std, div_std);
+        hdiv_opt.Shape(point, dataHDivOptimized, phi_opt, div_opt);
+        hdiv_const.Shape(point, dataHDivConst, phi_const, div_const);
+
+        for (int i = 0; i < nvol_std; i++)
+        {
+            for (int j = 0; j < dim; j++)
+            {
+                REAL val_std = phi_std(j, i + nfacet_std);
+                REAL val_opt = phi_opt(j, i + nfacet_opt);
+                if (abs(val_std-val_opt) > 1.e-10)
+                {
+                    std::cout << "val_std " << val_std << " val_opt " << val_opt << std::endl;
+                }
+                REQUIRE((val_std - val_opt) == Catch::Approx(0.));
+            }
+        }
+
+        for (int i = 0; i < nfacet_const; i++)
+        {
+            for (int j = 0; j < dim; j++)
+            {
+                REAL val_const = phi_const(j, i);
+                REAL val_opt = phi_opt(j, i);
+                if (abs(val_const - val_opt) > 1.e-10)
+                {
+                    std::cout << "val_const " << val_const << " val_opt " << val_opt << std::endl;
+                }
+                REQUIRE((val_const - val_opt) == Catch::Approx(0.));
             }
         }
     }


### PR DESCRIPTION
This PR introduces a new class of HDiv shapes called `TPZShapeHDivOptimized`. It combines the advantages of `TPZShapeHDivConstant` and `TPZShapeHDiv`, where the facet functions are constructed using `HCurlNoGrads` plus the RT0, while the internal functions are built using `HDivStandard`.

To use the proposed shape, one needs to call `ApproxSpace().SetHDivFamily(HDivFamily::EHDivOptimized)`;