### PR TITLE
Minor fixes to work with GFEM

### DIFF
--- a/Analysis/TPZAnalysis.cpp
+++ b/Analysis/TPZAnalysis.cpp
@@ -1393,6 +1393,7 @@ void TPZAnalysis::PrintVectorByElement(std::ostream &out, TPZFMatrix<STATE> &vec
         if (hasgeometry) {
             out << " Gel " << gel->Index() << " matid " << gel->MaterialId() << " Center " << xcenter << std::endl;
         }
+        TPZManVector<REAL,3> xco(3);
         for (ic = 0; ic<nc; ic++) {
             TPZManVector<STATE> connectsol;
             int64_t cindex = cel->ConnectIndex(ic);
@@ -1407,7 +1408,15 @@ void TPZAnalysis::PrintVectorByElement(std::ostream &out, TPZFMatrix<STATE> &vec
                     connectsol[i] = 0.;
                 }
             }
-            out << ic << " index " << cindex << " values " << connectsol << std::endl;
+            if(gel && ic < gel->NCornerNodes()) {
+                gel->NodePtr(ic)->GetCoordinates(xco);
+                out << "co " << xco << " ic ";
+            }
+
+            if(connectsol.size()) {
+                std::streamsize ss = std::cout.precision();
+                out << ic << " index " << cindex << " values " << std::fixed << std::setprecision(15) << connectsol << std::setprecision(ss) << std::endl;
+            }
         }
     }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,20 +387,11 @@ if(USING_UMFPACK)
 		  target_compile_definitions(pz PUBLIC USING_UMFPACK)
 endif(USING_UMFPACK)
 
-option(USING_EIGEN "Whether the EIGEN3 library will be linked in" OFF)
+option(USING_EIGEN "Whether the EIGEN library will be linked in" OFF)
 if(USING_EIGEN)
-		  find_package(Eigen3 CONFIG)
-		  target_link_libraries(pz PUBLIC Eigen3::Eigen)
-		  target_compile_definitions(pz PUBLIC USING_EIGEN)
+  include(cmake/EnableEigen.cmake)
+  enable_eigen(pz)
 endif(USING_EIGEN)
-
-
-
-
-
-
-
-
 
 include(cmake/InstallPZConfigFile.cmake)
 

