### PR TITLE
Structmatrix changes

### DIFF
--- a/Matrix/pzblock.cpp
+++ b/Matrix/pzblock.cpp
@@ -191,10 +191,12 @@ int64_t TPZBlock::Index(const int64_t bRow, const int r) const
 {
     auto MaxBlocks = fBlock.NElements();
     int64_t row(r);
+#ifdef PZDEBUG
     if(bRow <0 || bRow >= MaxBlocks || row < 0 || row >= fBlock[bRow].dim) {
         PZError << __PRETTY_FUNCTION__ <<" indexes out of range\n";
         DebugStop();
     }
+#endif
     row += fBlock[bRow].pos;
     return row;
 }

--- a/Mesh/TPZElementMatrixT.cpp
+++ b/Mesh/TPZElementMatrixT.cpp
@@ -268,10 +268,11 @@ void TPZElementMatrixT<TVar>::ApplyConstraints(){
 			// loop over the nodes from which dfn depends
 			TPZConnect::TPZDependBase *dep = dfn->FirstDepend();
 
-      TPZFNMatrix<50,TVar> depmat;
       TPZFNMatrix<150,TVar> fulldepmat;
 			while(dep) {
-        dep->FillDepMatrix(depmat);
+        auto dept = dynamic_cast<TPZConnect::TPZDepend<TVar>*>(dep);
+        if(!dept){DebugStop();}
+        const auto &depmat = dept->GetDepMatrix();
         
 				int64_t depnodeindex = dep->fDepConnectIndex;
 				// look for the index where depnode is found

--- a/Mesh/TPZElementMatrixT.cpp
+++ b/Mesh/TPZElementMatrixT.cpp
@@ -156,7 +156,7 @@ void TPZElementMatrixT<TVar>::ApplyConstraints(){
 	totalnodes = this->fConstrConnect.NElements();
 	
 	// compute the list of nodes and their proper order of processing
-	TPZVec<int> DependenceOrder;
+	TPZManVector<int,400> DependenceOrder;
 	// this->fConstrNod, totalnodes and DependenceOrder
 	// are initialized using codes documented above
 	BuildDependencyOrder(this->fConstrConnect,DependenceOrder,*this->fMesh);

--- a/Mesh/TPZElementMatrixT.cpp
+++ b/Mesh/TPZElementMatrixT.cpp
@@ -401,7 +401,10 @@ void TPZElementMatrixT<TVar>::PermuteGather(TPZVec<int64_t> &permute)
                 int64_t jblsize = fBlock.Size(jbl);
                 for (int64_t idf=0; idf<iblsize; ++idf) {
                     for (int64_t jdf=0; jdf<jblsize; ++jdf) {
-                        fMat.at(fBlock.at(ibl,jbl,idf,jdf)) = cp.fMat.at(cp.fBlock.at(permute[ibl],permute[jbl],idf,jdf));
+                      const auto [my_r,my_c] = fBlock.at(ibl,jbl,idf,jdf);
+                      const auto [cp_r,cp_c] =
+                        cp.fBlock.at(permute[ibl],permute[jbl],idf,jdf);
+                      fMat.g(my_r,my_c) = cp.fMat.g(cp_r,cp_c);
                     }
                 }
             }

--- a/Mesh/TPZElementMatrixT.h
+++ b/Mesh/TPZElementMatrixT.h
@@ -75,6 +75,7 @@ struct TPZElementMatrixT : public TPZElementMatrix {
     TPZBlock & ConstrBlock() override{
         return fConstrBlock;
     }
+  void SetUserAllocMat(TPZFMatrix<TVar> *mat){fUserAllocMat=mat;}
     /** @brief Pointer to a blocked matrix object*/
 	TPZFNMatrix<1000, TVar> fMat;
     /** @brief Block structure associated with fMat*/
@@ -83,6 +84,7 @@ struct TPZElementMatrixT : public TPZElementMatrix {
 	TPZFNMatrix<1000, TVar> fConstrMat;
     /** @brief Block structure associated with fConstrMat*/
 	TPZBlock fConstrBlock;
+  TPZFMatrix<TVar> *fUserAllocMat{nullptr};
 };
 
 extern template class TPZElementMatrixT<STATE>;

--- a/Mesh/pzcompel.cpp
+++ b/Mesh/pzcompel.cpp
@@ -244,11 +244,12 @@ void TPZCompEl::LoadSolutionInternal() {
             int numstate = dfn->NState(); //numstate eh fornecida pelo connect
             //         int numshape = nvar/numstate;
             TPZConnect::TPZDependBase *dep = dfn->FirstDepend();
-            TPZFNMatrix<50,TVar> depmat;
             int64_t blpos = block.Position(bl);
             for(iv=0; iv<nvar; iv++) MeshSol(blpos+iv, 0) = 0.;
             while(dep) {
-                dep->FillDepMatrix(depmat);
+                auto dept = dynamic_cast<TPZConnect::TPZDepend<TVar>*>(dep);
+                if(!dept){DebugStop();}
+                const auto &depmat = dept->GetDepMatrix();
                 int64_t depconindex = dep->fDepConnectIndex;
                 TPZConnect &depcon = Mesh()->ConnectVec()[depconindex];
                 int64_t depseq = depcon.SequenceNumber();

--- a/Mesh/pzcondensedcompel.cpp
+++ b/Mesh/pzcondensedcompel.cpp
@@ -9,6 +9,7 @@
 #include "pzelementgroup.h"
 #include "pzcmesh.h"
 #include "TPZElementMatrixT.h"
+#include "TPZMatCombinedSpaces.h"
 #include "TPZNullMaterial.h"
 #include "TPZNullMaterialCS.h"
 #ifdef PZ_LOG
@@ -367,19 +368,19 @@ void TPZCondensedCompElT<TVar>::CalcStiff(TPZElementMatrixT<TVar> &ekglob,
                                           TPZElementMatrixT<TVar> &efglob)
 {
 
-    auto* material =
+    auto* material_ss =
         dynamic_cast<TPZMatSingleSpaceT<TVar> *>(this->Material());
-    if(!material){
-        PZError << "Error at " << __PRETTY_FUNCTION__ << " this->Material() == NULL\n";
-        int matid = Reference()->MaterialId();
-        PZError << "Material Id which is missing = " << matid << std::endl;
-        ekglob.Reset();
-        efglob.Reset();
-        return;
-    }
-    auto *nullmat = dynamic_cast<TPZNullMaterial<TVar> *>(material);
-    auto *nullmatcs = dynamic_cast<TPZNullMaterialCS<TVar> *>(material);
-    if(nullmat || nullmatcs)
+    auto* material_cs =
+        dynamic_cast<TPZMatCombinedSpacesT<TVar> *>(this->Material());
+    /*
+      apparently you can have a condensed group that will not have an
+      associated material but still needs to compute a stiff matrix
+     */
+    const bool has_mat = material_ss || material_cs;
+    
+    auto *nullmat = dynamic_cast<TPZNullMaterial<TVar> *>(material_ss);
+    auto *nullmatcs = dynamic_cast<TPZNullMaterialCS<TVar> *>(material_cs);
+    if(has_mat && (nullmat || nullmatcs))
     {
         ekglob.Reset();
         efglob.Reset();

--- a/Mesh/pzcondensedcompel.cpp
+++ b/Mesh/pzcondensedcompel.cpp
@@ -9,7 +9,8 @@
 #include "pzelementgroup.h"
 #include "pzcmesh.h"
 #include "TPZElementMatrixT.h"
-
+#include "TPZNullMaterial.h"
+#include "TPZNullMaterialCS.h"
 #ifdef PZ_LOG
 static TPZLogger logger("pz.mesh.tpzcondensedcompel");
 #endif
@@ -365,6 +366,28 @@ template<class TVar>
 void TPZCondensedCompElT<TVar>::CalcStiff(TPZElementMatrixT<TVar> &ekglob,
                                           TPZElementMatrixT<TVar> &efglob)
 {
+
+    auto* material =
+        dynamic_cast<TPZMatSingleSpaceT<TVar> *>(this->Material());
+    if(!material){
+        PZError << "Error at " << __PRETTY_FUNCTION__ << " this->Material() == NULL\n";
+        int matid = Reference()->MaterialId();
+        PZError << "Material Id which is missing = " << matid << std::endl;
+        ekglob.Reset();
+        efglob.Reset();
+        return;
+    }
+    auto *nullmat = dynamic_cast<TPZNullMaterial<TVar> *>(material);
+    auto *nullmatcs = dynamic_cast<TPZNullMaterialCS<TVar> *>(material);
+    if(nullmat || nullmatcs)
+    {
+        ekglob.Reset();
+        efglob.Reset();
+        ekglob.fType = TPZElementMatrix::EK;
+        efglob.fType = TPZElementMatrix::EF;
+        return;
+    }
+    
     if(fKeepMatrix == false)
     {
         fKeepMatrix = true;

--- a/Mesh/pzcondensedcompel.cpp
+++ b/Mesh/pzcondensedcompel.cpp
@@ -554,7 +554,7 @@ void TPZCondensedCompElT<TVar>::CalcStiff(TPZElementMatrixT<TVar> &ekglob,
     int64_t dim = ek.fMat.Rows();
     for (int64_t i=0; i<dim ; ++i) {
         for (int64_t j=0; j<dim ; ++j) {
-            fCondensed(i,j) = ek.fMat(i,j);
+            fCondensed(i,j) = ek.fMat.g(i,j);
         }
     }
     
@@ -611,9 +611,9 @@ void TPZCondensedCompElT<TVar>::CalcStiff(TPZElementMatrixT<TVar> &ekglob,
     }
 #endif
     for (int64_t i=0; i<dim; i++) {
-        efglob.fMat(i,0) = F1.GetVal(i,0);
+        efglob.fMat(i,0) = F1.g(i,0);
         for (int64_t j=0; j<dim; j++) {
-            ekglob.fMat(i,j) = K11.GetVal(i,j);
+            ekglob.fMat.g(i,j) = K11.g(i,j);
         }
     }
     

--- a/Mesh/pzconnect.cpp
+++ b/Mesh/pzconnect.cpp
@@ -166,7 +166,7 @@ TPZConnect::TPZDepend<TVar> *TPZConnect::AddDependency(int64_t myindex, int64_t 
 		connect->fNext = fDependList;
 		fDependList = connect;
 	} else {
-		TPZFNMatrix<50,TVar> temp(isize,jsize), temp2(isize,jsize);
+		TPZFNMatrix<50,TVar> temp(isize,jsize);
 		int i,j;
 		for(i=0; i<isize; i++) for(j=0; j<jsize; j++) temp(i,j) = depmat(ipos+i,jpos+j);
 		
@@ -180,7 +180,9 @@ TPZConnect::TPZDepend<TVar> *TPZConnect::AddDependency(int64_t myindex, int64_t 
 		}
 		
 
-    connect->FillDepMatrix(temp2);
+    auto dept = dynamic_cast<TPZConnect::TPZDepend<TVar>*>(connect);
+    if(!dept){DebugStop();}
+    const auto &temp2 = dept->GetDepMatrix();
 		temp -= temp2;
 		REAL val = Norm(temp);
 		if(val > 1.e-6) {

--- a/Mesh/pzconnect.h
+++ b/Mesh/pzconnect.h
@@ -84,8 +84,6 @@ public:
     virtual TPZDependBase* Clone() = 0;
     virtual TPZDependBase* CreateEmptyInstance() = 0;
     virtual void PrintMat(std::ostream &out) = 0;
-    virtual void FillDepMatrix(TPZFMatrix<STATE> & mat) = 0;
-    virtual void FillDepMatrix(TPZFMatrix<CSTATE> & mat) = 0;
 		/**
 		 * @brief Copy a depend data structure to a clone depend in a clone mesh
 		 * @param orig original depend to be copied
@@ -106,30 +104,10 @@ public:
     int DepRows() override {return fDepMatrix.Rows();}
     int DepCols() override {return fDepMatrix.Cols();}
 
-    void FillDepMatrix(TPZFMatrix<CSTATE> &mat) override{
-      if constexpr (std::is_same_v<TVar,CSTATE>){
-        mat = fDepMatrix;
-      }else{
-        const auto nrows = DepRows();
-        const auto ncols = DepCols();
-        mat.Resize(nrows,ncols);
-        for(int i= 0; i < nrows; i++){
-          for(int j= 0; j < ncols; j++){
-            mat(i,j) = fDepMatrix(i,j);
-          }
-        }
-      }
+    TPZFMatrix<TVar> const &GetDepMatrix(){
+      return fDepMatrix;
     }
-
-    void FillDepMatrix(TPZFMatrix<STATE> &mat) override{
-      if constexpr (std::is_same_v<TVar,STATE>){
-        mat = fDepMatrix;
-      }else{
-        PZError<<__PRETTY_FUNCTION__
-               <<"\nIncompatible types.Aborting...\n";
-        DebugStop();
-      }
-    }
+    
 
     TPZDepend<TVar>* CreateEmptyInstance() override{
       return new TPZDepend<TVar>;

--- a/Mesh/pzelementgroup.cpp
+++ b/Mesh/pzelementgroup.cpp
@@ -283,7 +283,9 @@ void TPZElementGroup::CalcStiffInternal(TPZElementMatrixT<TVar> &ek,TPZElementMa
             int icindex = ekloc.fConnect[ic];
             int ibldest = locindex[icindex];
             for (int idf = 0; idf<iblsize; idf++) {
-                ef.fMat.at(ef.fBlock.at(ibldest,0,idf,0)) += efloc.fMat.at(efloc.fBlock.at(ic,0,idf,0));
+                const auto [my_r,my_c] = ef.fBlock.at(ibldest,0,idf,0);
+                const auto [loc_r,loc_c] = efloc.fBlock.at(ic,0,idf,0);
+                ef.fMat.g(my_r,my_c) += efloc.fMat.g(loc_r,loc_c);
             }
             for (int jc = 0; jc<nelcon; jc++) {
                 int jblsize = ekloc.fBlock.Size(jc);
@@ -291,7 +293,9 @@ void TPZElementGroup::CalcStiffInternal(TPZElementMatrixT<TVar> &ek,TPZElementMa
                 int jbldest = locindex[jcindex];
                 for (int idf = 0; idf<iblsize; idf++) {
                     for (int jdf=0; jdf<jblsize; jdf++) {
-                        ek.fMat.at(ek.fBlock.at(ibldest,jbldest,idf,jdf)) += ekloc.fMat.at(ekloc.fBlock.at(ic,jc,idf,jdf));
+                        const auto [my_r,my_c] = ek.fBlock.at(ibldest,jbldest,idf,jdf);
+                        const auto [loc_r,loc_c] = ekloc.fBlock.at(ic,jc,idf,jdf);
+                        ek.fMat.g(my_r,my_c) += ekloc.fMat.g(loc_r,loc_c);
                     }
                 }
             }

--- a/Mesh/pzelementgroup.h
+++ b/Mesh/pzelementgroup.h
@@ -273,6 +273,14 @@ public:
 	}
     
 
+    /**
+	 * @brief Computes the element stifness matrix and right hand side
+	 * @param ek element stiffness matrix
+	 * @param ef element load vector
+	 */
+	virtual void CalcStiff(TPZElementMatrixT<CSTATE> &ek,TPZElementMatrixT<CSTATE> &ef) override{
+        CalcStiffInternal<CSTATE>(ek,ef);
+    }
 	/**
 	 * @brief Computes the element stifness matrix and right hand side
 	 * @param ek element stiffness matrix

--- a/Mesh/pzelmat.h
+++ b/Mesh/pzelmat.h
@@ -103,7 +103,7 @@ struct TPZElementMatrix {
 	/** @brief Vector of all nodes connected to the element*/
 	TPZStack<int64_t> fConstrConnect;
 	
-	TPZManVector<int64_t> fDestinationIndex, fSourceIndex;
+	TPZManVector<int64_t,300> fDestinationIndex, fSourceIndex;
 };
 
 #endif

--- a/Mesh/pzinterpolationspace.cpp
+++ b/Mesh/pzinterpolationspace.cpp
@@ -7,6 +7,7 @@
 #include "TPZMaterial.h"
 #include "TPZMatSingleSpace.h"
 #include "TPZMatErrorSingleSpace.h"
+#include "TPZNullMaterial.h"
 #include "TPZMatLoadCases.h"
 #include "TPZMaterialDataT.h"
 #include "TPZBndCond.h"
@@ -415,6 +416,15 @@ void TPZInterpolationSpace::CalcStiffInternal(TPZElementMatrixT<TVar> &ek, TPZEl
         PZError << "Material Id which is missing = " << matid << std::endl;
         ek.Reset();
         ef.Reset();
+        return;
+    }
+    auto *nullmat = dynamic_cast<TPZNullMaterial<TVar> *>(material);
+    if(nullmat)
+    {
+        ek.Reset();
+        ef.Reset();
+        ek.fType = TPZElementMatrix::EK;
+        ef.fType = TPZElementMatrix::EF;
         return;
     }
     

--- a/Pre/TPZHDivApproxCreator.cpp
+++ b/Pre/TPZHDivApproxCreator.cpp
@@ -974,8 +974,9 @@ void TPZHDivApproxCreator::PartitionDependMatrix(TPZCompMesh *cmesh){
         if(c.HasDependency()){
             // std::cout << "Need to partition the dependency matrix." << std::endl;
             auto *ptr = c.FirstDepend();
-            TPZFNMatrix<200,STATE> depmat;
-            ptr->FillDepMatrix(depmat);
+            auto dept = dynamic_cast<TPZConnect::TPZDepend<STATE>*>(ptr);
+            if(!dept){DebugStop();}
+            const auto &depmat = dept->GetDepMatrix();
             while(ptr) {
                 int64_t cIndex_old1 = iCon;
                 int64_t cIndex_old2 = ptr->fDepConnectIndex;
@@ -1135,11 +1136,18 @@ void TPZHDivApproxCreator::GroupDependMatrix(TPZCompMesh *cmesh){
 
                 if (!dep00 || !dep01 || !dep10 || !dep11) DebugStop();
 
-                TPZFNMatrix<144,REAL> matdep00,matdep11,matdep10,matdep01;
-                dep00->FillDepMatrix(matdep00);
-                dep01->FillDepMatrix(matdep01);
-                dep10->FillDepMatrix(matdep10);
-                dep11->FillDepMatrix(matdep11);
+                auto GetDepMat= [](TPZConnect::TPZDependBase *dep)
+                -> TPZFMatrix<STATE> const &{
+                    auto dept = dynamic_cast<TPZConnect::TPZDepend<STATE>*>(dep);
+                    if(!dept){DebugStop();}
+                    return dept->GetDepMatrix();
+                };
+
+
+                const auto &matdep00 = GetDepMat(dep00);
+                const auto &matdep01 = GetDepMat(dep01);
+                const auto &matdep10 = GetDepMat(dep10);
+                const auto &matdep11 = GetDepMat(dep11);
                 
                 int rows = matdep00.Rows() + matdep11.Rows();
                 int cols = matdep00.Cols() + matdep11.Cols();

--- a/StrMatrix/TPZSkylineNSymStructMatrix.cpp
+++ b/StrMatrix/TPZSkylineNSymStructMatrix.cpp
@@ -37,10 +37,12 @@ int TPZSkylineNSymStructMatrix<TVar,TPar>::ClassId() const{
 
 #include "pzstrmatrixot.h"
 #include "pzstrmatrixflowtbb.h"
-
+#include "TPZStructMatrixOMPorTBB.h"
 template class TPZSkylineNSymStructMatrix<STATE,TPZStructMatrixOR<STATE>>;
 template class TPZSkylineNSymStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZSkylineNSymStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
+template class TPZSkylineNSymStructMatrix<STATE,TPZStructMatrixOMPorTBB<STATE>>;
 template class TPZSkylineNSymStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
 template class TPZSkylineNSymStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
 template class TPZSkylineNSymStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;
+template class TPZSkylineNSymStructMatrix<CSTATE,TPZStructMatrixOMPorTBB<CSTATE>>;

--- a/StrMatrix/TPZSpStructMatrix.cpp
+++ b/StrMatrix/TPZSpStructMatrix.cpp
@@ -222,13 +222,16 @@ void TPZSpStructMatrix<TVar,TPar>::Write(TPZStream& buf, int withclassid) const{
 
 #include "pzstrmatrixot.h"
 #include "pzstrmatrixflowtbb.h"
+#include "TPZStructMatrixOMPorTBB.h"
 
 template class TPZSpStructMatrix<STATE,TPZStructMatrixOR<STATE>>;
 template class TPZSpStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZSpStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
+template class TPZSpStructMatrix<STATE,TPZStructMatrixOMPorTBB<STATE>>;
 
 #ifndef USING_EIGEN
 template class TPZSpStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
 template class TPZSpStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
 template class TPZSpStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;
+template class TPZSpStructMatrix<CSTATE,TPZStructMatrixOMPorTBB<CSTATE>>;
 #endif

--- a/StrMatrix/TPZStrMatParInterface.cpp
+++ b/StrMatrix/TPZStrMatParInterface.cpp
@@ -1,17 +1,25 @@
 #include "TPZStrMatParInterface.h"
 #include "pzbasematrix.h"
 #include "TPZStructMatrix.h"
+#include "TPZSimpleTimer.h"
 
 TPZBaseMatrix *TPZStrMatParInterface::CreateAssemble(
     TPZBaseMatrix &rhs) {
     this->InitCreateAssemble();
 
     TPZStructMatrix *myself = dynamic_cast<TPZStructMatrix*>(this);
-    TPZBaseMatrix *stiff = myself->Create();
+    TPZBaseMatrix *stiff{nullptr};
+    {
+        TPZSimpleTimer timer("Create matrix");
+        stiff = myself->Create();
+    }
     
     const int64_t cols = MAX(1, rhs.Cols());
     if(ComputeRhs()) rhs.Redim(myself->EquationFilter().NEqExpand(), cols);
-    Assemble(*stiff, rhs);
+    {
+        TPZSimpleTimer timer("Assemble");
+        Assemble(*stiff, rhs);
+    }
     this->EndCreateAssemble(stiff);
 #ifdef PZ_LOG2
     if (loggerel.isDebugEnabled()) {

--- a/StrMatrix/TPZStructMatrixOMPorTBB.cpp
+++ b/StrMatrix/TPZStructMatrixOMPorTBB.cpp
@@ -108,7 +108,6 @@ void TPZStructMatrixOMPorTBB<TVar>::Assemble(TPZBaseMatrix & mat, TPZBaseMatrix 
 
     const auto &equationFilter =
             (dynamic_cast<TPZStructMatrix *>(this))->EquationFilter();
-    ass_stiff.start();
 
     if (equationFilter.IsActive()) {
         int64_t neqcondense = equationFilter.NActiveEquations();
@@ -274,7 +273,7 @@ void TPZStructMatrixOMPorTBB<TVar>::Serial_Assemble(TPZBaseMatrix & mat, TPZBase
 
         }
     }
-#ifdef PZDEBUG
+#ifdef HUGEDEBUG
     VerifyStiffnessSum(mat);
 #endif
 #ifdef USING_MKL
@@ -337,7 +336,7 @@ void TPZStructMatrixOMPorTBB<TVar>::MultiThread_Assemble(TPZBaseMatrix & mat, TP
         }
     }
 
-#ifdef PZDEBUG
+#ifdef HUGEDEBUG
     VerifyStiffnessSum(mat);
 #endif
 }

--- a/StrMatrix/TPZStructMatrixOMPorTBB.cpp
+++ b/StrMatrix/TPZStructMatrixOMPorTBB.cpp
@@ -318,7 +318,9 @@ int TPZStructMatrixOMPorTBB<TVar>::GetNumberColors(){
 
 template<class TVar>
 void TPZStructMatrixOMPorTBB<TVar>::MultiThread_Assemble(TPZBaseMatrix & mat, TPZBaseMatrix & rhs){
+#ifdef USING_MKL
     mkl_domain_set_num_threads(1, MKL_DOMAIN_BLAS);
+#endif    
     //mkl_set_num_threads_local(1);
     if (fShouldColor){
         if (fUsingTBB){
@@ -336,8 +338,9 @@ void TPZStructMatrixOMPorTBB<TVar>::MultiThread_Assemble(TPZBaseMatrix & mat, TP
             AssemblingUsingOMPbutNotColoring(mat,rhs);
         }
     }
-
+#ifdef USING_MKL
     mkl_domain_set_num_threads(0, MKL_DOMAIN_BLAS);
+#endif
 #ifdef HUGEDEBUG
     VerifyStiffnessSum(mat);
 #endif

--- a/StrMatrix/TPZStructMatrixOMPorTBB.cpp
+++ b/StrMatrix/TPZStructMatrixOMPorTBB.cpp
@@ -246,7 +246,7 @@ void TPZStructMatrixOMPorTBB<TVar>::Serial_Assemble(TPZBaseMatrix & mat, TPZBase
 
         el->CalcStiff(ek, ef);
 
-        if(!el->HasDependency()) {
+        if(!ek.HasDependency()) {
             ek.ComputeDestinationIndices();
             equationFilter.Filter(ek.fSourceIndex, ek.fDestinationIndex);
             //            TPZSFMatrix<TVar> test(stiffness);
@@ -514,7 +514,7 @@ void TPZStructMatrixOMPorTBB<TVar>::ComputingCalcstiffAndAssembling(TPZBaseMatri
     const auto &equationFilter =
             (dynamic_cast<TPZStructMatrix *>(this))->EquationFilter();
 
-    if(!el->HasDependency()) {
+    if(!ek.HasDependency()) {
         ek.ComputeDestinationIndices();
         equationFilter.Filter(ek.fSourceIndex, ek.fDestinationIndex);
 

--- a/StrMatrix/TPZStructMatrixOMPorTBB.h
+++ b/StrMatrix/TPZStructMatrixOMPorTBB.h
@@ -94,7 +94,8 @@ protected:
 
     void AssemblingUsingOMPbutNotColoring(TPZBaseMatrix & mat, TPZBaseMatrix & rhs );
 
-    void ComputingCalcstiffAndAssembling(TPZBaseMatrix & mat,TPZBaseMatrix & rhs,TPZCompEl *el);
+    void CalcStiffAndAssemble(TPZBaseMatrix & mat,TPZBaseMatrix & rhs,TPZCompEl *el,
+                              TPZElementMatrixT<TVar> &ek, TPZElementMatrixT<TVar> &ef);
 
 public:
     void OrderElements();

--- a/StrMatrix/TPZStructMatrixOMPorTBB.h
+++ b/StrMatrix/TPZStructMatrixOMPorTBB.h
@@ -61,6 +61,10 @@ public:
     void Assemble(TPZBaseMatrix & mat, TPZBaseMatrix & rhs) override;
     void Assemble(TPZBaseMatrix & rhs) override;
 
+    /** @brief Sets buffer size to be preallocated for a TPZFMatrix provided
+        to TPZElementMatrixT<TVar> for the dependency matrix, useful
+    when dealing with large dependencies to avoid repeated dynamic allocation*/
+    void BufferSizeForUserMatrix(const int sz){fUserMatSize=sz;}
 public:
     int ClassId() const override;
     void Read(TPZStream &buf, void *context) override;
@@ -127,6 +131,9 @@ protected:
     int fSomeoneIsSleeping;
 
     std::atomic<int64_t> fCurrentIndex;
+
+    /// user allocated mat for TPZElementMatrixT
+    int fUserMatSize{0};
 };
 
 extern template class TPZStructMatrixOMPorTBB<STATE>;

--- a/StrMatrix/pzskylstrmatrix.cpp
+++ b/StrMatrix/pzskylstrmatrix.cpp
@@ -50,11 +50,14 @@ void TPZSkylineStructMatrix<TVar,TPar>::Write(TPZStream& buf, int withclassid) c
 
 #include "pzstrmatrixot.h"
 #include "pzstrmatrixflowtbb.h"
+#include "TPZStructMatrixOMPorTBB.h"
 
 template class TPZSkylineStructMatrix<STATE,TPZStructMatrixOR<STATE>>;
 template class TPZSkylineStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZSkylineStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
+template class TPZSkylineStructMatrix<STATE,TPZStructMatrixOMPorTBB<STATE>>;
 
 template class TPZSkylineStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
 template class TPZSkylineStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
 template class TPZSkylineStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;
+template class TPZSkylineStructMatrix<CSTATE,TPZStructMatrixOMPorTBB<CSTATE>>;

--- a/StrMatrix/pzstrmatrixor.cpp
+++ b/StrMatrix/pzstrmatrixor.cpp
@@ -273,7 +273,7 @@ TPZStructMatrixOR<TVar>::Serial_Assemble(TPZBaseMatrix & stiff_base, TPZBaseMatr
             } else {
                 sout << "Stiffness for computational element without associated geometric element index " << el->Index() << "\n";
             }
-            if(el->HasDependency()){
+            if(ek.HasDependency()){
                 ek.fConstrMat.Print(sout);
                 ef.fConstrMat.Print(sout);
             }else{
@@ -431,7 +431,7 @@ TPZStructMatrixOR<TVar>::Serial_Assemble(TPZBaseMatrix & rhs_base) {
         if(loggerel.isDebugEnabled())
         {
             std::stringstream sout;
-            if(el->HasDependency()){
+            if(ef.HasDependency()){
                 ef.fConstrMat.Print(sout);
             }else{
                 ef.fMat.Print(sout);
@@ -607,7 +607,7 @@ TPZStructMatrixOR<TVar>::ThreadData::ThreadWork(void *datavoid) {
 #endif
 
 
-        if (!el->HasDependency()) {
+        if (!ek->HasDependency()) {
             ek->ComputeDestinationIndices();
 
             if (data->fStruct->HasRange()) {
@@ -646,7 +646,7 @@ TPZStructMatrixOR<TVar>::ThreadData::ThreadWork(void *datavoid) {
             } else {
                 sout << "Stiffness for computational element without associated geometric element index " << el->Index() << "\n";
             }
-            if(el->HasDependency()){
+            if(ek->HasDependency()){
                 ek->fConstrMat.Print(sout);
                 if(computeRhs){ef->fConstrMat.Print(sout);}
             }else{


### PR DESCRIPTION
This branch reflects several modifications needed for efficiently running a problem in which elements had large dependency matrices.

Most of the changes are associated with the `TPZStructMatrixOMPorTBB` class.
- Several fixes allowing it to be used with complex problems
- Several optimisations
- Correctly checking for dependencies, skipping invalid elements/elements with `TPZNullMaterial`
- Allows for using a preallocated buffer for large dependency matrices

Other affected classes were mostly optimised. Exceptions are:
- `TPZElementMatrixT<T>` allows for usage of buffer for large dependency matrix