### PR TITLE
Mem leaks

### DIFF
--- a/External/pzmetis.cpp
+++ b/External/pzmetis.cpp
@@ -165,6 +165,8 @@ void TPZMetis::Resequence(TPZVec<int64_t> &perm, TPZVec<int64_t> &inverseperm) {
         perm[i] = inversepermint[i];
         inverseperm[i] = permint[i];
     }
+    delete [] permint;
+    delete [] inversepermint;
         
 #endif
 }

--- a/Matrix/TPZSYSMPPardiso.cpp
+++ b/Matrix/TPZSYSMPPardiso.cpp
@@ -171,6 +171,10 @@ void TPZSYsmpMatrixPardiso<TVar>::MultAdd(const TPZFMatrix<TVar> &x,const TPZFMa
 					CheckStatus(status);
 				}
 			}
+
+      status = mkl_sparse_destroy(A);
+      CheckStatus(status);
+      
 			return;
 		}else{
       //not a valid MKL type

--- a/Matrix/TPZYSMPPardiso.cpp
+++ b/Matrix/TPZYSMPPardiso.cpp
@@ -190,6 +190,9 @@ this->MultAddChecks(x,y,z,alpha,beta,opt);
 					CheckStatus(status);
 				}
 			}
+
+      status = mkl_sparse_destroy(A);
+      CheckStatus(status);
 			return;
 		}else{
       //unsupported type

--- a/Matrix/pzfmatrix.h
+++ b/Matrix/pzfmatrix.h
@@ -828,8 +828,8 @@ inline int TPZFMatrix<TVar>::Redim(const int64_t newRows,const int64_t newCols) 
 
 template<class TVar>
 inline int TPZFMatrix<TVar>::Zero() {
-    int64_t size = this->fRow * this->fCol * sizeof(TVar);
-    memset(((void*)this->fElem),'\0',size);
+    int64_t size = this->fRow * this->fCol;
+    std::fill(this->fElem, this->fElem+size, TVar());
     this->fDecomposed = ENoDecompose;
     return( 1 );
 }

--- a/StrMatrix/pzstrmatrixot.cpp
+++ b/StrMatrix/pzstrmatrixot.cpp
@@ -541,6 +541,11 @@ void TPZStructMatrixOT<TVar>::MultiThread_Assemble(TPZBaseMatrix & mat_base, TPZ
         LOGPZ_DEBUG(loggerCheck,sout.str())
     }
 #endif
+
+    for(itr=0; itr<numthreads; itr++)
+    {
+        delete allthreadsD[itr];
+    }
 }
 
 template<class TVar>


### PR DESCRIPTION
This PR fixes a few memory leaks found by means of Address Sanitizer.

By far, the most relevant one was the method `TPZFMatrix<T>::Zero()` that would cause memory leak when  `T` was a non-trivial type, such as `FAD<double>`.  With #204 ,  this method was being called in `TPZFMatrix<T>::MultAdd`, which caused a giant leak in moderately large problems.