--- a/Material/DarcyFlow/TPZDarcyFlow.cpp
+++ b/Material/DarcyFlow/TPZDarcyFlow.cpp
@@ -182,6 +182,11 @@ int TPZDarcyFlow::NSolutionVariables(int var) const {
 
 void TPZDarcyFlow::Solution(const TPZMaterialDataT<STATE> &data, int var, TPZVec<STATE> &solOut) {
 
+    if(data.fShapeType == TPZMaterialData::EEmpty) {
+        solOut.Resize(NSolutionVariables(var));
+        solOut.Fill(0.);
+        return;
+    }
     switch (var) {
         case 1: {
             // Solution/Pressure

--- a/Material/Elasticity/TPZElasticity2D.h
+++ b/Material/Elasticity/TPZElasticity2D.h
@@ -22,6 +22,7 @@ class TPZElasticity2D : public TPZMatBase<STATE,
                                           TPZMatErrorSingleSpace<STATE>,
                                           TPZMatLoadCases<STATE>>
 {
+public:
     using TBase = TPZMatBase<STATE,
                              TPZMatSingleSpaceT<STATE>,
                              TPZMatErrorSingleSpace<STATE>,
@@ -42,6 +43,15 @@ public :
 	TPZElasticity2D(int id, STATE E, STATE nu, STATE fx, STATE fy, int planestress = 1);
     
     TPZElasticity2D(int id);
+
+    TPZElasticity2D(const TPZElasticity2D &copy) : TBase(copy), fE_def(copy.fE_def), fnu_def(copy.fnu_def),
+    fElasticity(copy.fElasticity), ff(copy.ff), fEover21PlusNu_def(copy.fEover21PlusNu_def),
+    fEover1MinNu2_def(copy.fEover1MinNu2_def), fPreStressXX(copy.fPreStressXX),
+    fPreStressYY(copy.fPreStressYY), fPreStressXY(copy.fPreStressXY), fPreStressZZ(copy.fPreStressZZ),
+    fPlaneStress(copy.fPlaneStress)
+    {
+        
+    }
 
     /** @name Elasticity */
     /** @brief Set elasticity parameters */

--- a/Material/Elasticity/TPZElasticity3D.cpp
+++ b/Material/Elasticity/TPZElasticity3D.cpp
@@ -416,8 +416,8 @@ void TPZElasticity3D::ContributeVecShape(const TPZMaterialDataT<STATE> &data,
                                          TPZFMatrix<STATE> &ek, TPZFMatrix<STATE> &ef)
 {
     const TPZFMatrix<REAL> & dphi = data.dphix;
-	const TPZFMatrix<REAL> & phi = data.fH1.fPhi;
-	
+	const TPZFMatrix<REAL> & phi = data.phi;
+	// dphi.Print("dphi");
 	int phc = phi.Cols();
 	int efc = ef.Cols();
 	
@@ -511,8 +511,8 @@ void TPZElasticity3D::ContributeVecShapeBC(const TPZMaterialDataT<STATE> & data,
                                            TPZFMatrix<STATE> & ef,
                                            TPZBndCondT<STATE> &bc)
 {
-    const TPZFMatrix<REAL> & phi = data.fH1.fPhi;
-    
+    const TPZFMatrix<REAL> & phi = data.phi;
+    // phi.Print("phi");
 	const REAL BIGNUMBER  = TPZMaterial::fBigNumber;
     
 	int phc = phi.Cols();
@@ -540,11 +540,12 @@ void TPZElasticity3D::ContributeVecShapeBC(const TPZMaterialDataT<STATE> & data,
 		}
 		case 1:// Neumann condition
         {
-            for (in = 0; in < phc; in++)
+            for (int il = 0; il <fNumLoadCases; il++)
             {
-                for (int il = 0; il <fNumLoadCases; il++)
+                const auto v2 = bcLoadCases->GetBCRhsVal(il);
+                // std::cout << "v2 = " << v2 << "\n";
+                for (in = 0; in < phc; in++)
                 {
-                    const auto v2 = bcLoadCases->GetBCRhsVal(il);
                     ef(in,il) += weight * ( v2[0]*phi(0,in) + v2[1]*phi(1,in) + v2[2]*phi(2,in) );
                 }
             }
@@ -835,8 +836,19 @@ int TPZElasticity3D::NSolutionVariables(int var) const {
 void TPZElasticity3D::Solution(const TPZMaterialDataT<STATE> &data,
                                int var,TPZVec<STATE> &Solout) {
 	const auto &Sol = data.sol[this->fPostProcIndex];
-    const auto &DSol = data.dsol[this->fPostProcIndex];
+    auto &DSol = data.dsol[this->fPostProcIndex];
     const auto &axes = data.axes;
+    if(DSol.Rows() !=3 || DSol.Cols() != 3) DebugStop();
+    // if(data.fShapeType == TPZMaterialData::EVecShape){
+    //     TPZFNMatrix<9,STATE> DSolXY(3,3);
+    //     for(int i = 0; i<3; i++) {
+    //         for(int j = 0; j<3; j++) {
+    //             DSolXY(i,j) = DSol(i*3+j,0);
+    //         }
+    //     }
+    //     DSol = DSolXY;
+    //     DSol.Print("DSol");
+    // }
     TPZFNMatrix<9,STATE> DSolXY(3,3);
     TPZAxesTools<STATE>::Axes2XYZ(DSol, DSolXY, axes);
 	if(var == TPZElasticity3D::EDisplacement) {

--- a/Material/TPZMatLoadCases.cpp
+++ b/Material/TPZMatLoadCases.cpp
@@ -90,6 +90,11 @@ const TPZVec<TVar>& TPZMatLoadCasesBC<TVar>::GetBCRhsVal(int i) const
     if (valVecSize == 0){
         auto tmp =
             dynamic_cast<const TPZBndCondT<TVar>*>(this);
+        if(!tmp){
+            PZError<<__PRETTY_FUNCTION__;
+            PZError<<"\nERROR: Invalid reference for creating BC.\nAborting...\n";
+            DebugStop();
+        }
         return tmp->Val2();        
     }else{
         return fBCRhsValVec[i];

--- a/Matrix/TPZEigenSparseMatrix.h
+++ b/Matrix/TPZEigenSparseMatrix.h
@@ -10,7 +10,7 @@
 #include "pz_config.h"
 #include "pzmatrix.h"
 #include "pzfmatrix.h"
-#include "TPZYSMPMatrix.h"
+#include "TPZSYSMPMatrix.h"
 #include <Eigen/Sparse>
 #include <Eigen/Dense>
 
@@ -27,7 +27,7 @@
  * Defines operations on general sparse matrices stored in the (old) Yale Sparse Matrix Package format.
  */
 template<class TVar>
-class TPZEigenSparseMatrix : public TPZFYsmpMatrix<TVar> {
+class TPZEigenSparseMatrix : public TPZSYsmpMatrix<TVar> {
     
     public :
     typedef Eigen::SparseMatrix<TVar,0,int64_t> SpMat; // declares a column-major sparse matrix type of double
@@ -35,14 +35,14 @@ class TPZEigenSparseMatrix : public TPZFYsmpMatrix<TVar> {
     
     typedef Eigen::Map<SpMat> EigenSparse;
     typedef Eigen::Map<SpMatInt> EigenSparseInt;
-    typedef Eigen::SimplicialLLT<EigenSparse> EigenCholesky;
+    typedef Eigen::SimplicialLLT<SpMat> EigenCholesky;
     
-    typedef Eigen::SparseLU<EigenSparse> EigenLU;
+    typedef Eigen::SparseLU<SpMat> EigenLU;
     
 #if defined(MACOSX) && defined(USEACCELERATESUPPORT)
     typedef Eigen::AccelerateLDLT<SpMatInt,Eigen::Lower | Eigen::Symmetric> EigenLDLT;
 #else
-    typedef Eigen::SimplicialLDLT<EigenSparse> EigenLDLT;
+    typedef Eigen::SimplicialLDLT<SpMat> EigenLDLT;
 #endif
     
 
@@ -57,13 +57,18 @@ public:
     TPZEigenSparseMatrix();
     TPZEigenSparseMatrix(const int64_t rows,const int64_t cols );
     TPZEigenSparseMatrix(const TPZEigenSparseMatrix<TVar>&) = default;
+    TPZEigenSparseMatrix(const TPZSYsmpMatrix<TVar>&copy) : TPZSYsmpMatrix<TVar>(copy) {
+
+    }
     TPZEigenSparseMatrix(TPZEigenSparseMatrix<TVar>&&) = default;
     
     
     TPZEigenSparseMatrix &operator=(const TPZEigenSparseMatrix<TVar> &copy) = default;
     TPZEigenSparseMatrix &operator=(TPZEigenSparseMatrix<TVar> &&copy) = default;
     
-    inline TPZEigenSparseMatrix<TVar>*NewMatrix() const override {return new TPZEigenSparseMatrix<TVar>();}
+    inline TPZEigenSparseMatrix<TVar>*NewMatrix() const override {
+        return new TPZEigenSparseMatrix<TVar>();
+        }
     CLONEDEF(TPZEigenSparseMatrix)
     
     virtual ~TPZEigenSparseMatrix();

--- a/Matrix/TPZYSMPMatrix.cpp
+++ b/Matrix/TPZYSMPMatrix.cpp
@@ -137,6 +137,12 @@ int TPZFYsmpMatrix<TVar>::PutVal(const int64_t row, const int64_t col, const TVa
     if(!flag) 
     {
 		cout << "TPZFYsmpMatrix::PutVal: Non existing position on sparse matrix: line = " << row << " column " << col << endl;
+		std::cout << "Columns registered ";
+		for(k=fIA[row];k<fIA[row+1];k++){
+			std::cout << fJA[k] << " ";
+		}
+		std::cout << std::endl;
+
 		DebugStop();
 		return 0;
     }

--- a/Matrix/pzbasematrix.h
+++ b/Matrix/pzbasematrix.h
@@ -156,7 +156,11 @@ public:
 
   /** @brief decompose the system of equations acording to the decomposition
    * scheme */
-    virtual int Decompose(const DecomposeType dt) = 0;
+    virtual int Decompose(const DecomposeType dt) {
+      std::cout << "TPZBaseMatrix::Decompose is not implemented\n";
+      DebugStop();
+      return 0;
+    }
 
   /** @brief It prints the matrix data in a MatrixFormat Rows X Cols */
   virtual void Print(const char *name, std::ostream &out = std::cout ,const MatrixOutputFormat form = EFormatted) const = 0;

--- a/Matrix/pzmatred.cpp
+++ b/Matrix/pzmatred.cpp
@@ -170,6 +170,7 @@ template<class TVar, class TSideMatrix>
 void TPZMatRed<TVar,TSideMatrix>::SetSolver(TPZAutoPointer<TPZMatrixSolver<TVar> > solver)
 {
 	fK00=solver->Matrix();
+    if(fK00->Rows() != fDim0) DebugStop();
 	fSolver = solver;
     this->fSymProp = fK00->GetSymmetry();
 }

--- a/Matrix/pzmatrix.h
+++ b/Matrix/pzmatrix.h
@@ -619,11 +619,11 @@ protected:
   virtual void CheckTypeCompatibility(const TPZMatrix<TVar>*A,
                                       const TPZMatrix<TVar>*B)const;
   /** @brief Number of entries storaged in the Matrix*/
-  virtual int64_t Size() const = 0;
+  virtual int64_t Size() const {DebugStop(); return -1;}
   /** @{ */
   /** @brief Pointer to the beginning of the storage of the matrix*/
-  virtual TVar* &Elem() = 0;
-  virtual const TVar* Elem() const = 0;
+  virtual TVar* &Elem() { DebugStop(); static TVar* t{nullptr}; return t; }
+  virtual const TVar* Elem() const { DebugStop(); return nullptr;}
   /** @} */
 	/**
 	 * @brief Is an auxiliar method used by MultiplyAdd

--- a/Mesh/pzcondensedcompel.cpp
+++ b/Mesh/pzcondensedcompel.cpp
@@ -323,12 +323,12 @@ void TPZCondensedCompElT<TVar>::Resequence()
     
 
     
-    fCondensed.SetSolver(autostep);
     if(fKeepMatrix == true)
     {
 //        fCondensed.Redim(nint+next,nint);
         fCondensed.Redim(fNumTotalEqs,fNumInternalEqs);
     }
+    fCondensed.SetSolver(autostep);
 }
 
 /// Assemble the stiffness matrix in locally kept datastructure

--- a/Mesh/pzgeoelside.h
+++ b/Mesh/pzgeoelside.h
@@ -273,6 +273,8 @@ public:
 	 * @note Third improved version */
 	void SideTransform3(TPZGeoElSide neighbour,TPZTransform<> &t);
 	
+	/// @brief Insert neighbour in the connectivity loop
+	/// @param neighbour will be my direct neighbour
 	void SetConnectivity(const TPZGeoElSide &neighbour) const;
     
 	/** @brief This method inserts the element/side and all lowerdimension sides into the connectivity loop */
@@ -285,6 +287,7 @@ public:
     void InsertConnectivity(TPZGeoElSide &neighbour, const TPZVec<int> &mapsides);
 
     /// Remove the element/side from the connectivity loop
+	// the neighbour of the element/side will be undefined
 	void RemoveConnectivity();
 	
 	static void BuildConnectivities(TPZVec<TPZGeoElSide> &elvec, TPZVec<TPZGeoElSide> &neighvec);

--- a/Mesh/pzinterpolationspace.cpp
+++ b/Mesh/pzinterpolationspace.cpp
@@ -142,6 +142,7 @@ void TPZInterpolationSpace::ReallyComputeSolutionT(TPZMaterialDataT<TVar>& data)
     const TPZFMatrix<REAL> &phi = data.phi;
     const TPZFMatrix<REAL> &dphix = data.dphix;
     const TPZFMatrix<REAL> &axes = data.axes;
+	const int dim = axes.Rows();
     TPZSolVec<TVar> &sol = data.sol;
     TPZGradSolVec<TVar> &dsol = data.dsol;
 	const int nstate = this->Material()->NStateVariables();
@@ -157,28 +158,60 @@ void TPZInterpolationSpace::ReallyComputeSolutionT(TPZMaterialDataT<TVar>& data)
     for (int is = 0; is<numbersol; is++) {
         sol[is].Resize(solVecSize);
         sol[is].Fill(0.);
-        dsol[is].Redim(dphix.Rows(), solVecSize);
-        dsol[is].Zero();
-    }	
-	int64_t iv = 0;
-	for(int in=0; in<ncon; in++) {
-		TPZConnect *df = &Connect(in);
-		const int64_t dfseq = df->SequenceNumber();
-		const int dfvar = block.Size(dfseq);
-		const int64_t pos = block.Position(dfseq);
-		for(int jn=0; jn<dfvar; jn++) {
-            for (int64_t is=0; is<numbersol; is++) {
-                sol[is][iv%nstate] +=
-                    (TVar)phi.Get(iv/nstate,0)*MeshSol(pos+jn,is);
-                for(auto d=0; d<dphix.Rows(); d++){
-                    dsol[is](d,iv%nstate) +=
-                        (TVar)dphix.Get(d,iv/nstate)*MeshSol(pos+jn,is);
-                }
-            }
-			iv++;
+		if(data.fShapeType == TPZMaterialData::EScalarShape) {
+	        dsol[is].Redim(dphix.Rows(), solVecSize);
+		} else if(data.fShapeType == TPZMaterialData::EVecShape) {
+			dsol[is].Redim(dim, solVecSize);
 		}
+        dsol[is].Zero();
+    }
+	if(data.fShapeType == TPZMaterialData::EScalarShape) {
+		int64_t iv = 0;
+		for(int in=0; in<ncon; in++) {
+			TPZConnect *df = &Connect(in);
+			const int64_t dfseq = df->SequenceNumber();
+			const int dfvar = block.Size(dfseq);
+			const int64_t pos = block.Position(dfseq);
+			for(int jn=0; jn<dfvar; jn++) {
+				for (int64_t is=0; is<numbersol; is++) {
+					sol[is][iv%nstate] +=
+						(TVar)phi.Get(iv/nstate,0)*MeshSol(pos+jn,is);
+					for(auto d=0; d<dphix.Rows(); d++){
+						dsol[is](d,iv%nstate) +=
+							(TVar)dphix.Get(d,iv/nstate)*MeshSol(pos+jn,is);
+					}
+				}
+				iv++;
+			}
+		}
+	} else if(data.fShapeType == TPZMaterialData::EVecShape) {
+		int64_t iv = 0;
+		for(int in=0; in<ncon; in++) {
+			TPZConnect *df = &Connect(in);
+			const int64_t dfseq = df->SequenceNumber();
+			const int dfvar = block.Size(dfseq);
+			const int64_t pos = block.Position(dfseq);
+			// loop over the multiplying coefficients of the connect dfvar = nshape*nstate
+			// but for each one of those there is a separate phi, dphix
+			for(int jn=0; jn<dfvar; jn++) {
+				for (int64_t is=0; is<numbersol; is++) {
+					auto meshsol = MeshSol(pos+jn,is);
+					for(int ist = 0; ist < nstate; ist++) {
+						sol[is][ist] += (TVar)phi(ist,iv)*MeshSol(pos+jn,is);
+						for(int d = 0; d < dim; d++) {
+							dsol[is](d,ist) += (TVar)dphix(d+ist*dim,iv)*MeshSol(pos+jn,is);
+						}
+					}
+				}
+				iv++;
+			}
+		}
+		if(iv != phi.Cols()) {
+			DebugStop();
+		}
+	} else {
+		DebugStop();
 	}
-	
 }//method
 
 

--- a/Post/TPZVTKGenerator.cpp
+++ b/Post/TPZVTKGenerator.cpp
@@ -92,6 +92,7 @@ void ComputeFieldAtEl(TPZCompEl *cel,
       //position will change depending on field dimension
       auto pos = init_pos[i] + fdim*iv;
       sol.Resize(fdim);
+      sol.Fill(0.0);
       graphel.Solution(ip, field.Id(), sol);
 
       /**TPZPostProcEl<TVar>::Solution might resize the sol array

--- a/Pre/TPZAcademicGeoMesh.cpp
+++ b/Pre/TPZAcademicGeoMesh.cpp
@@ -464,17 +464,8 @@ int TPZAcademicGeoMesh::AddBoundaryElements(TPZGeoMesh *gmesh)
                 continue;
             }
             TPZManVector<REAL,2> xi(2,0.);
-            //gelside.CenterPoint(xi);
-            TPZFNMatrix<6,REAL> axes(2,3);
-            TPZFNMatrix<4,REAL> jac(2,2),jacinv(2,2);
-            REAL detjac;
-            gelside.Jacobian(xi, jac, axes, detjac, jacinv);
-            TPZManVector<REAL,3> x(3,0.);
-            //gelside.X(xi, x);
             TPZManVector<REAL,3> normal(3);
-            normal[0] = axes(0,1)*axes(1,2)-axes(0,2)*axes(1,1);
-            normal[1] = -axes(0,0)*axes(1,2)+axes(0,2)*axes(1,0);
-            normal[2] = axes(0,0)*axes(1,1)-axes(0,1)*axes(1,0);
+            gelside.Normal(xi, normal);
             REAL tol = 1.e-6;
             REAL xmin = 1., xmax = 0.;
             int numfound = 0;

--- a/Pre/TPZGmshReader.cpp
+++ b/Pre/TPZGmshReader.cpp
@@ -350,6 +350,7 @@ void TPZGmshReader::ReadElements4(std::istream &read)
                     if (!m_read_undefined_physical_tag_elements) {
                         continue; // not adding elements without physical identifier
                     }
+                    std::cout << "Physical identifier " << physical_identifier << " with dim " << entity_dim << " not found in the physical tag list" << std::endl;
                 }
 
                 // std::cout << "Creating el for tag " << gmshPhysicalTagTemp <<

--- a/Pre/pzcreateapproxspace.cpp
+++ b/Pre/pzcreateapproxspace.cpp
@@ -537,7 +537,7 @@ void TPZCreateApproximationSpace::SetAllCreateFunctionsHDivDuplConnects(int dime
     fStyle = EHDiv;
     const HDivFamily &hdivfam = this->fhdivfam;
 
-    if (hdivfam != HDivFamily::EHDivConstant || hdivfam != HDivFamily::EHDivOptimized){
+    if (hdivfam != HDivFamily::EHDivConstant && hdivfam != HDivFamily::EHDivOptimized){
         std::cout << "HDiv Dupl Connects not implemented yet for this HDiv family!" << std::endl;
         DebugStop();
     }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The usage of NeoPZ can be improved by linking against the following libraries:
 - [LAPACK](http://www.netlib.org/lapack/), for eigenvalues computations in full or banded matrices. If enabled, it is also internally used replacing in-house linear algebra algorithms with BLAS functions.
 - [Boost](https://www.boost.org/), for experimental techniques.
 - [Catch2](https://www.github.com/catchorg/Catch2), for Unit Testing.
+- [Eigen](https://gitlab.com/libeigen/eigen), for integrating with Apple Accelerate on ARM-based CPUs and providing an alternative sparse solver (limited functionality, still in testing)
 
 ## Configuration and Install
 The NeoPZ library uses CMake for configuring and installing the library. As a simple example, on UNIX systems, this could be done as:

--- a/StrMatrix/TPZSpStructMatrix.cpp
+++ b/StrMatrix/TPZSpStructMatrix.cpp
@@ -229,9 +229,9 @@ template class TPZSpStructMatrix<STATE,TPZStructMatrixOT<STATE>>;
 template class TPZSpStructMatrix<STATE,TPZStructMatrixTBBFlow<STATE>>;
 template class TPZSpStructMatrix<STATE,TPZStructMatrixOMPorTBB<STATE>>;
 
-#ifndef USING_EIGEN
+// #ifndef USING_EIGEN
 template class TPZSpStructMatrix<CSTATE,TPZStructMatrixOR<CSTATE>>;
 template class TPZSpStructMatrix<CSTATE,TPZStructMatrixOT<CSTATE>>;
 template class TPZSpStructMatrix<CSTATE,TPZStructMatrixTBBFlow<CSTATE>>;
 template class TPZSpStructMatrix<CSTATE,TPZStructMatrixOMPorTBB<CSTATE>>;
-#endif
+// #endif

--- a/StrMatrix/pzstrmatrixor.cpp
+++ b/StrMatrix/pzstrmatrixor.cpp
@@ -274,6 +274,7 @@ TPZStructMatrixOR<TVar>::Serial_Assemble(TPZBaseMatrix & stiff_base, TPZBaseMatr
                 sout << "Stiffness for computational element without associated geometric element index " << el->Index() << "\n";
             }
             if(ek.HasDependency()){
+                sout << "source index " << ek.fSourceIndex << " destination index " << ek.fDestinationIndex << std::endl;
                 ek.fConstrMat.Print(sout);
                 ef.fConstrMat.Print(sout);
             }else{

--- a/UnitTest_PZ/TestEigen/TestEigen.cpp
+++ b/UnitTest_PZ/TestEigen/TestEigen.cpp
@@ -101,8 +101,8 @@ int main(){
 void buildProblem(std::vector<T>& coefficients, Eigen::VectorXd& b, int n)
 {
 #ifndef RUNWITHMAIN
-    std::random_device rd; // obtain a random number from hardware
-    std::mt19937 gen(rd()); // seed the generator
+    // std::random_device rd; // obtain a random number from hardware
+    // std::mt19937 gen(rd()); // seed the generator
     std::uniform_int_distribution<> distr(25, 63); // define the range
     for(int i = 0; i<n; i++) {
         double sum = 0, sumabs = 0.;
@@ -191,9 +191,9 @@ void AccelerateSparse()
 void TestSparseClass() {
 #ifdef PZ_USING_EIGEN
     const int64_t nrows = 2;
-    int64_t ia[] = {0,1,3};
-    int64_t ja[] = {0,0,1};
-    STATE val[] = {1.,0.,2.};
+    TPZVec<int64_t> ia = {0,1,3};
+    TPZVec<int64_t> ja = {0,0,1};
+    TPZVec<STATE> val = {1.,0.,2.};
 
     TPZFMatrix<STATE> F(nrows,1);
     F(0,0) = 1.;
@@ -202,7 +202,7 @@ void TestSparseClass() {
     
     TPZEigenSparseMatrix<STATE> spmat(nrows,nrows);
     spmat.SetData(ia, ja, val);
-    const DecomposeType dt = ECholesky;
+    const DecomposeType dt = ELDLt;
     spmat.Decompose(dt);
     spmat.SolveDirect(F, dt);
     std::cout << "solution " << F << std::endl;
@@ -217,15 +217,15 @@ void TestSparseClass() {
 void TestH1Problem() {
     
     const int volid = 1, bcid = -1;
-    const int ndiv = 5;
+    const int ndiv = 4;
     const int dim = 3;
-    const int pOrder = 2;
+    const int pOrder = 1;
     TPZVec<int> nDivs;
     if(dim == 2) nDivs = {ndiv,ndiv};
     else nDivs = {ndiv,ndiv,ndiv};
     TPZGeoMesh* gmesh = CreateGeoMesh(dim,nDivs,volid,bcid);
     TPZCompMesh* cmesh = CreateCMeshH1(gmesh,pOrder,volid,bcid);
-    
+    //cmesh->Print(std::cout);
     // ========> Solve H1
     TPZLinearAnalysis an(cmesh,RenumType::EDefault);
     constexpr int nThreads{16};
@@ -233,7 +233,7 @@ void TestH1Problem() {
     
     const bool useSparse = true;
     if(useSparse){
-        matstruct = new TPZSpStructMatrix<STATE>(cmesh);
+        matstruct = new TPZSSpStructMatrix<STATE>(cmesh);
     }
     else{
         matstruct = new TPZSkylineStructMatrix<STATE>(cmesh);

--- a/UnitTest_PZ/TestHDivApproxSpaceCreator/TestHDivApproxSpaceCreator.cpp
+++ b/UnitTest_PZ/TestHDivApproxSpaceCreator/TestHDivApproxSpaceCreator.cpp
@@ -143,8 +143,13 @@ TEST_CASE("Approx Space Creator", "[hdiv_space_creator_test][!mayfail]") {
     bool isRef = GENERATE(true,false);
     // bool isRef = GENERATE(true);
     bool isMHM = GENERATE(false);
-    
-    TestHdivApproxSpaceCreator(sType,pType,pOrder,isRBSpaces,mType,extraporder,isCondensed,hType,isRef,isMHM);
+
+    if (!(isRef && hType == HybridizationType::ESemi) && !(isCondensed && sType == HDivFamily::EHDivConstant) &&
+    !(sType == HDivFamily::EHDivConstant && pType == ProblemType::EElastic && mType == MMeshType::ETetrahedral) &&
+    !(sType != HDivFamily::EHDivConstant && hType == HybridizationType::ESemi))
+    {
+        TestHdivApproxSpaceCreator(sType, pType, pOrder, isRBSpaces, mType, extraporder, isCondensed, hType, isRef, isMHM);
+    }
     std::cout << "Finish test HDiv Approx Space Creator \n";
 }
 #else

--- a/cmake/EnableEigen.cmake
+++ b/cmake/EnableEigen.cmake
@@ -1,16 +1,9 @@
-# Here we will search for eigen. If eigen is not found, we will download it.
+# We need a specific version of Eigen in order to use Apple's Accelerate
 function(enable_eigen target)
-    #perhaps eigen was already downloaded when running cmake
     if(NOT eigen_POPULATED)
-        find_package(Eigen3 3.4 CONFIG)
-
         if(NOT EIGEN3_FOUND)
-            # Couldn't load via target, so fall back to allowing module mode finding, which will pick up
-            # tools/FindEigen3.cmake
-            find_package(Eigen3 3.4 QUIET)
-        endif()
-        if(NOT EIGEN3_FOUND)
-            set(EIGEN3_VERSION_STRING "3.4.90")
+            # This hash references to the commit where Eigen support for Accelerate was added
+            set(EIGEN3_VERSION_STRING "7dd3dda3daa218147557b33f8d05b3b023f05f7d")
             include(FetchContent)
             FetchContent_Declare(
                 eigen
@@ -29,19 +22,13 @@ function(enable_eigen target)
         endif()
     endif()
     if(EIGEN3_FOUND)
-        # if eigen was downloaded, the target was not created
         if(NOT TARGET Eigen3::Eigen)
-#            add_library(Eigen3::Eigen IMPORTED INTERFACE)
-			target_link_library(${target} PUBLIC Eigen3::Eigen)
+            target_link_libraries(${target} PUBLIC ${Eigen3_LIBRARIES})
+            include_directories(${EIGEN3_INCLUDE_DIR})
 			target_compile_definitions(${target} PRIVATE USING_EIGEN)
-      target_compile_definitions(${target} INTERFACE PZ_USING_EIGEN)
- #           set_property(TARGET Eigen3::Eigen PROPERTY INTERFACE_INCLUDE_DIRECTORIES
- #               "${EIGEN3_INCLUDE_DIR}")
+            target_compile_definitions(${target} INTERFACE PZ_USING_EIGEN)
         endif()
 
-        # Eigen 3.3.1+ cmake sets EIGEN3_VERSION_STRING (and hard codes the version when installed
-        # rather than looking it up in the cmake script); older versions, and the
-        # tools/FindEigen3.cmake, set EIGEN3_VERSION instead.
         if(NOT EIGEN3_VERSION AND EIGEN3_VERSION_STRING)
             set(EIGEN3_VERSION ${EIGEN3_VERSION_STRING})
         endif()


### PR DESCRIPTION
This PR fixes some features already present in NeoPZ in order to work with GFEM. Basically:

- CMake now downloads a specific version of Eigen instead of searching for a locally installed one. This was done because Eigen is essentially used in NeoPZ as an interface to Apple's Accelerate sparse solvers, so the version of Eigen needs to support Accelerate's features.
- Fow now, `TPZEigenSparseMatrix` derives from `TPZSYsmpMatrix`. Also, it is now being explicitly instantiated for `std::complex` types, which allows its usage as a base class for `TPZSpStructMatrix`. 
- We are still testing the `Decompose()` and `Solve()` methods of this class. Use them carefully.
- Some other minor fixes and refactorings were done. For instance, `Elem()` and `Decompose()` are no more pure virtual functions in the base matrix class.